### PR TITLE
replacing deprecated unittest functionality for future python version 

### DIFF
--- a/anuga/abstract_2d_finite_volumes/tests/test_ermapper.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_ermapper.py
@@ -184,7 +184,6 @@ class Test_ERMapper(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_ERMapper,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_ERMapper)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_ermapper.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_ermapper.py
@@ -184,6 +184,7 @@ class Test_ERMapper(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_ERMapper,'test')
+    #suite = unittest.makeSuite(Test_ERMapper,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_ERMapper)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
@@ -586,7 +586,8 @@ point2, 0.5, 2.0\n")
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Gauge, 'test')
+    #suite = unittest.makeSuite(Test_Gauge, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Gauge)
 #    runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_gauge.py
@@ -586,8 +586,6 @@ point2, 0.5, 2.0\n")
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Gauge, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Gauge)
-#    runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_general_mesh.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_general_mesh.py
@@ -513,8 +513,6 @@ class Test_General_Mesh(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_General_Mesh, 'test')
-    #suite = unittest.makeSuite(Test_General_Mesh, 'test')     
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_General_Mesh)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_general_mesh.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_general_mesh.py
@@ -514,7 +514,8 @@ class Test_General_Mesh(unittest.TestCase):
 
 if __name__ == "__main__":
     #suite = unittest.makeSuite(Test_General_Mesh, 'test')
-    suite = unittest.makeSuite(Test_General_Mesh, 'test')     
+    #suite = unittest.makeSuite(Test_General_Mesh, 'test')     
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_General_Mesh)
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/abstract_2d_finite_volumes/tests/test_generic_boundary_conditions.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_generic_boundary_conditions.py
@@ -437,6 +437,7 @@ class Test_Generic_Boundary_Conditions(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Generic_Boundary_Conditions, 'test')
+    #suite = unittest.makeSuite(Test_Generic_Boundary_Conditions, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Generic_Boundary_Conditions)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_generic_boundary_conditions.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_generic_boundary_conditions.py
@@ -437,7 +437,6 @@ class Test_Generic_Boundary_Conditions(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Generic_Boundary_Conditions, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Generic_Boundary_Conditions)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_generic_domain.py
@@ -961,7 +961,6 @@ class Test_Domain(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Domain,'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_generic_domain.py
@@ -961,6 +961,7 @@ class Test_Domain(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Domain,'test_')
+    #suite = unittest.makeSuite(Test_Domain,'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_ghost.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_ghost.py
@@ -47,6 +47,7 @@ class Test_Domain(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Domain,'test')
+    #suite = unittest.makeSuite(Test_Domain,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_ghost.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_ghost.py
@@ -47,7 +47,6 @@ class Test_Domain(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Domain,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_neighbour_mesh.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_neighbour_mesh.py
@@ -1909,6 +1909,7 @@ class Test_Mesh(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Mesh, 'test_')
+    #suite = unittest.makeSuite(Test_Mesh, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Mesh)
     runner = unittest.TextTestRunner()#verbosity=2)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_neighbour_mesh.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_neighbour_mesh.py
@@ -1909,7 +1909,6 @@ class Test_Mesh(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Mesh, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Mesh)
     runner = unittest.TextTestRunner()#verbosity=2)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_pmesh2domain.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_pmesh2domain.py
@@ -214,7 +214,6 @@ friction  \n \
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_pmesh2domain, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_pmesh2domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_pmesh2domain.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_pmesh2domain.py
@@ -214,6 +214,7 @@ friction  \n \
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_pmesh2domain, 'test')
+    #suite = unittest.makeSuite(Test_pmesh2domain, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_pmesh2domain)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_quantity.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_quantity.py
@@ -3925,6 +3925,7 @@ Parameters
 
 if __name__ == "__main__":
     # _set_values_from_asc')
-    suite = unittest.makeSuite(Test_Quantity, 'test_')
+    #suite = unittest.makeSuite(Test_Quantity, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Quantity)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_quantity.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_quantity.py
@@ -3924,8 +3924,6 @@ Parameters
 # -------------------------------------------------------------
 
 if __name__ == "__main__":
-    # _set_values_from_asc')
-    #suite = unittest.makeSuite(Test_Quantity, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Quantity)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_region.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_region.py
@@ -94,7 +94,6 @@ class Test_region(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_region, 'test')    
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_region)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_region.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_region.py
@@ -94,6 +94,7 @@ class Test_region(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_region, 'test')    
+    #suite = unittest.makeSuite(Test_region, 'test')    
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_region)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_tag_region.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_tag_region.py
@@ -257,7 +257,6 @@ class Test_tag_region(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_tag_region, 'test')    
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_tag_region)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_tag_region.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_tag_region.py
@@ -257,6 +257,7 @@ class Test_tag_region(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_tag_region, 'test')    
+    #suite = unittest.makeSuite(Test_tag_region, 'test')    
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_tag_region)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_util.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_util.py
@@ -1614,7 +1614,8 @@ class Test_Util(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Util, 'test')
+    #suite = unittest.makeSuite(Test_Util, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Util)
 #    runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/abstract_2d_finite_volumes/tests/test_util.py
