### PR TITLE
fix: clamp timestep at output time boundaries

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -2588,19 +2588,24 @@ class Generic_Domain:
         A small roundoff overshoot can make ``target - relative_time`` negative
         even though the evolve loop is about to yield.  Clamp those stale
         deadlines to zero instead of returning a negative timestep.
+
+        Use the explicitly tracked ``relative_yieldtime`` when available.
+        Computing the next yield boundary with ``relative_time % yieldstep`` is
+        floating-point fragile and can leave a tiny remainder that drives the
+        maximum timestep toward zero.
         """
 
         remaining_finaltime = self._time_remaining_until(self.relative_finaltime)
         if remaining_finaltime is None and finaltime is not None:
             remaining_finaltime = max(finaltime - self.get_time(), 0.0)
         if remaining_finaltime is not None and timestep > remaining_finaltime:
-            timestep = min(timestep, remaining_finaltime)
+            timestep = remaining_finaltime
 
         remaining_yieldstep = self._time_remaining_until(getattr(self, 'relative_yieldtime', None))
         if remaining_yieldstep is None and yieldstep is not None:
             remaining_yieldstep = max(float(yieldstep), 0.0)
         if remaining_yieldstep is not None and timestep > remaining_yieldstep:
-            timestep = min(timestep, remaining_yieldstep)
+            timestep = remaining_yieldstep
 
         return timestep
 

--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -2570,15 +2570,46 @@ class Generic_Domain:
         #       recorded_min_timesteps simply because of we have to yield at a
         #       given time
 
-        # Ensure that final time is not exceeded
-        if self.relative_finaltime is not None and self.relative_time + timestep > self.relative_finaltime:
-            timestep = self.relative_finaltime - self.relative_time
-
-        # Ensure that model time is aligned with yieldsteps
-        if self.relative_time + timestep > self.relative_yieldtime:
-            timestep = self.relative_yieldtime - self.relative_time
+        timestep = self._clip_timestep_to_output_times(timestep, yieldstep, finaltime)
 
         self.timestep = timestep
+
+    def _time_remaining_until(self, target_time):
+        """Return non-negative relative time remaining until target_time."""
+
+        if target_time is None:
+            return None
+
+        return max(target_time - self.relative_time, 0.0)
+
+    def _clip_timestep_to_output_times(self, timestep, yieldstep, finaltime):
+        """Limit timestep so evolve lands on yield/final boundaries.
+
+        A small roundoff overshoot can make ``target - relative_time`` negative
+        even though the evolve loop is about to yield.  Clamp those stale
+        deadlines to zero instead of returning a negative timestep.
+        """
+
+        remaining_finaltime = self._time_remaining_until(self.relative_finaltime)
+        if remaining_finaltime is None and finaltime is not None:
+            remaining_finaltime = max(finaltime - self.get_time(), 0.0)
+        if remaining_finaltime is not None and timestep > remaining_finaltime:
+            timestep = min(timestep, remaining_finaltime)
+
+        remaining_yieldstep = self._time_remaining_until(getattr(self, 'relative_yieldtime', None))
+        if remaining_yieldstep is None and yieldstep is not None:
+            remaining_yieldstep = max(float(yieldstep), 0.0)
+        if remaining_yieldstep is not None and timestep > remaining_yieldstep:
+            timestep = min(timestep, remaining_yieldstep)
+
+        return timestep
+
+    def _get_max_timestep_to_output_times(self, yieldstep, finaltime):
+        """Return max step allowed before the next evolve output boundary."""
+
+        return self._clip_timestep_to_output_times(self.evolve_max_timestep,
+                                                   yieldstep,
+                                                   finaltime)
 
     def compute_forcing_terms(self):
         """If there are any forcing functions driving the system

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2695,13 +2695,7 @@ class Domain(Generic_Domain):
         #       recorded_min_timesteps simply because of we have to yield at a
         #       given time
 
-        # Ensure that final time is not exceeded
-        if self.relative_finaltime is not None and self.relative_time + timestep > self.relative_finaltime:
-            timestep = self.relative_finaltime - self.relative_time
-
-        # Ensure that model time is aligned with yieldsteps
-        if self.relative_time + timestep > self.relative_yieldtime:
-            timestep = self.relative_yieldtime - self.relative_time
+        timestep = self._clip_timestep_to_output_times(timestep, yieldstep, finaltime)
 
         self.timestep = timestep
 
