### PR TITLE
fix(ci): pin libjxl so geodata loads; clean up NumPy 2.5 shape= deprecations

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -1808,14 +1808,14 @@ class Generic_Domain:
         n = int(len(fx) // 3)  # FIXME (Ole): No need to cast as int()
 
         triang = num.array(list(range(0, 3 * n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         plt.triplot(fx, fy, triang, 'g-')
 
         # Plot ghost triangles
         n = int(len(gx) // 3)  # FIXME (Ole): No need to cast as int()
         if n > 0:
             triang = num.array(list(range(0, 3 * n)))
-            triang.shape = (n, 3)
+            triang = triang.reshape(n, 3)
             plt.triplot(gx, gy, triang, 'b--')
 
         # Save triangulation to location pointed by filename

--- a/anuga/abstract_2d_finite_volumes/region.py
+++ b/anuga/abstract_2d_finite_volumes/region.py
@@ -194,14 +194,14 @@ class Region:
         # Plot mesh
         n = len(fx) // 3
         triang = num.array(list(range(0,3*n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         plt.triplot(fx, fy, triang, 'b-')
 
         # Plot region
         n = len(gx) // 3
         if n > 0:
             triang = num.array(list(range(0,3*n)))
-            triang.shape = (n, 3)
+            triang = triang.reshape(n, 3)
             plt.triplot(gx, gy, triang, 'r-')
 
         # Save triangulation to location pointed by filename

--- a/anuga/error_api.py
+++ b/anuga/error_api.py
@@ -104,7 +104,7 @@ def plotCentroidError(domain, control_data, rthr = 1E-7, athr = 1E-12,
         for i in range(0,size()):
             n = int(len(fx[i])//3)
             triang = num.array(list(range(0,3*n)))
-            triang.shape = (n, 3)
+            triang = triang.reshape(n, 3)
 
             if len(fx[i]) > 0:
                 plt.triplot(fx[i], fy[i], triang, 'g-')
@@ -114,7 +114,7 @@ def plotCentroidError(domain, control_data, rthr = 1E-7, athr = 1E-12,
             n = int(len(gx[i])//3)
 
             triang = num.array(list(range(0,3*n)))
-            triang.shape = (n, 3)
+            triang = triang.reshape(n, 3)
 
             if len(gx[i]) > 0:
                 plt.triplot(gx[i], gy[i], triang, 'b--')

--- a/anuga/operators/erosion_operators.py
+++ b/anuga/operators/erosion_operators.py
@@ -340,7 +340,7 @@ class Erosion_operator(Operator, Region):
         ## Plot full triangles
         n = int(len(fx1) / 3)
         triang = num.array(list(range(0, 3*n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         print(triang)
         plt.triplot(fx1, fy1, triang, 'go-')
 
@@ -364,7 +364,7 @@ class Erosion_operator(Operator, Region):
         ## Plot full triangles
         n = int(len(fx0) / 3)
         triang = num.array(list(range(0,3*n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         print(triang)
         plt.triplot(fx0, fy0, triang, 'bo-')
 
@@ -385,7 +385,7 @@ class Erosion_operator(Operator, Region):
         ## Plot full triangles
         n = int(len(fx0) / 3)
         triang = num.array(list(range(0,3*n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         print(triang)
         plt.triplot(fx0, fy0, triang, 'bo-')
 

--- a/anuga/parallel/parallel_shallow_water.py
+++ b/anuga/parallel/parallel_shallow_water.py
@@ -425,7 +425,7 @@ class Parallel_domain(Domain):
                 n = int(len(fx[i])//3)
 
                 triang = num.array(list(range(0,3*n)))
-                triang.shape = (n, 3)
+                triang = triang.reshape(n, 3)
                 plt.triplot(fx[i], fy[i], triang, 'g-', linewidth = 0.5)
 
             # Plot ghost triangles
@@ -433,7 +433,7 @@ class Parallel_domain(Domain):
                 n = int(len(gx[i])//3)
                 if n > 0:
                     triang = num.array(list(range(0,3*n)))
-                    triang.shape = (n, 3)
+                    triang = triang.reshape(n, 3)
                     plt.triplot(gx[i], gy[i], triang, 'b--', linewidth = 0.5)
 
             # Save triangulation to location pointed by filename
@@ -481,14 +481,14 @@ class Parallel_domain(Domain):
         # Plot full triangles
         n = int(len(fx)/3)
         triang = num.array(list(range(0,3*n)))
-        triang.shape = (n, 3)
+        triang = triang.reshape(n, 3)
         plt.triplot(fx, fy, triang, 'g-', linewidth = 0.5)
 
         # Plot ghost triangles
         n = int(len(gx)/3)
         if n > 0:
             triang = num.array(list(range(0,3*n)))
-            triang.shape = (n, 3)
+            triang = triang.reshape(n, 3)
             plt.triplot(gx, gy, triang, 'b--', linewidth = 0.5)
 
         # Save triangulation to location pointed by filename

--- a/anuga/utilities/plot_utils.py
+++ b/anuga/utilities/plot_utils.py
@@ -1221,7 +1221,7 @@ def Make_Geotif(swwFile=None,
             if(verbose):
                 print('Making raster ...')
 
-            gridq.shape = (len(desiredY),len(desiredX))
+            gridq = gridq.reshape(len(desiredY),len(desiredX))
             make_grid(numpy.flipud(gridq), desiredY, desiredX, output_name, EPSG_CODE=EPSG_CODE,
                       proj4string=proj4string, creation_options=creation_options)
 

--- a/environments/environment_3.10.yml
+++ b/environments/environment_3.10.yml
@@ -11,6 +11,10 @@ dependencies:
   - rasterio
   - fiona
   - shapely
+  # Pin libjxl to the soname libgdal-core is built against (0.11): a fresh
+  # conda-forge solve otherwise omits libjxl on Linux/macOS and GDAL fails
+  # at import with 'libjxl.so.0.11: cannot open shared object file'.
+  - libjxl <0.12
   - matplotlib
   - meshpy
   - meson

--- a/environments/environment_3.11.yml
+++ b/environments/environment_3.11.yml
@@ -11,6 +11,10 @@ dependencies:
   - rasterio
   - fiona
   - shapely
+  # Pin libjxl to the soname libgdal-core is built against (0.11): a fresh
+  # conda-forge solve otherwise omits libjxl on Linux/macOS and GDAL fails
+  # at import with 'libjxl.so.0.11: cannot open shared object file'.
+  - libjxl <0.12
   - matplotlib
   - meshpy
   - meson

--- a/environments/environment_3.12.yml
+++ b/environments/environment_3.12.yml
@@ -11,6 +11,10 @@ dependencies:
   - rasterio
   - fiona
   - shapely
+  # Pin libjxl to the soname libgdal-core is built against (0.11): a fresh
+  # conda-forge solve otherwise omits libjxl on Linux/macOS and GDAL fails
+  # at import with 'libjxl.so.0.11: cannot open shared object file'.
+  - libjxl <0.12
   - matplotlib
   - meshpy
   - meson

--- a/environments/environment_3.13.yml
+++ b/environments/environment_3.13.yml
@@ -12,6 +12,10 @@ dependencies:
   - rasterio
   - fiona
   - shapely
+  # Pin libjxl to the soname libgdal-core is built against (0.11): a fresh
+  # conda-forge solve otherwise omits libjxl on Linux/macOS and GDAL fails
+  # at import with 'libjxl.so.0.11: cannot open shared object file'.
+  - libjxl <0.12
   - matplotlib
   - meshpy
   - meson

--- a/environments/environment_3.14.yml
+++ b/environments/environment_3.14.yml
@@ -12,6 +12,10 @@ dependencies:
   - rasterio
   - fiona
   - shapely
+  # Pin libjxl to the soname libgdal-core is built against (0.11): a fresh
+  # conda-forge solve otherwise omits libjxl on Linux/macOS and GDAL fails
+  # at import with 'libjxl.so.0.11: cannot open shared object file'.
+  - libjxl <0.12
   - matplotlib
   - meshpy
   - meson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,5 +147,11 @@ filterwarnings = [
     "ignore:Barometric_pressure is deprecated:DeprecationWarning",
     "ignore:Culvert_flow_general.*is deprecated:DeprecationWarning",
     "ignore:anuga.culvert_flows is deprecated:DeprecationWarning",
+    # rasterio (<=1.5.0) still does `arr.shape = ...` internally, which NumPy 2.5
+    # deprecates; the warning is attributed to ANUGA's raster.read() call sites
+    # via stacklevel.  Not fixable in ANUGA — remove once rasterio ships a
+    # NumPy-2.5-compatible release.  (ANUGA's own .shape= assignments were
+    # converted to .reshape().)
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 


### PR DESCRIPTION
Two related fixes for the geodata CI breakage on `develop` (Linux/macOS, Python 3.11–3.14).

## 1. Pin `libjxl <0.12` so `libgdal-core` can load

CI's conda solve installs `libgdal-core 3.12.3` but **omits `libjxl`** (a weak dependency), so importing rasterio/fiona fails at runtime:

```
ImportError: libjxl.so.0.11: cannot open shared object file: No such file or directory
```

This disabled the entire geodata stack — ~20 rasterio/fiona/shapely tests silently skipped, and geodata-dependent code paths failed. (Windows and py3.10 were unaffected: `libjxl.so` is a Linux/macOS concern.)

Making `libjxl` an explicit dependency (`<0.12`, matching the `0.11` soname `libgdal-core 3.12.3` is built against) forces it into the solve. Verified with `conda create --dry-run`: resolves to `libjxl-0.11.2` + `libgdal-core-3.12.3-he63569f_3`. Added to `environment_3.10.yml`…`3.14.yml` (the files the Example workflow uses for every OS).

## 2. Clean up NumPy 2.5 `arr.shape = (...)` deprecations

With geodata restored, the un-skipped tests surfaced NumPy 2.5's deprecation of in-place `arr.shape = (...)`:

- Converted ANUGA's own `arr.shape = (...)` → `arr = arr.reshape(...)` (14 sites: `plot_utils`, `error_api`, `erosion_operators`, `generic_domain`, `parallel_shallow_water`, `region`). Left `sparse.py`'s `self.shape =` (a custom-class attribute, not a NumPy array) untouched.
- The remaining warnings come from **rasterio (≤1.5.0)** doing `arr.shape=` inside `raster.read()`, attributed to ANUGA call sites via stacklevel — not fixable here. Added a `filterwarnings` ignore for the message, removable once rasterio is NumPy-2.5 compatible.

## Verification

- `conda --dry-run` confirms the libjxl pin resolves to the compatible soname.
- Locally (with geodata present): ruff clean, targeted tests pass. The definitive check is this PR's CI on the affected Python/OS matrix — geodata tests should now **run** (not skip), with clean warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)