+++ b/anuga/abstract_2d_finite_volumes/tests/test_util.py
@@ -1614,8 +1614,6 @@ class Test_Util(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Util, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Util)
-#    runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/advection/tests/test_advection.py
+++ b/anuga/advection/tests/test_advection.py
@@ -179,6 +179,7 @@ class Test_Advection(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Advection, 'test')
+    #suite = unittest.makeSuite(Test_Advection, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Advection)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/advection/tests/test_advection.py
+++ b/anuga/advection/tests/test_advection.py
@@ -179,7 +179,6 @@ class Test_Advection(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Advection, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Advection)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/alpha_shape/tests/test_alpha_shape.py
+++ b/anuga/alpha_shape/tests/test_alpha_shape.py
@@ -397,7 +397,6 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(TestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/alpha_shape/tests/test_alpha_shape.py
+++ b/anuga/alpha_shape/tests/test_alpha_shape.py
@@ -397,6 +397,7 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(TestCase,'test')
+    #suite = unittest.makeSuite(TestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/caching/tests/test_caching.py
+++ b/anuga/caching/tests/test_caching.py
@@ -996,7 +996,6 @@ class Test_Caching(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Caching, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Caching)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/caching/tests/test_caching.py
+++ b/anuga/caching/tests/test_caching.py
@@ -996,6 +996,7 @@ class Test_Caching(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Caching, 'test')
+    #suite = unittest.makeSuite(Test_Caching, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Caching)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_geo_reference.py
+++ b/anuga/coordinate_transforms/tests/test_geo_reference.py
@@ -769,7 +769,6 @@ class geo_referenceTestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(geo_referenceTestCase, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(geo_referenceTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_geo_reference.py
+++ b/anuga/coordinate_transforms/tests/test_geo_reference.py
@@ -769,7 +769,8 @@ class geo_referenceTestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(geo_referenceTestCase, 'test')
+    #suite = unittest.makeSuite(geo_referenceTestCase, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(geo_referenceTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
     

--- a/anuga/coordinate_transforms/tests/test_lat_long_UTM_conversion.py
+++ b/anuga/coordinate_transforms/tests/test_lat_long_UTM_conversion.py
@@ -121,6 +121,7 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    mysuite = unittest.makeSuite(TestCase,'test')
+    #mysuite = unittest.makeSuite(TestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
-    runner.run(mysuite)
+    runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_lat_long_UTM_conversion.py
+++ b/anuga/coordinate_transforms/tests/test_lat_long_UTM_conversion.py
@@ -121,7 +121,6 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #mysuite = unittest.makeSuite(TestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_point.py
+++ b/anuga/coordinate_transforms/tests/test_point.py
@@ -119,7 +119,6 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #mysuite = unittest.makeSuite(TestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_point.py
+++ b/anuga/coordinate_transforms/tests/test_point.py
@@ -119,7 +119,8 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    mysuite = unittest.makeSuite(TestCase,'test')
+    #mysuite = unittest.makeSuite(TestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
-    runner.run(mysuite)
+    runner.run(suite)
 

--- a/anuga/coordinate_transforms/tests/test_redfearn.py
+++ b/anuga/coordinate_transforms/tests/test_redfearn.py
@@ -537,7 +537,6 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #mysuite = unittest.makeSuite(TestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/coordinate_transforms/tests/test_redfearn.py
+++ b/anuga/coordinate_transforms/tests/test_redfearn.py
@@ -537,6 +537,7 @@ class TestCase(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    mysuite = unittest.makeSuite(TestCase,'test')
+    #mysuite = unittest.makeSuite(TestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner()
-    runner.run(mysuite)
+    runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_class.py
+++ b/anuga/culvert_flows/tests/test_culvert_class.py
@@ -813,7 +813,6 @@ class Test_Culvert(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Culvert, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Culvert)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_class.py
+++ b/anuga/culvert_flows/tests/test_culvert_class.py
@@ -813,7 +813,8 @@ class Test_Culvert(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Culvert, 'test')
+    #suite = unittest.makeSuite(Test_Culvert, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Culvert)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
         

--- a/anuga/culvert_flows/tests/test_culvert_polygons.py
+++ b/anuga/culvert_flows/tests/test_culvert_polygons.py
@@ -78,7 +78,8 @@ class Test_poly(unittest.TestCase):
                
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_poly, 'test')
+    #suite = unittest.makeSuite(Test_poly, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_poly)
     runner = unittest.TextTestRunner()
     runner.run(suite)
         

--- a/anuga/culvert_flows/tests/test_culvert_polygons.py
+++ b/anuga/culvert_flows/tests/test_culvert_polygons.py
@@ -78,7 +78,6 @@ class Test_poly(unittest.TestCase):
                
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_poly, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_poly)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines.py
@@ -579,7 +579,8 @@ class Test_culvert_routines(unittest.TestCase):
                
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_culvert_routines, 'test')
+    #suite = unittest.makeSuite(Test_culvert_routines, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines)
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/culvert_flows/tests/test_culvert_routines.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines.py
@@ -579,7 +579,6 @@ class Test_culvert_routines(unittest.TestCase):
                
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_culvert_routines, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_box_10pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_box_10pct.py
@@ -336,6 +336,7 @@ class Test_culvert_routines_box_10pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_culvert_routines_box_10pct, 'test')
+    #suite = unittest.makeSuite(Test_culvert_routines_box_10pct, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_box_10pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_box_10pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_box_10pct.py
@@ -336,7 +336,6 @@ class Test_culvert_routines_box_10pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_culvert_routines_box_10pct, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_box_10pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_box_1pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_box_1pct.py
@@ -336,6 +336,7 @@ class Test_culvert_routines_box_1pct(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_culvert_routines_box_1pct, 'test')
+    #suite = unittest.makeSuite(Test_culvert_routines_box_1pct, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_box_1pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_box_1pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_box_1pct.py
@@ -336,7 +336,6 @@ class Test_culvert_routines_box_1pct(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_culvert_routines_box_1pct, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_box_1pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_pipe_10pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_pipe_10pct.py
@@ -332,7 +332,6 @@ class Test_culvert_routines_pipe_10pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_culvert_routines_pipe_10pct, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_pipe_10pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_pipe_10pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_pipe_10pct.py
@@ -332,6 +332,7 @@ class Test_culvert_routines_pipe_10pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_culvert_routines_pipe_10pct, 'test')
+    #suite = unittest.makeSuite(Test_culvert_routines_pipe_10pct, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_pipe_10pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_pipe_1pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_pipe_1pct.py
@@ -333,6 +333,7 @@ class Test_culvert_routines_pipe_1pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_culvert_routines_pipe_1pct, 'test')
+    #suite = unittest.makeSuite(Test_culvert_routines_pipe_1pct, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_pipe_1pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_culvert_routines_pipe_1pct.py
+++ b/anuga/culvert_flows/tests/test_culvert_routines_pipe_1pct.py
@@ -333,7 +333,6 @@ class Test_culvert_routines_pipe_1pct(unittest.TestCase):
 # =========================================================================
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_culvert_routines_pipe_1pct, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_culvert_routines_pipe_1pct)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_new_culvert_class.py
+++ b/anuga/culvert_flows/tests/test_new_culvert_class.py
@@ -818,7 +818,6 @@ class Test_Culvert(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Culvert, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Culvert)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/culvert_flows/tests/test_new_culvert_class.py
+++ b/anuga/culvert_flows/tests/test_new_culvert_class.py
@@ -818,7 +818,8 @@ class Test_Culvert(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Culvert, 'test')
+    #suite = unittest.makeSuite(Test_Culvert, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Culvert)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
         

--- a/anuga/damage_modelling/tests/test_exposure.py
+++ b/anuga/damage_modelling/tests/test_exposure.py
@@ -333,6 +333,7 @@ class Test_Exposure(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Exposure,'test')
+    #suite = unittest.makeSuite(Test_Exposure,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Exposure)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/damage_modelling/tests/test_exposure.py
+++ b/anuga/damage_modelling/tests/test_exposure.py
@@ -333,7 +333,6 @@ class Test_Exposure(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Exposure,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Exposure)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/damage_modelling/tests/test_inundation_damage.py
+++ b/anuga/damage_modelling/tests/test_inundation_damage.py
@@ -641,7 +641,8 @@ if __name__ == "__main__":
         sys.stdout = fid
     else:
         pass
-    suite = unittest.makeSuite(Test_inundation_damage,'test')
+    #suite = unittest.makeSuite(Test_inundation_damage,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_inundation_damage)
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/damage_modelling/tests/test_inundation_damage.py
+++ b/anuga/damage_modelling/tests/test_inundation_damage.py
@@ -641,7 +641,6 @@ if __name__ == "__main__":
         sys.stdout = fid
     else:
         pass
-    #suite = unittest.makeSuite(Test_inundation_damage,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_inundation_damage)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file/tests/test_csv.py
+++ b/anuga/file/tests/test_csv.py
@@ -406,7 +406,6 @@ class Test_csv(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_csv, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_csv)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file/tests/test_csv.py
+++ b/anuga/file/tests/test_csv.py
@@ -406,6 +406,7 @@ class Test_csv(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_csv, 'test')
+    #suite = unittest.makeSuite(Test_csv, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_csv)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file/tests/test_mux.py
+++ b/anuga/file/tests/test_mux.py
@@ -1540,7 +1540,6 @@ ValueError: matrices are not aligned for copy
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Mux,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Mux)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/file/tests/test_mux.py
+++ b/anuga/file/tests/test_mux.py
@@ -1540,7 +1540,8 @@ ValueError: matrices are not aligned for copy
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Mux,'test')
+    #suite = unittest.makeSuite(Test_Mux,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Mux)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
         

--- a/anuga/file/tests/test_read_sww.py
+++ b/anuga/file/tests/test_read_sww.py
@@ -345,7 +345,6 @@ class Test_read_sww(unittest.TestCase):
         
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_read_sww, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_read_sww)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/file/tests/test_read_sww.py
+++ b/anuga/file/tests/test_read_sww.py
@@ -345,7 +345,8 @@ class Test_read_sww(unittest.TestCase):
         
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_read_sww, 'test')
+    #suite = unittest.makeSuite(Test_read_sww, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_read_sww)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
     

--- a/anuga/file/tests/test_sww.py
+++ b/anuga/file/tests/test_sww.py
@@ -902,7 +902,6 @@ class Test_sww(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_sww, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_sww)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file/tests/test_sww.py
+++ b/anuga/file/tests/test_sww.py
@@ -902,6 +902,7 @@ class Test_sww(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_sww, 'test')
+    #suite = unittest.makeSuite(Test_sww, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_sww)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file/tests/test_ungenerate.py
+++ b/anuga/file/tests/test_ungenerate.py
@@ -277,7 +277,6 @@ END\n")
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(ungenerateTestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(ungenerateTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/file/tests/test_ungenerate.py
+++ b/anuga/file/tests/test_ungenerate.py
@@ -277,7 +277,8 @@ END\n")
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(ungenerateTestCase,'test')
+    #suite = unittest.makeSuite(ungenerateTestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(ungenerateTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
     

--- a/anuga/file/tests/test_urs.py
+++ b/anuga/file/tests/test_urs.py
@@ -213,7 +213,6 @@ class Test_Urs(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Urs,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Urs)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/file/tests/test_urs.py
+++ b/anuga/file/tests/test_urs.py
@@ -213,6 +213,7 @@ class Test_Urs(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Urs,'test')
+    #suite = unittest.makeSuite(Test_Urs,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Urs)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_2pts.py
+++ b/anuga/file_conversion/tests/test_2pts.py
@@ -242,6 +242,7 @@ END CROSS-SECTIONS:
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_2Pts, 'test_')
+    #suite = unittest.makeSuite(Test_2Pts, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_2Pts)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)    

--- a/anuga/file_conversion/tests/test_2pts.py
+++ b/anuga/file_conversion/tests/test_2pts.py
@@ -242,7 +242,6 @@ END CROSS-SECTIONS:
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_2Pts, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_2Pts)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)    