@@ -3579,21 +3573,7 @@ class Domain(Generic_Domain):
                 stage_val = float(value[0])
             set_flather_value(gpu_dom, stage_val)
 
-        # Time remaining to the next yield boundary. Use the explicitly tracked
-        # relative_yieldtime (set and incremented by the evolve loop), NOT
-        # (relative_time % yieldstep): the modulo is floating-point fragile, e.g.
-        # 0.3 % 0.1 == 0.0999... gives remaining ~1e-17 -> max_timestep ~0 ->
-        # the step never advances and evolve() spins. Mirrors update_timestep().
-        relative_yieldtime = getattr(self, 'relative_yieldtime', None)
-        if relative_yieldtime is not None:
-            remaining_yieldstep = relative_yieldtime - self.get_relative_time()
-        else:
-            remaining_yieldstep = yieldstep
-        if finaltime is not None:
-            remaining_finaltime = finaltime - self.get_time()
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep, remaining_finaltime)
-        else:
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep)
+        max_timestep = self._get_max_timestep_to_output_times(yieldstep, finaltime)
 
         if not hasattr(self, '_ader2_prev_dt'):
             self._ader2_prev_dt = 0.0
@@ -4103,22 +4083,7 @@ class Domain(Generic_Domain):
                 stage_val = float(value[0])
             set_flather_value(gpu_dom, stage_val)
 
-        # Compute max allowed timestep (mirrors update_timestep() logic)
-        # Time remaining to the next yield boundary. Use the explicitly tracked
-        # relative_yieldtime (set and incremented by the evolve loop), NOT
-        # (relative_time % yieldstep): the modulo is floating-point fragile, e.g.
-        # 0.3 % 0.1 == 0.0999... gives remaining ~1e-17 -> max_timestep ~0 ->
-        # the step never advances and evolve() spins. Mirrors update_timestep().
-        relative_yieldtime = getattr(self, 'relative_yieldtime', None)
-        if relative_yieldtime is not None:
-            remaining_yieldstep = relative_yieldtime - self.get_relative_time()
-        else:
-            remaining_yieldstep = yieldstep
-        if finaltime is not None:
-            remaining_finaltime = finaltime - self.get_time()
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep, remaining_finaltime)
-        else:
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep)
+        max_timestep = self._get_max_timestep_to_output_times(yieldstep, finaltime)
 
         # Execute full Euler step in C (includes MPI timestep reduction)
         self.timestep = evolve_one_euler_step_gpu(gpu_dom, max_timestep, 1)
@@ -4251,23 +4216,7 @@ class Domain(Generic_Domain):
                 stage_val = float(value[0])
             set_flather_value(gpu_dom, stage_val)
 
-        # Compute max allowed timestep (respecting yieldstep and finaltime)
-        # This mirrors the logic in update_timestep()
-        # Time remaining to the next yield boundary. Use the explicitly tracked
-        # relative_yieldtime (set and incremented by the evolve loop), NOT
-        # (relative_time % yieldstep): the modulo is floating-point fragile, e.g.
-        # 0.3 % 0.1 == 0.0999... gives remaining ~1e-17 -> max_timestep ~0 ->
-        # the step never advances and evolve() spins. Mirrors update_timestep().
-        relative_yieldtime = getattr(self, 'relative_yieldtime', None)
-        if relative_yieldtime is not None:
-            remaining_yieldstep = relative_yieldtime - self.get_relative_time()
-        else:
-            remaining_yieldstep = yieldstep
-        if finaltime is not None:
-            remaining_finaltime = finaltime - self.get_time()
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep, remaining_finaltime)
-        else:
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep)
+        max_timestep = self._get_max_timestep_to_output_times(yieldstep, finaltime)
 
         # Execute full RK2 step in C (includes MPI timestep reduction)
         # apply_forcing=1 enables Manning friction on GPU
@@ -4599,22 +4548,7 @@ class Domain(Generic_Domain):
                 stage_val = float(value[0])
             set_flather_value(gpu_dom, stage_val)
 
