### PR TITLE
Stop using removed alias `numpy.float`

### DIFF
--- a/anuga/visualiser/numerical_dam_break_dry.py
+++ b/anuga/visualiser/numerical_dam_break_dry.py
@@ -12,7 +12,7 @@ import sys
 import anuga
 from anuga import Domain as Domain
 from math import cos
-from numpy import zeros, float
+from numpy import zeros
 from time import localtime, strftime, gmtime
 #from balanced_dev import *
 

--- a/validation_tests/analytical_exact/lake_at_rest_immersed_bump/numerical_immersed_bump.py
+++ b/validation_tests/analytical_exact/lake_at_rest_immersed_bump/numerical_immersed_bump.py
@@ -11,7 +11,7 @@ import sys
 import anuga
 from anuga import Domain as Domain
 from math import cos
-from numpy import zeros, float
+from numpy import zeros
 from time import localtime, strftime, gmtime
 #from balanced_dev import *
 from anuga import myid, finalize, distribute

--- a/validation_tests/other_references/radial_dam_break_dry/radial_dam_break.py
+++ b/validation_tests/other_references/radial_dam_break_dry/radial_dam_break.py
@@ -10,7 +10,7 @@ similar to a beach environment
 import sys
 import anuga
 from math import cos
-from numpy import zeros, float
+from numpy import zeros
 
 #------------------------------------------------------------------------------
 # Setup parameters and utilitiy functions

--- a/validation_tests/other_references/radial_dam_break_wet/radial_dam_break.py
+++ b/validation_tests/other_references/radial_dam_break_wet/radial_dam_break.py
@@ -10,7 +10,7 @@ similar to a beach environment
 import sys
 import anuga
 from math import cos
-from numpy import zeros, float
+from numpy import zeros
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Related to:
* #67

% `ruff check --select=NPY001 --output-format=concise`
```
anuga/visualiser/numerical_dam_break_dry.py:70:23: NPY001
analytical_exact/lake_at_rest_immersed_bump/numerical_immersed_bump.py:30:23: NPY001
validation_tests/other_references/radial_dam_break_dry/radial_dam_break.py:28:23: NPY001
validation_tests/other_references/radial_dam_break_wet/radial_dam_break.py:30:23: NPY001
```
% `ruff rule NPY001`
# numpy-deprecated-type-alias (NPY001)

Derived from the **NumPy-specific rules** linter.

Fix is sometimes available.

## What it does
Checks for deprecated NumPy type aliases.

## Why is this bad?
NumPy's `np.int` has long been an alias of the builtin `int`; the same
is true of `np.float` and others. These aliases exist primarily
for historic reasons, and have been a cause of frequent confusion
for newcomers.

These aliases were deprecated in 1.20, and removed in 1.24.
Note, however, that `np.bool` and `np.long` were reintroduced in 2.0 with
different semantics, and are thus omitted from this rule.

## Example
```python
import numpy as np

np.int
```

Use instead:
```python
int
```