--- a/anuga/file_conversion/tests/test_csv2sts.py
+++ b/anuga/file_conversion/tests/test_csv2sts.py
@@ -118,7 +118,6 @@ class Test_csv2sts(unittest.TestCase):
             os.remove(sts_out)           
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_csv2sts,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_csv2sts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_csv2sts.py
+++ b/anuga/file_conversion/tests/test_csv2sts.py
@@ -118,6 +118,7 @@ class Test_csv2sts(unittest.TestCase):
             os.remove(sts_out)           
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_csv2sts,'test')
+    #suite = unittest.makeSuite(Test_csv2sts,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_csv2sts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_dem2array.py
+++ b/anuga/file_conversion/tests/test_dem2array.py
@@ -115,6 +115,7 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_dem2array,'test')
+    #$suite = unittest.makeSuite(Test_dem2array,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_dem2array)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_dem2array.py
+++ b/anuga/file_conversion/tests/test_dem2array.py
@@ -115,7 +115,6 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #$suite = unittest.makeSuite(Test_dem2array,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_dem2array)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_dem2dem.py
+++ b/anuga/file_conversion/tests/test_dem2dem.py
@@ -214,7 +214,8 @@ class Test_Dem2Dem(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Dem2Dem, 'test')
+    #suite = unittest.makeSuite(Test_Dem2Dem, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Dem)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
         

--- a/anuga/file_conversion/tests/test_dem2dem.py
+++ b/anuga/file_conversion/tests/test_dem2dem.py
@@ -214,7 +214,6 @@ class Test_Dem2Dem(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Dem2Dem, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Dem)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_dem2pts.py
+++ b/anuga/file_conversion/tests/test_dem2pts.py
@@ -407,6 +407,7 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Dem2Pts,'test')
+    #suite = unittest.makeSuite(Test_Dem2Pts,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_dem2pts.py
+++ b/anuga/file_conversion/tests/test_dem2pts.py
@@ -407,7 +407,6 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Dem2Pts,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_file_conversion.py
+++ b/anuga/file_conversion/tests/test_file_conversion.py
@@ -1108,6 +1108,7 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_File_Conversion,'test')
+    #suite = unittest.makeSuite(Test_File_Conversion,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_File_Conversion)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_file_conversion.py
+++ b/anuga/file_conversion/tests/test_file_conversion.py
@@ -1108,7 +1108,6 @@ Parameters
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_File_Conversion,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_File_Conversion)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_grd2array.py
+++ b/anuga/file_conversion/tests/test_grd2array.py
@@ -265,7 +265,6 @@ class Test_grd2array(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_grd2array, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_grd2array)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_grd2array.py
+++ b/anuga/file_conversion/tests/test_grd2array.py
@@ -265,7 +265,8 @@ class Test_grd2array(unittest.TestCase):
 #################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_grd2array, 'test')
+    #suite = unittest.makeSuite(Test_grd2array, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_grd2array)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
         

--- a/anuga/file_conversion/tests/test_llasc2pts.py
+++ b/anuga/file_conversion/tests/test_llasc2pts.py
@@ -126,7 +126,6 @@ NODATA_value  %g
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_LLAsc2Pts,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_LLAsc2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_llasc2pts.py
+++ b/anuga/file_conversion/tests/test_llasc2pts.py
@@ -126,6 +126,7 @@ NODATA_value  %g
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_LLAsc2Pts,'test')
+    #suite = unittest.makeSuite(Test_LLAsc2Pts,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_LLAsc2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_sww2dem.py
+++ b/anuga/file_conversion/tests/test_sww2dem.py
@@ -2750,6 +2750,7 @@ Statistics of SWW file:
 if __name__ == "__main__":
     # suite = unittest.makeSuite(Test_Shallow_Water, 'test_rainfall_forcing_with_evolve')
 
-    suite = unittest.makeSuite(Test_Sww2Dem, 'test')
+    #suite = unittest.makeSuite(Test_Sww2Dem, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Sww2Dem)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_sww2dem.py
+++ b/anuga/file_conversion/tests/test_sww2dem.py
@@ -2748,9 +2748,6 @@ Statistics of SWW file:
 #################################################################################
 
 if __name__ == "__main__":
-    # suite = unittest.makeSuite(Test_Shallow_Water, 'test_rainfall_forcing_with_evolve')
-
-    #suite = unittest.makeSuite(Test_Sww2Dem, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Sww2Dem)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_tif2.py
+++ b/anuga/file_conversion/tests/test_tif2.py
@@ -664,7 +664,6 @@ class Test_tif2(unittest.TestCase):
 
 #################################################################################
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_tif2, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_tif2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_tif2.py
+++ b/anuga/file_conversion/tests/test_tif2.py
@@ -664,6 +664,7 @@ class Test_tif2(unittest.TestCase):
 
 #################################################################################
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_tif2, 'test')
+    #suite = unittest.makeSuite(Test_tif2, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_tif2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_urs2sts.py
+++ b/anuga/file_conversion/tests/test_urs2sts.py
@@ -2124,7 +2124,6 @@ class Test_Urs2Sts(Test_Mux):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Urs2Sts,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Urs2Sts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_urs2sts.py
+++ b/anuga/file_conversion/tests/test_urs2sts.py
@@ -2124,6 +2124,7 @@ class Test_Urs2Sts(Test_Mux):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Urs2Sts,'test')
+    #suite = unittest.makeSuite(Test_Urs2Sts,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Urs2Sts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_urs2sww.py
+++ b/anuga/file_conversion/tests/test_urs2sww.py
@@ -625,7 +625,6 @@ class Test_Dem2Pts(Test_Mux):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Dem2Pts,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/file_conversion/tests/test_urs2sww.py
+++ b/anuga/file_conversion/tests/test_urs2sww.py
@@ -625,6 +625,7 @@ class Test_Dem2Pts(Test_Mux):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Dem2Pts,'test')
+    #suite = unittest.makeSuite(Test_Dem2Pts,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Dem2Pts)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_fit.py
+++ b/anuga/fit_interpolate/tests/test_fit.py
@@ -1147,6 +1147,7 @@ class Test_Fit(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Fit,'test')
+    #suite = unittest.makeSuite(Test_Fit,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Fit)
     runner = unittest.TextTestRunner() #verbosity=1)
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_fit.py
+++ b/anuga/fit_interpolate/tests/test_fit.py
@@ -1147,7 +1147,6 @@ class Test_Fit(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Fit,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Fit)
     runner = unittest.TextTestRunner() #verbosity=1)
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_interpolate.py
+++ b/anuga/fit_interpolate/tests/test_interpolate.py
@@ -1959,7 +1959,6 @@ class Test_Interpolate(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Interpolate,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Interpolate)
     runner = unittest.TextTestRunner() #verbosity=1)
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_interpolate.py
+++ b/anuga/fit_interpolate/tests/test_interpolate.py
@@ -1959,7 +1959,8 @@ class Test_Interpolate(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Interpolate,'test')
+    #suite = unittest.makeSuite(Test_Interpolate,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Interpolate)
     runner = unittest.TextTestRunner() #verbosity=1)
     runner.run(suite)
 