-        # Compute max allowed timestep (respecting yieldstep and finaltime)
-        # Time remaining to the next yield boundary. Use the explicitly tracked
-        # relative_yieldtime (set and incremented by the evolve loop), NOT
-        # (relative_time % yieldstep): the modulo is floating-point fragile, e.g.
-        # 0.3 % 0.1 == 0.0999... gives remaining ~1e-17 -> max_timestep ~0 ->
-        # the step never advances and evolve() spins. Mirrors update_timestep().
-        relative_yieldtime = getattr(self, 'relative_yieldtime', None)
-        if relative_yieldtime is not None:
-            remaining_yieldstep = relative_yieldtime - self.get_relative_time()
-        else:
-            remaining_yieldstep = yieldstep
-        if finaltime is not None:
-            remaining_finaltime = finaltime - self.get_time()
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep, remaining_finaltime)
-        else:
-            max_timestep = min(self.evolve_max_timestep, remaining_yieldstep)
+        max_timestep = self._get_max_timestep_to_output_times(yieldstep, finaltime)
 
         # Execute full RK3 step in C (includes MPI timestep reduction)
         # apply_forcing=1 enables Manning friction on GPU

--- a/anuga/shallow_water/tests/test_flow_algorithms.py
+++ b/anuga/shallow_water/tests/test_flow_algorithms.py
@@ -1,6 +1,7 @@
 """Tests for shallow_water_domain flow algorithm setters."""
 import unittest
 import anuga
+import numpy as num
 
 
 def _make_domain():
@@ -52,6 +53,33 @@ class Test_set_flow_algorithm(unittest.TestCase):
         domain = _make_domain()
         domain.set_flow_algorithm('DE1.7')
         self.assertEqual(domain.get_flow_algorithm(), 'DE1_7')
+
+
+class Test_timestep_output_limits(unittest.TestCase):
+
+    def test_update_timestep_clamps_stale_yield_deadline_to_zero(self):
+        domain = _make_domain()
+        domain.relative_time = 1000.0
+        domain.relative_yieldtime = num.nextafter(domain.relative_time, -num.inf)
+        domain.relative_finaltime = None
+        domain.flux_timestep = 10.0
+
+        domain.update_timestep(yieldstep=1.0, finaltime=None)
+
+        self.assertEqual(domain.timestep, 0.0)
+        self.assertEqual(domain._get_max_timestep_to_output_times(1.0, None), 0.0)
+
+    def test_update_timestep_clamps_stale_final_deadline_to_zero(self):
+        domain = _make_domain()
+        domain.relative_time = 1000.0
+        domain.relative_yieldtime = domain.relative_time + 10.0
+        domain.relative_finaltime = num.nextafter(domain.relative_time, -num.inf)
+        domain.flux_timestep = 10.0
+
+        domain.update_timestep(yieldstep=10.0, finaltime=domain.relative_finaltime)
+
+        self.assertEqual(domain.timestep, 0.0)
+        self.assertEqual(domain._get_max_timestep_to_output_times(10.0, domain.relative_finaltime), 0.0)
 
 
 class Test_DE0_defaults(unittest.TestCase):


### PR DESCRIPTION
## Summary
- centralise timestep clipping for yield/final output boundaries in Generic_Domain
- clamp stale output deadlines to zero instead of returning a negative timestep after floating-point drift
- reuse the same clipping helper in shallow-water GPU C-loop paths for DE0/DE1/DE2/DE_ader2
- add regression coverage for stale yield/final deadlines

## Why
Large or long-running simulations can accumulate tiny floating-point drift around yield/final boundaries. The previous duplicated clipping logic could turn an already-passed output deadline into a negative timestep, which is especially risky for the accelerated C-loop paths.

## Verification
- docker GPU container: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 on RTX 5060
- CPU_ONLY unified build: CC=gcc pip install --no-build-isolation -e . -Csetup-args=-Dgpu_offload=false
- GPU offload build: NVHPC 26.5 nvc, -Dgpu_offload=true -Dgpu_arch=cc120
- pytest anuga/shallow_water/tests/test_flow_algorithms.py -q
- pytest anuga/operators/tests/test_boundary_flux_integral_operator.py -q
- pytest anuga/shallow_water/tests/test_sw_domain_openmp.py -q
- pytest anuga/abstract_2d_finite_volumes/tests/test_generic_domain.py -q
- pytest anuga/shallow_water/tests/test_shallow_water_domain.py -q
- CPU_ONLY: pytest anuga/shallow_water/tests/test_DE_gpu_omp.py -q
- GPU offload: python scripts/anuga_run_isolated_tests.py anuga/shallow_water/tests/test_DE_gpu_omp.py --timeout 180 (65/65 pass)
