### PR TITLE
Add BFS locality mesh partitioning

### DIFF
--- a/anuga/parallel/distribute_mesh.py
+++ b/anuga/parallel/distribute_mesh.py
@@ -121,7 +121,7 @@ def reorder_quantities(quantities, epart_order):
 def partition_mesh(domain, n_procs,
                    parameters=None,
                    verbose=False):
-    """Partition a mesh across multiple processors using METIS, Morton, or Hilbert partitioning.
+    """Partition a mesh across multiple processors using METIS, Morton, Hilbert, RCM, or BFS partitioning.
 
     This function takes a serial mesh and distributes it across multiple processors
     by reordering triangles according to a partitioning scheme. It generates
@@ -138,7 +138,7 @@ def partition_mesh(domain, n_procs,
         Additional parameters for the partitioning algorithm. Supported keys:
 
         - 'partition_scheme' : str, default 'metis'
-            Partitioning scheme ('metis', 'morton', or 'hilbert')
+            Partitioning scheme ('metis', 'morton', 'hilbert', 'rcm', or 'bfs')
         - 'distribute_quantity_names' : list, default DEFAULT_DISTRIBUTE_QUANTITY_NAMES
             Names of quantities to distribute
         - 'in_place' : bool, default False
@@ -167,7 +167,7 @@ def partition_mesh(domain, n_procs,
 
     Notes
     -----
-    The function uses METIS, Morton, or Hilbert partitioning to distribute triangles
+    The function uses METIS, Morton, Hilbert, RCM, or BFS partitioning to distribute triangles
     across processors. Set `in_place=True` in parameters if the original sequential
     domain will not be used again to save memory.
 
@@ -215,7 +215,9 @@ def partition_mesh(domain, n_procs,
     else:
         distribute_quantities = {}
 
-    from anuga.parallel.partitioning import metis_partition, morton_partition, hilbert_partition, rcm_partition
+    from anuga.parallel.partitioning import (
+        metis_partition, morton_partition, hilbert_partition, rcm_partition,
+        bfs_partition)
 
     if verbose: print("partition_mesh: Computing partitioning using {}...".format(partition_scheme))
     if partition_scheme == 'morton':
@@ -224,6 +226,8 @@ def partition_mesh(domain, n_procs,
         epart_order, triangles_per_proc = hilbert_partition(domain, n_procs)
     elif partition_scheme == 'rcm':
         epart_order, triangles_per_proc = rcm_partition(domain, n_procs)
+    elif partition_scheme == 'bfs':
+        epart_order, triangles_per_proc = bfs_partition(domain, n_procs)
     else:
         epart_order, triangles_per_proc = metis_partition(domain, n_procs)
 

--- a/anuga/parallel/partitioning.py
+++ b/anuga/parallel/partitioning.py
@@ -3,8 +3,23 @@
 import numpy as np
 
 #==============================================================================================================
-# Code for partitioning meshes using METIS, Morton codes, and Hilbert codes.
+# Code for partitioning meshes using METIS, Morton codes, Hilbert codes, and
+# adjacency BFS ordering.
 #==============================================================================================================
+
+
+def _balanced_triangles_per_proc(n_tri, n_procs):
+    """Return a near-even triangle count for each processor."""
+    if n_procs > n_tri:
+        raise ValueError("Number of processors must be less than or equal to the number of triangles")
+
+    triangles_per_proc = np.full(n_procs, n_tri // n_procs, dtype=int)
+    remainder = n_tri % n_procs
+    if remainder > 0:
+        triangles_per_proc[:remainder] += 1
+
+    assert triangles_per_proc.sum() == n_tri, "Total number of triangles must match after partitioning"
+    return triangles_per_proc
 
 
 #==============================================================================================================
@@ -261,22 +276,13 @@ def morton_partition(domain, n_procs):
 
     n_tri = domain.number_of_triangles
 
-    if n_procs > n_tri:
-        raise ValueError("Number of processors must be less than or equal to the number of triangles")
-
+    triangles_per_proc = _balanced_triangles_per_proc(n_tri, n_procs)
 
     points = domain.centroid_coordinates
     order = morton_order_from_points(points)
 
     # Now we have an ordering of the triangles based on their centroids' Morton codes.
     # We can divide this ordering into contiguous blocks for each processor.
-
-    triangles_per_proc = np.full(n_procs, n_tri // n_procs, dtype=int)
-    remainder = n_tri % n_procs
-    if remainder > 0:
-        triangles_per_proc[:remainder] += 1
-
-    assert triangles_per_proc.sum() == n_tri, "Total number of triangles must match after partitioning"
 
     return order, triangles_per_proc
 
@@ -435,22 +441,13 @@ def hilbert_partition(domain, n_procs):
 
     n_tri = domain.number_of_triangles
 
-    if n_procs > n_tri:
-        raise ValueError("Number of processors must be less than or equal to the number of triangles")
-
+    triangles_per_proc = _balanced_triangles_per_proc(n_tri, n_procs)
 
     points = domain.centroid_coordinates
     order = hilbert_order_from_points(points)
 
     # Now we have an ordering of the triangles based on their centroids' Hilbert codes.
     # We can divide this ordering into contiguous blocks for each processor.
-
-    triangles_per_proc = np.full(n_procs, n_tri // n_procs, dtype=int)
-    remainder = n_tri % n_procs
-    if remainder > 0:
-        triangles_per_proc[:remainder] += 1
-
-    assert triangles_per_proc.sum() == n_tri, "Total number of triangles must match after partitioning"
 
     return order, triangles_per_proc
 
@@ -531,23 +528,148 @@ def hilbert_order_from_points(points, p=16):
     return np.argsort(h, kind="mergesort")
 
 
+#==============================================================================================================
+# Code for adjacency BFS ordering.
+#
+# This keeps mesh-neighbour traversal local while using a spatial seed order to
+# make component starts and per-node neighbour ties deterministic.
+#==============================================================================================================
+
+def bfs_partition(domain, n_procs):
+    """
+    Partition a mesh using adjacency BFS ordering.
+
+    This function builds a deterministic breadth-first traversal over the
+    triangle-neighbour graph.  The traversal is seeded and tie-broken by Morton
+    order of triangle centroids so disconnected components and equal-depth
+    neighbours still follow a spatially local order.
+
+    Parameters
+    ----------
+    domain : object
+        Domain object containing ``number_of_triangles``, ``neighbours``, and
+        ``centroid_coordinates``.
+    n_procs : int
+        Number of processors to partition the mesh across.
+
+    Returns
+    -------
+    epart_order : ndarray
+        Integer array of triangle indices in BFS-locality order.
+    triangles_per_proc : ndarray
+        Integer array of length n_procs where triangles_per_proc[i] is the
+        number of triangles assigned to processor i.
+
+    Raises
+    ------
+    ValueError
+        If n_procs is greater than the number of triangles in the domain.
+    """
+    n_tri = domain.number_of_triangles
+    seed_order = morton_order_from_points(domain.centroid_coordinates)
+    order = bfs_order_from_neighbours(domain.neighbours, seed_order=seed_order)
+    triangles_per_proc = _balanced_triangles_per_proc(n_tri, n_procs)
+    return order, triangles_per_proc
+
+
+def bfs_order_from_neighbours(neighbours, seed_order=None):
+    """
+    Return a deterministic BFS ordering from a triangle-neighbour array.
+
+    Parameters
+    ----------
+    neighbours : ndarray, shape (N, K)
+        Neighbour triangle ids.  Negative values are treated as boundaries.
+    seed_order : array_like of int, optional
+        Permutation of ``0..N-1`` controlling which unvisited component is
+        traversed next and how same-depth neighbours are ordered.  If omitted,
+        triangle ids are used.
+
+    Returns
+    -------
+    order : ndarray of int, shape (N,)
+        Triangle ids in BFS-locality order.
+    """
+    from scipy.sparse import csr_matrix
+    from scipy.sparse.csgraph import breadth_first_order
+
+    neighbours = np.asarray(neighbours, dtype=np.int64)
+    if neighbours.ndim != 2:
+        raise ValueError("neighbours must be a 2D array")
+
+    n_tri = neighbours.shape[0]
+    if seed_order is None:
+        seed_order = np.arange(n_tri, dtype=int)
+    else:
+        seed_order = np.asarray(seed_order, dtype=int)
+
+    if seed_order.shape != (n_tri,):
+        raise ValueError("seed_order must have length equal to number of triangles")
+    if not np.array_equal(np.sort(seed_order), np.arange(n_tri, dtype=int)):
+        raise ValueError("seed_order must be a permutation of triangle ids")
+
+    seed_rank = np.empty(n_tri, dtype=int)
+    seed_rank[seed_order] = np.arange(n_tri, dtype=int)
+
+    rows = np.repeat(np.arange(n_tri, dtype=np.int64), neighbours.shape[1])
+    cols = neighbours.ravel()
+    valid = (cols >= 0) & (cols < n_tri) & (cols != rows)
+    rows = rows[valid]
+    cols = cols[valid]
+
+    # csr_matrix preserves the input order within each row.  Sorting neighbour
+    # ids by seed_rank keeps SciPy's BFS deterministic and equivalent to the
+    # original Python queue implementation.
+    perm = np.lexsort((seed_rank[cols], rows))
+    rows = rows[perm]
+    cols = cols[perm]
+
+    counts = np.bincount(rows, minlength=n_tri).astype(np.int32)
+    indptr = np.empty(n_tri + 1, dtype=np.int32)
+    indptr[0] = 0
+    np.cumsum(counts, out=indptr[1:])
+    graph = csr_matrix(
+        (np.ones(len(cols), dtype=np.int8), cols.astype(np.int32), indptr),
+        shape=(n_tri, n_tri))
+
+    visited = np.zeros(n_tri, dtype=bool)
+    chunks = []
+
+    for seed in seed_order:
+        seed = int(seed)
+        if visited[seed]:
+            continue
+
+        component = breadth_first_order(
+            graph, seed, directed=False, return_predecessors=False)
+        component = component[~visited[component]]
+        if len(component):
+            visited[component] = True
+            chunks.append(component.astype(int, copy=False))
+
+    if chunks:
+        return np.concatenate(chunks)
+    return np.empty(0, dtype=int)
+
+
 def reorder_domain(domain, method='hilbert', n_procs=None, verbose=False):
     """Reorder domain triangles for cache locality.
 
-    Computes an ordering using a space-filling curve or Metis partitioning and
-    applies it to the domain in-place.  Call after distribute() and before
-    create_riverwalls() / operator setup so those indices are built on top of
-    the reordered mesh.
+    Computes an ordering using a space-filling curve, graph ordering, or Metis
+    partitioning and applies it to the domain in-place.  Call after distribute()
+    and before create_riverwalls() / operator setup so those indices are built
+    on top of the reordered mesh.
 
     Parameters
     ----------
     domain : Domain
     method : str
-        'hilbert' (default), 'morton', or 'metis'
+        'hilbert' (default), 'morton', 'rcm', 'bfs', 'metis',
+        'metis_hilbert', or 'metis_rcm'.
     n_procs : int or None
         Number of partitions for Metis ordering.  If None, reads
         ``OMP_NUM_THREADS`` from the environment (defaulting to 1 when unset).
-        For Hilbert/Morton this parameter is ignored.
+        For Hilbert/Morton/RCM/BFS this parameter is ignored.
     verbose : bool
 
     Returns
@@ -565,6 +687,8 @@ def reorder_domain(domain, method='hilbert', n_procs=None, verbose=False):
         epart_order, _ = morton_partition(domain, 1)
     elif method == 'rcm':
         epart_order, _ = rcm_partition(domain)
+    elif method == 'bfs':
+        epart_order, _ = bfs_partition(domain, 1)
     elif method == 'metis':
         epart_order, _ = metis_partition(domain, max(1, n_procs))
     elif method == 'metis_hilbert':

--- a/anuga/parallel/tests/test_partitioning.py
+++ b/anuga/parallel/tests/test_partitioning.py
@@ -3,6 +3,8 @@ import numpy as np
 
 from anuga.parallel.partitioning import morton_order_from_points
 from anuga.parallel.partitioning import hilbert_order_from_points
+from anuga.parallel.partitioning import bfs_order_from_neighbours
+from anuga.parallel.partitioning import bfs_partition
 
 def test_morton_order_from_points_basic():
     """Test basic Morton ordering with simple points."""
@@ -131,3 +133,60 @@ def test_hilbert_order_from_points_all_same():
     order = hilbert_order_from_points(points)
     assert len(order) == 3
     assert np.array_equal(np.sort(order), np.arange(3))
+
+
+def test_bfs_order_from_neighbours_chain():
+    """BFS order follows neighbour adjacency and skips boundary markers."""
+    neighbours = np.array([
+        [1, -1, -1],
+        [0, 2, -1],
+        [1, 3, -1],
+        [2, -1, -1],
+    ])
+    order = bfs_order_from_neighbours(neighbours)
+    assert np.array_equal(order, np.arange(4))
+
+
+def test_bfs_order_from_neighbours_disconnected_seed_order():
+    """Disconnected components are started in seed_order order."""
+    neighbours = np.array([
+        [1, -1, -1],
+        [0, -1, -1],
+        [3, -1, -1],
+        [2, -1, -1],
+    ])
+    order = bfs_order_from_neighbours(neighbours, seed_order=[2, 3, 0, 1])
+    assert np.array_equal(order, np.array([2, 3, 0, 1]))
+
+
+def test_bfs_order_from_neighbours_invalid_inputs():
+    """BFS ordering validates neighbour and seed array shapes."""
+    with pytest.raises(ValueError, match="neighbours must be a 2D array"):
+        bfs_order_from_neighbours(np.array([0, 1, 2]))
+    with pytest.raises(ValueError, match="seed_order must have length"):
+        bfs_order_from_neighbours(np.array([[1], [0]]), seed_order=[0])
+    with pytest.raises(ValueError, match="seed_order must be a permutation"):
+        bfs_order_from_neighbours(np.array([[1], [0]]), seed_order=[0, 0])
+
+
+def test_bfs_partition_rectangular_basic_mesh():
+    """BFS partition returns a complete ordering and balanced partitions."""
+    from anuga.abstract_2d_finite_volumes.basic_mesh import (
+        rectangular_cross_basic_mesh)
+
+    bm = rectangular_cross_basic_mesh(4, 3)
+    order, triangles_per_proc = bfs_partition(bm, 5)
+
+    assert np.array_equal(np.sort(order), np.arange(bm.number_of_triangles))
+    assert triangles_per_proc.sum() == bm.number_of_triangles
+    assert np.max(triangles_per_proc) - np.min(triangles_per_proc) <= 1
+
+
+def test_bfs_partition_rejects_too_many_processors():
+    """BFS partition follows the existing partition size contract."""
+    from anuga.abstract_2d_finite_volumes.basic_mesh import (
+        rectangular_basic_mesh)
+
+    bm = rectangular_basic_mesh(1, 1)
+    with pytest.raises(ValueError, match="Number of processors"):
+        bfs_partition(bm, bm.number_of_triangles + 1)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -86,6 +86,10 @@ mpirun -np 8 python benchmarks/distribute_benchmarks.py --size 500
 
 # Morton scheme, 3 repetitions for stable medians
 mpirun -np 8 python benchmarks/distribute_benchmarks.py --size 500 --scheme morton --reps 3
+
+# RCM and BFS locality schemes, useful for graph-ordering comparisons
+mpirun -np 8 python benchmarks/distribute_benchmarks.py --size 500 --scheme rcm --reps 3
+mpirun -np 8 python benchmarks/distribute_benchmarks.py --size 500 --scheme bfs --reps 3
 ```
 
 | Method | Description |
@@ -101,8 +105,8 @@ mpirun -np 8 python benchmarks/distribute_benchmarks.py --size 500 --scheme mort
 # Run the full np=[10,20,30] × scheme=[metis,morton,hilbert] grid
 python benchmarks/run_benchmark_grid.py --size 1000
 
-# Custom grid
-python benchmarks/run_benchmark_grid.py --size 500 --np 4,8,16 --schemes metis,morton
+# Custom grid including graph-ordering schemes
+python benchmarks/run_benchmark_grid.py --size 500 --np 4,8,16 --schemes metis,morton,hilbert,rcm,bfs
 
 # Dry run (print commands without executing)
 python benchmarks/run_benchmark_grid.py --dry-run

--- a/benchmarks/distribute_benchmarks.py
+++ b/benchmarks/distribute_benchmarks.py
@@ -19,7 +19,7 @@ Options
 -------
 --size M       Grid size M: produces 4*M*M triangles (default 500)
 --reps R       Repetitions for median timing (default 1)
---scheme S     Partition scheme: metis | morton | hilbert (default metis)
+--scheme S     Partition scheme: metis | morton | hilbert | rcm | bfs (default metis)
 --interval T   Memory ticker sample interval in seconds (default 1.0)
 --no-evolve    Skip the correctness evolve check after timing
 """
@@ -440,7 +440,7 @@ def parse_args():
     p.add_argument('--size',      type=int,   default=500)
     p.add_argument('--reps',      type=int,   default=1)
     p.add_argument('--scheme',    type=str,   default='metis',
-                   choices=['metis', 'morton', 'hilbert'])
+                   choices=['metis', 'morton', 'hilbert', 'rcm', 'bfs'])
     p.add_argument('--interval',  type=float, default=1.0)
     p.add_argument('--no-evolve', action='store_true')
     return p.parse_args()

--- a/examples/parallel/run_parallel_basic_mesh.py
+++ b/examples/parallel/run_parallel_basic_mesh.py
@@ -45,7 +45,7 @@ parser.add_argument('-sn', '--sqrtN', type=int, default=sqrtN,
 parser.add_argument('-gl', '--ghost_layer', type=int, default=2,
                     help='ghost layer width')
 parser.add_argument('-ps', '--partition_scheme', type=str, default='metis',
-                    help='partition scheme: metis, morton, or hilbert')
+                    help='partition scheme: metis, morton, hilbert, rcm, or bfs')
 parser.add_argument('-sww', '--store_sww', action='store_true',
                     help='write SWW output files')
 parser.add_argument('-v', '--verbose', action='store_true',

--- a/examples/parallel/run_parallel_basic_mesh_collaborative.py
+++ b/examples/parallel/run_parallel_basic_mesh_collaborative.py
@@ -47,7 +47,7 @@ parser.add_argument('-sn', '--sqrtN', type=int, default=sqrtN,
 parser.add_argument('-gl', '--ghost_layer', type=int, default=2,
                     help='ghost layer width')
 parser.add_argument('-ps', '--partition_scheme', type=str, default='metis',
-                    help='partition scheme: metis, morton, or hilbert')
+                    help='partition scheme: metis, morton, hilbert, rcm, or bfs')
 parser.add_argument('-sww', '--store_sww', action='store_true',
                     help='write SWW output files')
 parser.add_argument('-v', '--verbose', action='store_true',

--- a/examples/parallel/run_parallel_rectangular.py
+++ b/examples/parallel/run_parallel_rectangular.py
@@ -88,7 +88,7 @@ parser.add_argument('-v', '--verbose', action='store_true', help='turn on verbos
 parser.add_argument('-ve', '--evolve_verbose', action='store_true', help='turn on evolve verbosity')
 
 parser.add_argument('-ps', '--partition_scheme', type=str, default='metis',
-                    help='set partition scheme in [metis, morton, hilbert]')
+                    help='set partition scheme in [metis, morton, hilbert, rcm, bfs]')
 
 parser.add_argument('-ro', '--reorder', type=str, default='none',
                     choices=['none', 'hilbert', 'morton', 'rcm', 'metis', 'metis_hilbert', 'metis_rcm'],

--- a/examples/parallel/run_sdpl_rectangular_create_partition_dump.py
+++ b/examples/parallel/run_sdpl_rectangular_create_partition_dump.py
@@ -84,7 +84,7 @@ parser.add_argument('-ve', '--evolve_verbose', action='store_true', help='turn o
 parser.add_argument('-sww', '--store_sww', action='store_true', help='turn on storing sww file')
 
 parser.add_argument('-ps', '--partition_scheme', type=str, default='metis',
-                    help='set partition scheme in [metis, morton, hilbert]')
+                    help='set partition scheme in [metis, morton, hilbert, rcm, bfs]')
 
 args = parser.parse_args()
 

--- a/scripts/benchmark_distribute.py
+++ b/scripts/benchmark_distribute.py
@@ -375,7 +375,7 @@ def parse_args():
     p.add_argument('--interval', type=float, default=1.0,
                    help='Memory ticker sample interval in seconds (default: 1.0)')
     p.add_argument('--scheme',   type=str,   default='metis',
-                   choices=['metis', 'morton', 'hilbert'],
+                   choices=['metis', 'morton', 'hilbert', 'rcm', 'bfs'],
                    help='Partitioning scheme (default: metis)')
     return p.parse_args()
 

--- a/scripts/benchmark_distribute_mesh.py
+++ b/scripts/benchmark_distribute_mesh.py
@@ -14,7 +14,7 @@ Options
 -------
 --size M       Grid size: 4*M*M triangles (rectangular_cross, default 500)
 --reps R       Repetitions for timing (default 1)
---scheme S     Partition scheme: metis | morton | hilbert (default morton)
+--scheme S     Partition scheme: metis | morton | hilbert | rcm | bfs (default morton)
 --interval T   Memory ticker interval in seconds (default 5.0)
 --no-evolve    Skip the short evolve check (default: run 1 step)
 """
@@ -115,7 +115,7 @@ def parse_args():
     p.add_argument('--size',     type=int,   default=500)
     p.add_argument('--reps',     type=int,   default=1)
     p.add_argument('--scheme',   type=str,   default='morton',
-                   choices=['metis', 'morton', 'hilbert'])
+                   choices=['metis', 'morton', 'hilbert', 'rcm', 'bfs'])
     p.add_argument('--interval', type=float, default=5.0)
     p.add_argument('--no-evolve', action='store_true')
     return p.parse_args()


### PR DESCRIPTION
## Summary

Adds an optional BFS locality-based mesh partitioning scheme for ANUGA's parallel mesh distribution path.

The new `partition_scheme='bfs'` orders triangles by a deterministic breadth-first traversal over the triangle-neighbour graph, seeded and tie-broken by Morton order of triangle centroids. It is now based on `develop` and can be benchmarked directly against the existing `rcm`, `metis`, `morton`, and `hilbert` schemes.

## Motivation

Issue #140 discusses mesh ordering and locality as a performance factor for ANUGA, including interest in BFS/locality-based ordering. This PR adds BFS as an explicit graph-traversal partitioning option without changing the default `metis` behavior.

## Changes

- Add `bfs_order_from_neighbours()` and `bfs_partition()` in `anuga.parallel.partitioning`.
- Use SciPy's CSR `breadth_first_order()` for the BFS traversal, with neighbour order sorted by Morton seed rank for deterministic tie-breaking.
- Wire `partition_scheme='bfs'` through `partition_mesh()`.
- Add `reorder_domain(..., method='bfs')` support alongside `rcm`.
- Add unit coverage for BFS ordering, disconnected components, invalid inputs, balanced partition sizing, and processor-count validation.
- Update benchmark/example CLI help so `bfs` and `rcm` can be selected explicitly.
- Document RCM/BFS benchmark invocations in `benchmarks/README.md`.

## RCM comparison

BFS and RCM are not duplicate orderings: they generate different permutations. In rectangular and random Delaunay test meshes, they produce very similar neighbour-locality and ghost/edge-cut metrics. RCM is faster to compute, while BFS provides an explicit breadth-first traversal baseline for comparing graph-local partitioning behavior.

Based on the timings below, I would not suggest BFS as a replacement/default over RCM; it is better positioned as an optional comparison/experimental locality scheme.

## Validation

Run inside `hydro-coupled-fvm-dev:v2.0` after installing SciPy, pymetis, mpi4py/OpenMPI, and an editable Meson build:

- `pytest anuga/parallel/tests/test_partitioning.py -q` -> 21 passed
- `pytest anuga/parallel/tests/test_distribute_basic_mesh.py::TestBasic_meshConstruction -q` -> 5 passed
- Smoke-tested `partition_mesh(..., parameters={'partition_scheme': scheme})` for `rcm`, `bfs`, `morton`, and `hilbert` on `rectangular_cross_basic_mesh`.

Partition-order benchmark, rectangular_cross meshes, 8 blocks, median of 5 runs:

| Triangles | RCM time | BFS time | RCM edge cut | BFS edge cut |
|---:|---:|---:|---:|---:|
| 10,000 | 0.0007s | 0.0025s | 746 | 763 |
| 40,000 | 0.0021s | 0.0096s | 1,538 | 1,538 |
| 160,000 | 0.0085s | 0.0391s | 3,064 | 3,064 |
| 360,000 | 0.0200s | 0.0896s | 4,606 | 4,606 |

Random Delaunay meshes, 8 blocks, median of 5 runs:

| Triangles | RCM time | BFS time | RCM edge cut | BFS edge cut |
|---:|---:|---:|---:|---:|
| 10,274 | 0.0009s | 0.0034s | 828 | 801 |
| 40,558 | 0.0029s | 0.0136s | 1,698 | 1,647 |
| 161,122 | 0.0116s | 0.0557s | 3,254 | 3,268 |

MPI smoke benchmark, `mpirun --allow-run-as-root -np 4 python benchmarks/distribute_benchmarks.py --size 100 --reps 2 --no-evolve`:

| Scheme | distribute() | collaborative() | distribute_basic_mesh() | dump()+load() | Ghost triangles |
|---|---:|---:|---:|---:|---:|
| rcm | 0.043s | 0.028s | 0.021s | 0.091s | 1,908 (4.8%) |
| bfs | 0.045s | 0.035s | 0.029s | 0.100s | 1,908 (4.8%) |