--- a/anuga/fit_interpolate/tests/test_interpolate2d.py
+++ b/anuga/fit_interpolate/tests/test_interpolate2d.py
@@ -464,6 +464,7 @@ class Test_interpolate(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.makeSuite(Test_interpolate, 'test')
+    #suite = unittest.makeSuite(Test_interpolate, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_interpolate)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_interpolate2d.py
+++ b/anuga/fit_interpolate/tests/test_interpolate2d.py
@@ -464,7 +464,6 @@ class Test_interpolate(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    #suite = unittest.makeSuite(Test_interpolate, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_interpolate)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/fit_interpolate/tests/test_search_functions.py
+++ b/anuga/fit_interpolate/tests/test_search_functions.py
@@ -231,7 +231,8 @@ class Test_search_functions(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_search_functions, 'test')
+    #suite = unittest.makeSuite(Test_search_functions, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_search_functions)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
     

--- a/anuga/fit_interpolate/tests/test_search_functions.py
+++ b/anuga/fit_interpolate/tests/test_search_functions.py
@@ -231,7 +231,6 @@ class Test_search_functions(unittest.TestCase):
 
 #-------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_search_functions, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_search_functions)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/geometry/tests/test_geometry.py
+++ b/anuga/geometry/tests/test_geometry.py
@@ -105,7 +105,6 @@ class Test_Geometry(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #mysuite = unittest.makeSuite(Test_Geometry, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Geometry)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/geometry/tests/test_geometry.py
+++ b/anuga/geometry/tests/test_geometry.py
@@ -105,6 +105,7 @@ class Test_Geometry(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    mysuite = unittest.makeSuite(Test_Geometry, 'test')
+    #mysuite = unittest.makeSuite(Test_Geometry, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Geometry)
     runner = unittest.TextTestRunner()
-    runner.run(mysuite)
+    runner.run(suite)

--- a/anuga/geometry/tests/test_polygon.py
+++ b/anuga/geometry/tests/test_polygon.py
@@ -1982,8 +1982,6 @@ class Test_Polygon(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # _intersection_bug_20081110_TR_BL')
-    #suite = unittest.makeSuite(Test_Polygon, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Polygon)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/geometry/tests/test_polygon.py
+++ b/anuga/geometry/tests/test_polygon.py
@@ -1983,6 +1983,7 @@ class Test_Polygon(unittest.TestCase):
 
 if __name__ == "__main__":
     # _intersection_bug_20081110_TR_BL')
-    suite = unittest.makeSuite(Test_Polygon, 'test')
+    #suite = unittest.makeSuite(Test_Polygon, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Polygon)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/geospatial_data/tests/test_geospatial_data.py
+++ b/anuga/geospatial_data/tests/test_geospatial_data.py
@@ -1857,7 +1857,8 @@ class Test_Geospatial_data(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Geospatial_data, 'test')
+    #suite = unittest.makeSuite(Test_Geospatial_data, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Geospatial_data)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
 

--- a/anuga/geospatial_data/tests/test_geospatial_data.py
+++ b/anuga/geospatial_data/tests/test_geospatial_data.py
@@ -1857,7 +1857,6 @@ class Test_Geospatial_data(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Geospatial_data, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Geospatial_data)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/load_mesh/tests/test_loadASCII.py
+++ b/anuga/load_mesh/tests/test_loadASCII.py
@@ -551,6 +551,7 @@ showme1.0 0.0 10.0 \n\
 ################################################################################
 
 if __name__ == '__main__':
-    suite = unittest.makeSuite(loadASCIITestCase,'test')
+    #suite = unittest.makeSuite(loadASCIITestCase,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(loadASCIITestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/load_mesh/tests/test_loadASCII.py
+++ b/anuga/load_mesh/tests/test_loadASCII.py
@@ -551,7 +551,6 @@ showme1.0 0.0 10.0 \n\
 ################################################################################
 
 if __name__ == '__main__':
-    #suite = unittest.makeSuite(loadASCIITestCase,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(loadASCIITestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/mesh_engine/tests/test_generate_mesh.py
+++ b/anuga/mesh_engine/tests/test_generate_mesh.py
@@ -462,6 +462,7 @@ class triangTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(triangTestCase, 'test_')
+    #suite = unittest.makeSuite(triangTestCase, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(triangTestCase)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/anuga/mesh_engine/tests/test_generate_mesh.py
+++ b/anuga/mesh_engine/tests/test_generate_mesh.py
@@ -462,7 +462,6 @@ class triangTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(triangTestCase, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(triangTestCase)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/anuga/operators/tests/test_base_operator.py
+++ b/anuga/operators/tests/test_base_operator.py
@@ -46,6 +46,7 @@ class Test_Operator(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Operator, 'test')
+    #suite = unittest.makeSuite(Test_Operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/operators/tests/test_base_operator.py
+++ b/anuga/operators/tests/test_base_operator.py
@@ -46,7 +46,6 @@ class Test_Operator(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/operators/tests/test_boundary_flux_integral_operator.py
+++ b/anuga/operators/tests/test_boundary_flux_integral_operator.py
@@ -130,7 +130,8 @@ class Test_boundary_flux_integral_operator(unittest.TestCase):
          
         
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_boundary_flux_integral_operator, 'test')
+    #suite = unittest.makeSuite(Test_boundary_flux_integral_operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_boundary_flux_integral_operator)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
 

--- a/anuga/operators/tests/test_boundary_flux_integral_operator.py
+++ b/anuga/operators/tests/test_boundary_flux_integral_operator.py
@@ -130,7 +130,6 @@ class Test_boundary_flux_integral_operator(unittest.TestCase):
          
         
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_boundary_flux_integral_operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_boundary_flux_integral_operator)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_erosion_operators.py
+++ b/anuga/operators/tests/test_erosion_operators.py
@@ -100,7 +100,6 @@ class Test_erosion_operators(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_erosion_operators, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_erosion_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_erosion_operators.py
+++ b/anuga/operators/tests/test_erosion_operators.py
@@ -100,6 +100,7 @@ class Test_erosion_operators(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_erosion_operators, 'test')
+    #suite = unittest.makeSuite(Test_erosion_operators, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_erosion_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_friction_operators.py
+++ b/anuga/operators/tests/test_friction_operators.py
@@ -216,6 +216,7 @@ class Test_set_friction_operators(unittest.TestCase):
             Set_depth_friction_operator(domain, friction="invalid_string", region=region)
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_set_friction_operators, 'test')
+    #suite = unittest.makeSuite(Test_set_friction_operators, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_friction_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_friction_operators.py
+++ b/anuga/operators/tests/test_friction_operators.py
@@ -216,7 +216,6 @@ class Test_set_friction_operators(unittest.TestCase):
             Set_depth_friction_operator(domain, friction="invalid_string", region=region)
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_set_friction_operators, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_friction_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_kinematic_viscosity_operator.py
+++ b/anuga/operators/tests/test_kinematic_viscosity_operator.py
@@ -1391,6 +1391,7 @@ class Test_kinematic_viscosity(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_kinematic_viscosity, 'test_') #test_')
+    #suite = unittest.makeSuite(Test_kinematic_viscosity, 'test_') #test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_kinematic_viscocity)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/operators/tests/test_kinematic_viscosity_operator.py
+++ b/anuga/operators/tests/test_kinematic_viscosity_operator.py
@@ -1391,7 +1391,6 @@ class Test_kinematic_viscosity(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_kinematic_viscosity, 'test_') #test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_kinematic_viscocity)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/operators/tests/test_rate_operators.py
+++ b/anuga/operators/tests/test_rate_operators.py
@@ -1770,7 +1770,6 @@ class Test_rate_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_rate_operators, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_rate_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_rate_operators.py
+++ b/anuga/operators/tests/test_rate_operators.py
@@ -1770,6 +1770,7 @@ class Test_rate_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_rate_operators, 'test_')
+    #suite = unittest.makeSuite(Test_rate_operators, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_rate_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_elevation_operator.py
+++ b/anuga/operators/tests/test_set_elevation_operator.py
@@ -728,6 +728,7 @@ class Test_set_elevation_operator(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_set_elevation_operator, 'test')
+    #suite = unittest.makeSuite(Test_set_elevation_operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_elevation_operator)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_elevation_operator.py
+++ b/anuga/operators/tests/test_set_elevation_operator.py
@@ -728,7 +728,6 @@ class Test_set_elevation_operator(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_set_elevation_operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_elevation_operator)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_quantity.py
+++ b/anuga/operators/tests/test_set_quantity.py
@@ -506,7 +506,6 @@ class Test_set_quantity(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_set_quantity, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_quantity)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_quantity.py
+++ b/anuga/operators/tests/test_set_quantity.py
@@ -506,6 +506,7 @@ class Test_set_quantity(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_set_quantity, 'test')
+    #suite = unittest.makeSuite(Test_set_quantity, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_quantity)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_stage_operator.py
+++ b/anuga/operators/tests/test_set_stage_operator.py
@@ -486,6 +486,7 @@ class Test_set_stage_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_set_stage_operators, 'test')
+    #suite = unittest.makeSuite(Test_set_stage_operators, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_stage_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_stage_operator.py
+++ b/anuga/operators/tests/test_set_stage_operator.py
@@ -486,7 +486,6 @@ class Test_set_stage_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_set_stage_operators, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_stage_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_w_uh_vh_operators.py
+++ b/anuga/operators/tests/test_set_w_uh_vh_operators.py
@@ -206,6 +206,7 @@ class Test_set_w_uh_vh_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_set_w_uh_vh_operators, 'test')
+    #suite = unittest.makeSuite(Test_set_w_uh_vh_operators, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_w_uh_vh_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/operators/tests/test_set_w_uh_vh_operators.py
+++ b/anuga/operators/tests/test_set_w_uh_vh_operators.py
@@ -206,7 +206,6 @@ class Test_set_w_uh_vh_operators(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_set_w_uh_vh_operators, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_set_w_uh_vh_operators)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/parallel/tests/test_distribute_mesh.py
+++ b/anuga/parallel/tests/test_distribute_mesh.py
@@ -2894,7 +2894,6 @@ class Test_Distribute_Mesh(unittest.TestCase):
 # -------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Distribute_Mesh, "test")
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Distribute_Mesh)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/parallel/tests/test_distribute_mesh.py
+++ b/anuga/parallel/tests/test_distribute_mesh.py
@@ -2894,6 +2894,7 @@ class Test_Distribute_Mesh(unittest.TestCase):
 # -------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Distribute_Mesh, "test")
+    #suite = unittest.makeSuite(Test_Distribute_Mesh, "test")
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Distribute_Mesh)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_boyd_box_operator.py
+++ b/anuga/parallel/tests/test_parallel_boyd_box_operator.py
@@ -324,7 +324,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_boyd_box_operator, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_boyd_box_operator)
         #print "Running for numproc = 1"
         runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_boyd_box_operator.py
