### PR TITLE
fix(sww): don't crash storing a near-duplicate/checkpoint timestep at large t

### DIFF
--- a/anuga/file/sww.py
+++ b/anuga/file/sww.py
@@ -996,8 +996,24 @@ class Write_sww(Write_sts):
             # check if time already saved as in check pointing
             if slice_index > 0:
                 if time <= file_time[slice_index-1]:
-                    check = numpy.where(numpy.abs(file_time[:]-time) < 1.0e-14)
-                    slice_index = int(check[0][0])
+                    # This time is being (re)written rather than appended
+                    # (e.g. resuming from a checkpoint, or a near-duplicate
+                    # yield time): find the existing slot to overwrite.
+                    # The tolerance must scale with the time magnitude — a
+                    # fixed 1e-14 is *below* the float64 ULP for any t beyond
+                    # a few tens of seconds, so the match would spuriously
+                    # fail at large t. If nothing matches, append rather than
+                    # crash with an IndexError on an empty result.
+                    tol = 1.0e-9 * max(1.0, abs(time))
+                    check = numpy.where(numpy.abs(file_time[:]-time) <= tol)[0]
+                    if len(check) > 0:
+                        slice_index = int(check[0])
+                    else:
+                        log.warning(
+                            'store_quantities: time %.17g <= last stored time '
+                            '%.17g but no slot matches within %g; appending'
+                            % (time, file_time[slice_index-1], tol))
+                        slice_index = len(file_time)
             file_time[slice_index] = time
         else:
             # Has to be cast in case it was numpy.int


### PR DESCRIPTION
## Problem

`Write_sww.store_quantities()` raises `IndexError: index 0 is out of bounds for axis 0 with size 0` deep into long runs (reported at simulation time ~6960 s, after ~26 minutes of wall time):

```
File ".../anuga/file/sww.py", line 1000, in store_quantities
    slice_index = int(check[0][0])
IndexError: index 0 is out of bounds for axis 0 with size 0
```

When the time being written is `<=` the last time already in the file (a checkpoint resume, or a near-duplicate yield time), the writer looks up the existing slot with an **absolute** tolerance:

```python
check = numpy.where(numpy.abs(file_time[:]-time) < 1.0e-14)
slice_index = int(check[0][0])
```

But `1e-14` is **below the float64 ULP for any `t` beyond a few tens of seconds** (ULP ≈ 9e-13 at t≈6960). So the match silently fails, `check[0]` is empty, and `check[0][0]` throws — killing the whole run at the write. This is not a file-rollover (`max_size` default is 200 GB).

## Fix

- Scale the match tolerance to the time magnitude (`1e-9 * max(1, |t|)`) so legitimate matches are found at large `t`. The tolerance stays far below any realistic yieldstep, so it cannot match the wrong step.
- If nothing matches, **append** (with a warning) instead of crashing on an empty result.

## Verification

Reproduced at t≈6960 s with a time `1e-10` off an existing slot (well beyond the old `1e-14` test): previously `IndexError`, now correctly overwrites the matching slot — no crash. Genuine checkpoint resumes still overwrite the right slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)