### PR TITLE
test(scenario): skip polygon-CSV rainfall test when geodata stack is absent

### DIFF
--- a/anuga/scenario/tests/test_setup_rainfall.py
+++ b/anuga/scenario/tests/test_setup_rainfall.py
@@ -25,6 +25,19 @@ except ImportError as _e:
     HAS_MODULE = False
     SKIP_REASON = str(_e)
 
+# Reading a polygon CSV pulls in the geodata interface (fiona/rasterio/shapely)
+# via spatialInputUtil. When that stack is not installed, tests that touch it
+# must skip rather than fail — matching every other geodata test in the suite
+# (see test_tif2.py, test_spatialInputUtil.py). Without this the polygon test
+# turns a missing optional dependency into a hard ImportError that reds CI.
+try:
+    import fiona  # noqa: F401
+    import rasterio  # noqa: F401
+    import shapely  # noqa: F401
+    HAS_GEODATA = True
+except ImportError:
+    HAS_GEODATA = False
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -152,6 +165,9 @@ class TestSetupRainfall(unittest.TestCase):
 
     # --- Polygon-restricted rainfall ---
 
+    @unittest.skipUnless(
+        HAS_GEODATA,
+        'requires geodata interface (fiona, rasterio, shapely)')
     def test_rain_with_polygon_csv(self):
         rain_csv = self._rain_path('rain.csv')
         poly_csv = self._rain_path('poly.csv')

--- a/anuga/utilities/spatialInputUtil.py
+++ b/anuga/utilities/spatialInputUtil.py
@@ -60,8 +60,22 @@ try:
     from shapely.geometry import (MultiPoint, LineString, Polygon, Point,
                                    mapping, shape)
     spatial_available = True
-except ImportError:
+    spatial_import_error = None
+except ImportError as _e:
+    # Geodata features degrade to a clear ImportError (see the stubs below),
+    # but do NOT swallow the cause silently: record it and warn. A broken
+    # geodata install (e.g. a fiona/rasterio/GDAL ABI mismatch, as seen in CI
+    # during a conda-forge GDAL migration) then shows the real error instead of
+    # only the generic "not installed" message.
     spatial_available = False
+    spatial_import_error = _e
+    import warnings as _warnings
+    _warnings.warn(
+        'anuga.utilities.spatialInputUtil: geodata interface unavailable -- '
+        '%s: %s. fiona/rasterio/shapely could not be imported; geodata '
+        'features (shapefiles, rasters, polygon CSVs) will raise ImportError.'
+        % (type(_e).__name__, _e),
+        stacklevel=2)
 
 
 #####################################
@@ -1232,6 +1246,9 @@ if spatial_available:
 else: # spatial_available == False
     msg='Failed to import fiona rasterio or shapely --'\
         + 'perhaps geodata python interface is not installed.'
+    if spatial_import_error is not None:
+        msg += ' (root cause: %s: %s)' % (
+            type(spatial_import_error).__name__, spatial_import_error)
 
 
 


### PR DESCRIPTION
## Problem

CI is red on `develop` (and therefore on every open PR, e.g. #150) because one test hard-fails when the geodata stack is missing:

```
TestSetupRainfall.test_rain_with_polygon_csv
E  ImportError: Failed to import fiona rasterio or shapely --perhaps geodata python interface is not installed.
   anuga/utilities/spatialInputUtil.py:1248
= 1 failed, 2618 passed, 265 skipped =
```

The `Example` jobs for Python **3.11–3.14 on Linux/macOS** currently run without an importable fiona/rasterio/shapely (note the **265 skipped**, ~20 "requires rasterio"). Nearly every geodata test guards itself and skips — but `test_rain_with_polygon_csv` (reads a polygon CSV → `spatialInputUtil`) has no guard, so it turns a missing optional dependency into a failed job. (3.10 and Windows have the geodata stack, so they pass.)

## Fix

Add the same skip guard the other geodata tests use (`test_tif2.py`, `test_spatialInputUtil.py`): detect fiona/rasterio/shapely at import and `@unittest.skipUnless(HAS_GEODATA, ...)` the polygon test. A missing optional dependency now **skips** rather than reds CI.

This is a base-branch fix, independent of any feature PR. With it on `develop`, rebasing an affected PR (e.g. #150) turns its CI green.

Note: the deeper question — *why* fiona/rasterio/shapely aren't importable for py3.11–3.14 on Linux/macOS despite being listed in `environments/environment_<ver>.yml` — is worth a separate look, since ~20 geodata tests are silently skipping there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)