+++ b/anuga/parallel/tests/test_parallel_boyd_box_operator.py
@@ -324,7 +324,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_boyd_box_operator, 'test')
+        #suite = unittest.makeSuite(Test_parallel_boyd_box_operator, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_boyd_box_operator)
         #print "Running for numproc = 1"
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_dist_settings.py
+++ b/anuga/parallel/tests/test_parallel_dist_settings.py
@@ -172,7 +172,6 @@ if __name__=="__main__":
     if numprocs == 1: 
         if verbose: print('SEQUENTIAL START')
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_dist_settings.py
+++ b/anuga/parallel/tests/test_parallel_dist_settings.py
@@ -172,7 +172,8 @@ if __name__=="__main__":
     if numprocs == 1: 
         if verbose: print('SEQUENTIAL START')
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:
         #------------------------------------------

--- a/anuga/parallel/tests/test_parallel_distribute_domain.py
+++ b/anuga/parallel/tests/test_parallel_distribute_domain.py
@@ -103,7 +103,6 @@ class Test_parallel_distribute_domain(unittest.TestCase):
            
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    #suite = unittest.makeSuite(Test_parallel_distribute_domain, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_distribute_domain)
     runner.run(suite)
 

--- a/anuga/parallel/tests/test_parallel_distribute_domain.py
+++ b/anuga/parallel/tests/test_parallel_distribute_domain.py
@@ -103,6 +103,7 @@ class Test_parallel_distribute_domain(unittest.TestCase):
            
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    suite = unittest.makeSuite(Test_parallel_distribute_domain, 'test')
+    #suite = unittest.makeSuite(Test_parallel_distribute_domain, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_distribute_domain)
     runner.run(suite)
 

--- a/anuga/parallel/tests/test_parallel_file_boundary.py
+++ b/anuga/parallel/tests/test_parallel_file_boundary.py
@@ -491,9 +491,7 @@ if __name__=="__main__":
     #verbose=False
     if myid ==0 and verbose: 
         print('PARALLEL START')
-    #suite = unittest.makeSuite(Test_urs2sts_parallel,'parallel_test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_urs2sts_parallel)
-    #suite = unittest.makeSuite(Test_urs2sts_parallel,'sequential_test')
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/parallel/tests/test_parallel_file_boundary.py
+++ b/anuga/parallel/tests/test_parallel_file_boundary.py
@@ -491,7 +491,8 @@ if __name__=="__main__":
     #verbose=False
     if myid ==0 and verbose: 
         print('PARALLEL START')
-    suite = unittest.makeSuite(Test_urs2sts_parallel,'parallel_test')
+    #suite = unittest.makeSuite(Test_urs2sts_parallel,'parallel_test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_urs2sts_parallel)
     #suite = unittest.makeSuite(Test_urs2sts_parallel,'sequential_test')
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_frac_op.py
+++ b/anuga/parallel/tests/test_parallel_frac_op.py
@@ -301,7 +301,8 @@ if __name__=="__main__":
 
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_frac_op.py
+++ b/anuga/parallel/tests/test_parallel_frac_op.py
@@ -301,7 +301,6 @@ if __name__=="__main__":
 
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_inlet_operator.py
+++ b/anuga/parallel/tests/test_parallel_inlet_operator.py
@@ -288,7 +288,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_inlet_operator.py
+++ b/anuga/parallel/tests/test_parallel_inlet_operator.py
@@ -288,7 +288,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_inlet_operator_with_region.py
+++ b/anuga/parallel/tests/test_parallel_inlet_operator_with_region.py
@@ -285,7 +285,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_inlet_operator_with_region.py
+++ b/anuga/parallel/tests/test_parallel_inlet_operator_with_region.py
@@ -285,7 +285,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_frac_op, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_frac_op)
         #print "Running for numproc = 1"
         runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_riverwall.py
+++ b/anuga/parallel/tests/test_parallel_riverwall.py
@@ -88,6 +88,5 @@ class Test_parallel_riverwall(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    #suite = unittest.makeSuite(Test_parallel_riverwall, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_riverwall)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_riverwall.py
+++ b/anuga/parallel/tests/test_parallel_riverwall.py
@@ -88,5 +88,6 @@ class Test_parallel_riverwall(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    suite = unittest.makeSuite(Test_parallel_riverwall, 'test')
+    #suite = unittest.makeSuite(Test_parallel_riverwall, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_riverwall)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_shallow_domain.py
+++ b/anuga/parallel/tests/test_parallel_shallow_domain.py
@@ -88,5 +88,6 @@ class Test_parallel_shallow_domain(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    suite = unittest.makeSuite(Test_parallel_shallow_domain, 'test')
+    #suite = unittest.makeSuite(Test_parallel_shallow_domain, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_shallow_domain)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_shallow_domain.py
+++ b/anuga/parallel/tests/test_parallel_shallow_domain.py
@@ -88,6 +88,5 @@ class Test_parallel_shallow_domain(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    #suite = unittest.makeSuite(Test_parallel_shallow_domain, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_shallow_domain)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_sw_flow.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow.py
@@ -86,5 +86,6 @@ class Test_parallel_sw_flow(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+    #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_sw_flow.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow.py
@@ -86,6 +86,5 @@ class Test_parallel_sw_flow(unittest.TestCase):
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner()
-    #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
     runner.run(suite)

--- a/anuga/parallel/tests/test_parallel_sw_flow_de0.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_de0.py
@@ -201,7 +201,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1: 
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_sw_flow_de0.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_de0.py
@@ -201,7 +201,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1: 
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:
 

--- a/anuga/parallel/tests/test_parallel_sw_flow_low_froude_0.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_low_froude_0.py
@@ -208,7 +208,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_parallel_sw_flow_low_froude_0.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_low_froude_0.py
@@ -208,7 +208,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:
 

--- a/anuga/parallel/tests/test_parallel_sw_flow_low_froude_1.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_low_froude_1.py
@@ -204,7 +204,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:
 

--- a/anuga/parallel/tests/test_parallel_sw_flow_low_froude_1.py
+++ b/anuga/parallel/tests/test_parallel_sw_flow_low_froude_1.py
@@ -204,7 +204,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1:
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_sequential_dist_sw_flow.py
+++ b/anuga/parallel/tests/test_sequential_dist_sw_flow.py
@@ -316,7 +316,6 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1: 
         runner = unittest.TextTestRunner()
-        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
         suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:

--- a/anuga/parallel/tests/test_sequential_dist_sw_flow.py
+++ b/anuga/parallel/tests/test_sequential_dist_sw_flow.py
@@ -316,7 +316,8 @@ def assert_(condition, msg="Assertion Failed"):
 if __name__=="__main__":
     if numprocs == 1: 
         runner = unittest.TextTestRunner()
-        suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        #suite = unittest.makeSuite(Test_parallel_sw_flow, 'test')
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test_parallel_sw_flow)
         runner.run(suite)
     else:
 

--- a/anuga/pmesh/tests/test_mesh.py
+++ b/anuga/pmesh/tests/test_mesh.py
@@ -2155,7 +2155,8 @@ def list_comp(A,B):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(meshTestCase, 'test')
+    #suite = unittest.makeSuite(meshTestCase, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(meshTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
     

--- a/anuga/pmesh/tests/test_mesh.py
+++ b/anuga/pmesh/tests/test_mesh.py
@@ -2155,7 +2155,6 @@ def list_comp(A,B):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(meshTestCase, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(meshTestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/pmesh/tests/test_mesh_interface.py
+++ b/anuga/pmesh/tests/test_mesh_interface.py
@@ -996,7 +996,6 @@ END\n')
 ################################################################################
 
 if __name__ == "__main__":
-    #jsuite = unittest.makeSuite(TestCase, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/pmesh/tests/test_mesh_interface.py
+++ b/anuga/pmesh/tests/test_mesh_interface.py
@@ -996,7 +996,8 @@ END\n')
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(TestCase, 'test')
+    #jsuite = unittest.makeSuite(TestCase, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestCase)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
 

--- a/anuga/pmesh/tests/test_meshquad.py
+++ b/anuga/pmesh/tests/test_meshquad.py
@@ -185,6 +185,7 @@ class Test_Quad(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    mysuite = unittest.makeSuite(Test_Quad,'test')
+    #mysuite = unittest.makeSuite(Test_Quad,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Quad)
     runner = unittest.TextTestRunner()
-    runner.run(mysuite)
+    runner.run(suite)

--- a/anuga/pmesh/tests/test_meshquad.py
+++ b/anuga/pmesh/tests/test_meshquad.py
@@ -185,7 +185,6 @@ class Test_Quad(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #mysuite = unittest.makeSuite(Test_Quad,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Quad)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/rain/TODO.md
+++ b/anuga/rain/TODO.md
@@ -1,0 +1,1 @@
+Missing unit tests for rain, TODO JORGE

--- a/anuga/shallow_water/tests/test_DE_cuda.py
+++ b/anuga/shallow_water/tests/test_DE_cuda.py
@@ -315,7 +315,6 @@ class Test_DE_cuda(unittest.TestCase):
         #pprint.pprint(domain2.edge_timestep)    
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_DE_cuda, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_cuda)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_cuda.py
+++ b/anuga/shallow_water/tests/test_DE_cuda.py
@@ -315,6 +315,7 @@ class Test_DE_cuda(unittest.TestCase):
         #pprint.pprint(domain2.edge_timestep)    
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_DE_cuda, 'test_')
+    #suite = unittest.makeSuite(Test_DE_cuda, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_cuda)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_openmp.py
+++ b/anuga/shallow_water/tests/test_DE_openmp.py
@@ -330,6 +330,7 @@ class Test_DE_openmp(unittest.TestCase):
   
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
+    #suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_openmp)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_openmp.py
+++ b/anuga/shallow_water/tests/test_DE_openmp.py
@@ -330,7 +330,6 @@ class Test_DE_openmp(unittest.TestCase):
   
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_openmp)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_orig.py
+++ b/anuga/shallow_water/tests/test_DE_orig.py
@@ -105,6 +105,7 @@ class Test_DE_domain(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_DE1_domain, 'test')
+    #suite = unittest.makeSuite(Test_DE1_domain, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE1_domain)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_orig.py
+++ b/anuga/shallow_water/tests/test_DE_orig.py
@@ -105,7 +105,6 @@ class Test_DE_domain(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_DE1_domain, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE1_domain)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_simd.py
+++ b/anuga/shallow_water/tests/test_DE_simd.py
@@ -330,6 +330,7 @@ class Test_DE_simd(unittest.TestCase):
   
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
+    #suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_openmp)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_DE_simd.py
+++ b/anuga/shallow_water/tests/test_DE_simd.py
@@ -330,7 +330,6 @@ class Test_DE_simd(unittest.TestCase):
   
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_DE_openmp, 'test_runup')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_DE_openmp)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_data_manager.py
+++ b/anuga/shallow_water/tests/test_data_manager.py
@@ -846,8 +846,6 @@ class Test_Data_Manager(Test_Mux):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Data_Manager, 'test_sww2domain2')
-    #jsuite = unittest.makeSuite(Test_Data_Manager, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Data_Manager)
     
     

--- a/anuga/shallow_water/tests/test_data_manager.py
+++ b/anuga/shallow_water/tests/test_data_manager.py
@@ -847,7 +847,8 @@ class Test_Data_Manager(Test_Mux):
 
 if __name__ == "__main__":
     #suite = unittest.makeSuite(Test_Data_Manager, 'test_sww2domain2')
-    suite = unittest.makeSuite(Test_Data_Manager, 'test')
+    #jsuite = unittest.makeSuite(Test_Data_Manager, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Data_Manager)
     
     
     

--- a/anuga/shallow_water/tests/test_forcing.py
+++ b/anuga/shallow_water/tests/test_forcing.py
@@ -2380,7 +2380,6 @@ class Test_Forcing(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Forcing, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Forcing)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_forcing.py
+++ b/anuga/shallow_water/tests/test_forcing.py
@@ -2380,6 +2380,7 @@ class Test_Forcing(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Forcing, 'test')
+    #suite = unittest.makeSuite(Test_Forcing, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Forcing)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_friction.py
+++ b/anuga/shallow_water/tests/test_friction.py
@@ -78,7 +78,6 @@ class Test_Friction(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Friction, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Friction)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_friction.py
+++ b/anuga/shallow_water/tests/test_friction.py
@@ -78,6 +78,7 @@ class Test_Friction(unittest.TestCase):
 
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Friction, 'test')
+    #suite = unittest.makeSuite(Test_Friction, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Friction)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_loadsave.py
+++ b/anuga/shallow_water/tests/test_loadsave.py
@@ -207,6 +207,7 @@ class Test_LoadSave(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_LoadSave, 'test')
+    #suite = unittest.makeSuite(Test_LoadSave, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_LoadSave)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)    

--- a/anuga/shallow_water/tests/test_loadsave.py
+++ b/anuga/shallow_water/tests/test_loadsave.py
@@ -207,7 +207,6 @@ class Test_LoadSave(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_LoadSave, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_LoadSave)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)    

--- a/anuga/shallow_water/tests/test_local_extrapolation_and_flux_updating.py
+++ b/anuga/shallow_water/tests/test_local_extrapolation_and_flux_updating.py
@@ -108,7 +108,6 @@ class Test_local_extrapolation_and_flux_updating(unittest.TestCase):
         return
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_local_extrapolation_and_flux_updating, 'test')
     suite = unittest.TestSuite([
         Test_local_extrapolation_and_flux_updating('test_local_extrapolation_and_flux_updating_DE0'),
         Test_local_extrapolation_and_flux_updating('test_local_extrapolation_and_flux_updating_DE1')])

--- a/anuga/shallow_water/tests/test_local_extrapolation_and_flux_updating.py
+++ b/anuga/shallow_water/tests/test_local_extrapolation_and_flux_updating.py
@@ -108,7 +108,10 @@ class Test_local_extrapolation_and_flux_updating(unittest.TestCase):
         return
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_local_extrapolation_and_flux_updating, 'test')
+    #suite = unittest.makeSuite(Test_local_extrapolation_and_flux_updating, 'test')
+    suite = unittest.TestSuite([
+        Test_local_extrapolation_and_flux_updating('test_local_extrapolation_and_flux_updating_DE0'),
+        Test_local_extrapolation_and_flux_updating('test_local_extrapolation_and_flux_updating_DE1')])
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)
 

--- a/anuga/shallow_water/tests/test_most2nc.py
+++ b/anuga/shallow_water/tests/test_most2nc.py
@@ -47,6 +47,7 @@ class Test_most2nc(unittest.TestCase):
         os.remove('test.nc')
         
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_most2nc,'test')
+    #suite = unittest.makeSuite(Test_most2nc,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_most2nc)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_most2nc.py
+++ b/anuga/shallow_water/tests/test_most2nc.py
@@ -47,7 +47,6 @@ class Test_most2nc(unittest.TestCase):
         os.remove('test.nc')
         
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_most2nc,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_most2nc)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_shallow_water_domain.py
+++ b/anuga/shallow_water/tests/test_shallow_water_domain.py
@@ -9122,12 +9122,8 @@ friction  \n \
 #################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Shallow_Water, 'test_another_runup_example')
     suite = unittest.TestSuite([
     Test_Shallow_Water('test_another_runup_example')
 ])
-
-    #unittest.TextTestRunner().run(suite)
-    #suite = unittest.makeSuite(Test_Shallow_Water, 'test')
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_shallow_water_domain.py
+++ b/anuga/shallow_water/tests/test_shallow_water_domain.py
@@ -9122,7 +9122,12 @@ friction  \n \
 #################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Shallow_Water, 'test_another_runup_example')
+    #suite = unittest.makeSuite(Test_Shallow_Water, 'test_another_runup_example')
+    suite = unittest.TestSuite([
+    Test_Shallow_Water('test_another_runup_example')
+])
+
+    #unittest.TextTestRunner().run(suite)
     #suite = unittest.makeSuite(Test_Shallow_Water, 'test')
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_sww_interrogate.py
+++ b/anuga/shallow_water/tests/test_sww_interrogate.py
@@ -1059,7 +1059,8 @@ class Test_sww_Interrogate(unittest.TestCase):
  
  
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_sww_Interrogate, 'test_')
+    #suite = unittest.makeSuite(Test_sww_Interrogate, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_sww_Interrogate)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)
                

--- a/anuga/shallow_water/tests/test_sww_interrogate.py
+++ b/anuga/shallow_water/tests/test_sww_interrogate.py
@@ -1059,7 +1059,6 @@ class Test_sww_Interrogate(unittest.TestCase):
  
  
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_sww_Interrogate, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_sww_Interrogate)
     runner = unittest.TextTestRunner() #verbosity=2)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_system.py
+++ b/anuga/shallow_water/tests/test_system.py
@@ -190,6 +190,7 @@ class Test_system(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_system,'test')
+    #suite = unittest.makeSuite(Test_system,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_system)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_system.py
+++ b/anuga/shallow_water/tests/test_system.py
@@ -190,7 +190,6 @@ class Test_system(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_system,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_system)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_timezone.py
+++ b/anuga/shallow_water/tests/test_timezone.py
@@ -138,7 +138,6 @@ class Test_Timzone(unittest.TestCase):
         assert str(domain.get_datetime()) == '2021-03-21 18:31:00+11:00'
             
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Timzone, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Timezone)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/shallow_water/tests/test_timezone.py
+++ b/anuga/shallow_water/tests/test_timezone.py
@@ -138,6 +138,7 @@ class Test_Timzone(unittest.TestCase):
         assert str(domain.get_datetime()) == '2021-03-21 18:31:00+11:00'
             
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Timzone, 'test')
+    #suite = unittest.makeSuite(Test_Timzone, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Timezone)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/structures/tests/test_boyd_box_operator.py
+++ b/anuga/structures/tests/test_boyd_box_operator.py
@@ -3252,7 +3252,6 @@ class Test_boyd_box_operator(unittest.TestCase):
         assert numpy.allclose(d, d_expected, rtol=2.0e-2) #depth at outlet used to calc v          
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_boyd_box_operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_boyd_box_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_boyd_box_operator.py
+++ b/anuga/structures/tests/test_boyd_box_operator.py
@@ -3252,6 +3252,7 @@ class Test_boyd_box_operator(unittest.TestCase):
         assert numpy.allclose(d, d_expected, rtol=2.0e-2) #depth at outlet used to calc v          
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_boyd_box_operator, 'test')
+    #suite = unittest.makeSuite(Test_boyd_box_operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_boyd_box_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_boyd_pipe_operator.py
+++ b/anuga/structures/tests/test_boyd_pipe_operator.py
@@ -657,7 +657,6 @@ class Test_boyd_pipe_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_boyd_pipe_operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_boyd_pipe_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_boyd_pipe_operator.py
+++ b/anuga/structures/tests/test_boyd_pipe_operator.py
@@ -657,6 +657,7 @@ class Test_boyd_pipe_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_boyd_pipe_operator, 'test')
+    #suite = unittest.makeSuite(Test_boyd_pipe_operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_boyd_pipe_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_inlet_operator.py
+++ b/anuga/structures/tests/test_inlet_operator.py
@@ -369,6 +369,7 @@ class Test_inlet_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_inlet_operator, 'test')
+    #suite = unittest.makeSuite(Test_inlet_operator, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_inlet_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_inlet_operator.py
+++ b/anuga/structures/tests/test_inlet_operator.py
@@ -369,7 +369,6 @@ class Test_inlet_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_inlet_operator, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_inlet_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_internal_boundary_functions.py
+++ b/anuga/structures/tests/test_internal_boundary_functions.py
@@ -213,7 +213,6 @@ class Test_internal_boundary_functions(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_internal_boundary_functions, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_internal_boundary_functions)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/structures/tests/test_internal_boundary_functions.py
+++ b/anuga/structures/tests/test_internal_boundary_functions.py
@@ -213,6 +213,7 @@ class Test_internal_boundary_functions(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_internal_boundary_functions, 'test')
+    #suite = unittest.makeSuite(Test_internal_boundary_functions, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_internal_boundary_functions)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/structures/tests/test_riverwall_structure.py
+++ b/anuga/structures/tests/test_riverwall_structure.py
@@ -614,7 +614,6 @@ class Test_riverwall_structure(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_riverwall_structure, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_riverwall_structure)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_riverwall_structure.py
+++ b/anuga/structures/tests/test_riverwall_structure.py
@@ -614,6 +614,7 @@ class Test_riverwall_structure(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_riverwall_structure, 'test')
+    #suite = unittest.makeSuite(Test_riverwall_structure, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_riverwall_structure)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_weir_orifice_trapezoid_operator.py
+++ b/anuga/structures/tests/test_weir_orifice_trapezoid_operator.py
@@ -673,7 +673,6 @@ class Test_weir_orifice_trapezoid_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_weir_orifice_trapezoid_operator, 'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_weir_orifice_trapezoid_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/structures/tests/test_weir_orifice_trapezoid_operator.py
+++ b/anuga/structures/tests/test_weir_orifice_trapezoid_operator.py
@@ -673,6 +673,7 @@ class Test_weir_orifice_trapezoid_operator(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_weir_orifice_trapezoid_operator, 'test_')
+    #suite = unittest.makeSuite(Test_weir_orifice_trapezoid_operator, 'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_weir_orifice_trapezoid_operator)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/tsunami_source/tests/test_eq.py
+++ b/anuga/tsunami_source/tests/test_eq.py
@@ -61,7 +61,6 @@ class Test_eq(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_eq,'test_')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_eq)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/tsunami_source/tests/test_eq.py
+++ b/anuga/tsunami_source/tests/test_eq.py
@@ -61,6 +61,7 @@ class Test_eq(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_eq,'test_')
+    #suite = unittest.makeSuite(Test_eq,'test_')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_eq)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/tsunami_source/tests/test_smf.py
+++ b/anuga/tsunami_source/tests/test_smf.py
@@ -137,7 +137,8 @@ class Test_smf(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_smf,'test')
+    #suite = unittest.makeSuite(Test_smf,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_smf)
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/tsunami_source/tests/test_smf.py
+++ b/anuga/tsunami_source/tests/test_smf.py
@@ -137,7 +137,6 @@ class Test_smf(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_smf,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_smf)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/tsunami_source/tests/test_tsunami_okada.py
+++ b/anuga/tsunami_source/tests/test_tsunami_okada.py
@@ -298,7 +298,8 @@ class Test_eq(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_eq,'test')
+    #suite = unittest.makeSuite(Test_eq,'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_eq)
     runner = unittest.TextTestRunner()
     runner.run(suite)
 

--- a/anuga/tsunami_source/tests/test_tsunami_okada.py
+++ b/anuga/tsunami_source/tests/test_tsunami_okada.py
@@ -298,7 +298,6 @@ class Test_eq(unittest.TestCase):
 #-------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_eq,'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_eq)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_cg_solve.py
+++ b/anuga/utilities/tests/test_cg_solve.py
@@ -552,8 +552,6 @@ class Test_CG_Solve(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_CG_Solve, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_CG_Solve)
-    #runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/utilities/tests/test_cg_solve.py
+++ b/anuga/utilities/tests/test_cg_solve.py
@@ -552,7 +552,8 @@ class Test_CG_Solve(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_CG_Solve, 'test')
+    #suite = unittest.makeSuite(Test_CG_Solve, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_CG_Solve)
     #runner = unittest.TextTestRunner(verbosity=2)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/utilities/tests/test_csv_tools.py
+++ b/anuga/utilities/tests/test_csv_tools.py
@@ -421,7 +421,6 @@ class Test_CSV_utils(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_CSV_utils, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_CSV_utils)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_csv_tools.py
+++ b/anuga/utilities/tests/test_csv_tools.py
@@ -421,6 +421,7 @@ class Test_CSV_utils(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_CSV_utils, 'test')
+    #suite = unittest.makeSuite(Test_CSV_utils, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_CSV_utils)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_data_audit.py
+++ b/anuga/utilities/tests/test_data_audit.py
@@ -334,7 +334,6 @@ class Test_data_audit(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_data_audit, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_data_audit)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_data_audit.py
+++ b/anuga/utilities/tests/test_data_audit.py
@@ -334,6 +334,7 @@ class Test_data_audit(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_data_audit, 'test')
+    #suite = unittest.makeSuite(Test_data_audit, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_data_audit)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_file_utils.py
+++ b/anuga/utilities/tests/test_file_utils.py
@@ -150,7 +150,6 @@ class Test_FileUtils(unittest.TestCase):
 
 # -------------------------------------------------------------
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_FileUtils, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_FileUtils)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_file_utils.py
+++ b/anuga/utilities/tests/test_file_utils.py
@@ -150,6 +150,7 @@ class Test_FileUtils(unittest.TestCase):
 
 # -------------------------------------------------------------
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_FileUtils, 'test')
+    #suite = unittest.makeSuite(Test_FileUtils, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_FileUtils)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_function_utils.py
+++ b/anuga/utilities/tests/test_function_utils.py
@@ -53,7 +53,6 @@ class Test_Function_Utils(unittest.TestCase):
 # -------------------------------------------------------------
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Function_Utils, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Function_Utils)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_function_utils.py
+++ b/anuga/utilities/tests/test_function_utils.py
@@ -53,6 +53,7 @@ class Test_Function_Utils(unittest.TestCase):
 # -------------------------------------------------------------
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Function_Utils, 'test')
+    #suite = unittest.makeSuite(Test_Function_Utils, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Function_Utils)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_log_analyser.py
+++ b/anuga/utilities/tests/test_log_analyser.py
@@ -81,7 +81,6 @@ class logTestCase(unittest.TestCase):
 
 ################################################################################
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(logTestCase, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(logTestCase)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_log_analyser.py
+++ b/anuga/utilities/tests/test_log_analyser.py
@@ -81,6 +81,7 @@ class logTestCase(unittest.TestCase):
 
 ################################################################################
 if __name__ == "__main__":
-    suite = unittest.makeSuite(logTestCase, 'test')
+    #suite = unittest.makeSuite(logTestCase, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(logTestCase)
     runner = unittest.TextTestRunner()  # verbosity=2)
     runner.run(suite)

--- a/anuga/utilities/tests/test_mem_time_equation.py
+++ b/anuga/utilities/tests/test_mem_time_equation.py
@@ -42,7 +42,6 @@ class Test_mem_time_equation(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_mem_time_equation, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_mem_time_equation)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_mem_time_equation.py
+++ b/anuga/utilities/tests/test_mem_time_equation.py
@@ -42,6 +42,7 @@ class Test_mem_time_equation(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_mem_time_equation, 'test')
+    #suite = unittest.makeSuite(Test_mem_time_equation, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_mem_time_equation)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_model_tools.py
+++ b/anuga/utilities/tests/test_model_tools.py
@@ -91,7 +91,6 @@ class Test_Model_Tools(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Model_Tools, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Model_Tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_model_tools.py
+++ b/anuga/utilities/tests/test_model_tools.py
@@ -91,6 +91,7 @@ class Test_Model_Tools(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Model_Tools, 'test')
+    #suite = unittest.makeSuite(Test_Model_Tools, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Model_Tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_numerical_tools.py
+++ b/anuga/utilities/tests/test_numerical_tools.py
@@ -634,6 +634,7 @@ class Test_Numerical_Tools(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Numerical_Tools, 'test')
+    #suite = unittest.makeSuite(Test_Numerical_Tools, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Numerical_Tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_numerical_tools.py
+++ b/anuga/utilities/tests/test_numerical_tools.py
@@ -634,7 +634,6 @@ class Test_Numerical_Tools(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Numerical_Tools, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Numerical_Tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_plot_utils.py
+++ b/anuga/utilities/tests/test_plot_utils.py
@@ -495,6 +495,7 @@ class Test_plot_utils(unittest.TestCase):
 ################################################################################
 if __name__ == "__main__":
     # _triangle_containing_point')
-    suite = unittest.makeSuite(Test_plot_utils, 'test')
+    #suite = unittest.makeSuite(Test_plot_utils, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_plot_utils)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_plot_utils.py
+++ b/anuga/utilities/tests/test_plot_utils.py
@@ -495,7 +495,6 @@ class Test_plot_utils(unittest.TestCase):
 ################################################################################
 if __name__ == "__main__":
     # _triangle_containing_point')
-    #suite = unittest.makeSuite(Test_plot_utils, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_plot_utils)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_quantity_setting_functions.py
+++ b/anuga/utilities/tests/test_quantity_setting_functions.py
@@ -419,7 +419,6 @@ class Test_quantity_setting_functions(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_quantity_setting_functions, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_quantity_setting)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_quantity_setting_functions.py
+++ b/anuga/utilities/tests/test_quantity_setting_functions.py
@@ -419,6 +419,7 @@ class Test_quantity_setting_functions(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_quantity_setting_functions, 'test')
+    #suite = unittest.makeSuite(Test_quantity_setting_functions, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_quantity_setting)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_sparse.py
+++ b/anuga/utilities/tests/test_sparse.py
@@ -209,6 +209,7 @@ class Test_Sparse(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_Sparse, 'test')
+    #suite = unittest.makeSuite(Test_Sparse, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_Sparse)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_sparse.py
+++ b/anuga/utilities/tests/test_sparse.py
@@ -209,7 +209,6 @@ class Test_Sparse(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_Sparse, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Sparse)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_spatialInputUtil.py
+++ b/anuga/utilities/tests/test_spatialInputUtil.py
@@ -435,7 +435,6 @@ class Test_spatialInputUtil(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_spatialInputUtil, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_spatialInputUtil)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/utilities/tests/test_spatialInputUtil.py
+++ b/anuga/utilities/tests/test_spatialInputUtil.py
@@ -435,6 +435,7 @@ class Test_spatialInputUtil(unittest.TestCase):
 
 # =========================================================================
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_spatialInputUtil, 'test')
+    #suite = unittest.makeSuite(Test_spatialInputUtil, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_spatialInputUtil)
     runner = unittest.TextTestRunner(verbosity=1)
     runner.run(suite)

--- a/anuga/utilities/tests/test_system_tools.py
+++ b/anuga/utilities/tests/test_system_tools.py
@@ -490,7 +490,6 @@ class Test_system_tools(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_system_tools, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_system_tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_system_tools.py
+++ b/anuga/utilities/tests/test_system_tools.py
@@ -490,6 +490,7 @@ class Test_system_tools(unittest.TestCase):
 ################################################################################
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_system_tools, 'test')
+    #suite = unittest.makeSuite(Test_system_tools, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_system_tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_xml_tools.py
+++ b/anuga/utilities/tests/test_xml_tools.py
@@ -269,6 +269,7 @@ class Test_xml_tools(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(Test_xml_tools, 'test')
+    #suite = unittest.makeSuite(Test_xml_tools, 'test')
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test_xml_tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/anuga/utilities/tests/test_xml_tools.py
+++ b/anuga/utilities/tests/test_xml_tools.py
@@ -269,7 +269,6 @@ class Test_xml_tools(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #suite = unittest.makeSuite(Test_xml_tools, 'test')
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_xml_tools)
     runner = unittest.TextTestRunner()
     runner.run(suite)


### PR DESCRIPTION
Here I replaced the deprecated `makeSuite` from python 3.11 that will be dropped in later python versions using the supported `LoadTestsFromTestCase` function. 
