### PR TITLE
Fix API-reference docstrings (RST) and use active conda env in install_anuga_nvc.sh

### DIFF
--- a/anuga/abstract_2d_finite_volumes/quantity.py
+++ b/anuga/abstract_2d_finite_volumes/quantity.py
@@ -941,9 +941,8 @@ class Quantity:
 
 
 
-        Exactly one of the arguments
-          numeric, quantity, function, filename
-        must be present.
+        Exactly one of the arguments ``numeric``, ``quantity``, ``function`` or
+        ``filename`` must be present.
         """
 
         from anuga.geospatial_data.geospatial_data import Geospatial_data
@@ -1249,15 +1248,16 @@ class Quantity:
                                  indices=None,
                                  use_cache=False,
                                  verbose=False):
-        """Set values for quantity using specified function
+        """Set values for quantity using specified function.
 
-        Input
-        f: x, y -> z Function where x, y and z are arrays
-        location: Where values are to be stored.
-                  Permissible options are: vertices, centroid,
-                  unique vertices
-                  Default is "vertices"
-        indices:
+        Input::
+
+            f: x, y -> z Function where x, y and z are arrays
+            location: Where values are to be stored.
+                      Permissible options are: vertices, centroid,
+                      unique vertices
+                      Default is "vertices"
+            indices:
         """
 
         # FIXME: Should check that function returns something sensible and
@@ -2287,11 +2287,12 @@ class Quantity:
         vertices 2.  This corresponds to the node coordinates obtained from the
         method general_mesh.get_vertex_coordinates()
 
-        Calling convention
-        if xy is True:
-           X, Y, A, V = get_vertex_values
-        else:
-           A, V = get_vertex_values
+        Calling convention::
+
+            if xy is True:
+                X, Y, A, V = get_vertex_values()
+            else:
+                A, V = get_vertex_values()
         """
 
         if smooth is None:

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -5251,7 +5251,8 @@ class Domain(Generic_Domain):
         Returns
         -------
         dict
-            Keys:
+            Keys::
+
               time              relative simulation time
               current_timestep  self.timestep (last accepted global dt)
               cfl               self.CFL setting
@@ -5445,13 +5446,14 @@ class Domain(Generic_Domain):
     def compute_capabilities(self) -> dict:
         """Report which compute backends this build/run supports.
 
-        Returns a dict with:
-            'gpu_offload'     : bool — process can offload mode-2 to a GPU device
+        Returns a dict with::
+
+            'gpu_offload'     : bool - process can offload mode-2 to a GPU device
                                        (build supports it, device present, offload
-                                       not disabled); see :func:`set_gpu_offload`
-            'num_gpu_devices' : int  — number of offload devices visible
-            'mpi'             : bool — gpu_ext built with C MPI ('unified' parallel ok)
-            'modes'           : list — per-domain modes available ('unified' only
+                                       not disabled); see set_gpu_offload()
+            'num_gpu_devices' : int  - number of offload devices visible
+            'mpi'             : bool - gpu_ext built with C MPI ('unified' parallel ok)
+            'modes'           : list - per-domain modes available ('unified' only
                                        when the gpu_ext extension is importable)
         """
         try:
@@ -5468,16 +5470,6 @@ class Domain(Generic_Domain):
     def set_compute_mode(self, mode: str = 'unified', verbose: bool = False) -> None:
         """Select this domain's compute mode (per-domain).
 
-        Parameters
-        ----------
-        mode : {'legacy', 'unified'}
-            - ``'legacy'`` — mode 1: the ``sw_domain_openmp_ext`` solver with
-              serial-Python fractional-step operators.
-            - ``'unified'`` — mode 2: the unified ``sw_domain_gpu_ext`` C kernels
-              (solver and operators). Runs CPU-multicore by default; offloads to
-              a GPU only when GPU offload is enabled process-wide via
-              :func:`anuga.set_gpu_offload` on a GPU-capable build.
-
         This is a per-domain setting — different domains in one script may use
         different modes. Whether 'unified' uses a GPU is a separate, process-wide
         decision (see :func:`set_gpu_offload`), because OpenMP target offload is
@@ -5488,6 +5480,16 @@ class Domain(Generic_Domain):
         with a rank-0 warning. The active mode is recorded in
         ``self.compute_mode``; the original request in
         ``self.requested_compute_mode``.
+
+        Parameters
+        ----------
+        mode : {'legacy', 'unified'}
+            - ``'legacy'`` — mode 1: the ``sw_domain_openmp_ext`` solver with
+              serial-Python fractional-step operators.
+            - ``'unified'`` — mode 2: the unified ``sw_domain_gpu_ext`` C kernels
+              (solver and operators). Runs CPU-multicore by default; offloads to
+              a GPU only when GPU offload is enabled process-wide via
+              :func:`anuga.set_gpu_offload` on a GPU-capable build.
         """
         import warnings
 

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -81,27 +81,40 @@ echo "# nvc found: $NVC"
 echo " "
 
 # ------------------------------------------------------------------
-# Verify conda environment exists
+# Select the conda environment
+#   Prefer an already-activated environment (this is what the user is working
+#   in — likely with anuga already installed). Otherwise fall back to a
+#   miniforge install in $HOME with env anuga_env_$PY.
 # ------------------------------------------------------------------
-CONDA_BIN="$HOME/miniforge3/bin"
-if [ ! -f "$CONDA_BIN/conda" ]; then
-    echo "#=====================================================";
-    echo "# ERROR: miniforge3 not found at $HOME/miniforge3"
-    echo "# Run install_miniforge.sh first."
-    echo "#=====================================================";
-    exit 1
+if [ -n "$CONDA_PREFIX" ] && [ -n "$CONDA_DEFAULT_ENV" ] \
+        && [ "$CONDA_DEFAULT_ENV" != "base" ]; then
+    ENV_NAME="$CONDA_DEFAULT_ENV"
+    CONDA_RUN=""   # build/test run in the current, already-activated shell
+    echo "# Using the active conda environment: ${ENV_NAME}  (${CONDA_PREFIX})"
+else
+    CONDA_BIN="$HOME/miniforge3/bin"
+    if [ ! -f "$CONDA_BIN/conda" ]; then
+        echo "#=====================================================";
+        echo "# ERROR: no conda environment is active and miniforge3 was not"
+        echo "#        found at $HOME/miniforge3."
+        echo "#"
+        echo "# Either activate your anuga environment first"
+        echo "#   (e.g. conda activate anuga_env_${PY}), or run"
+        echo "#   install_miniforge.sh to create one."
+        echo "#=====================================================";
+        exit 1
+    fi
+    ENV_NAME="anuga_env_${PY}"
+    if ! "$CONDA_BIN/conda" env list | grep -q "${ENV_NAME}"; then
+        echo "#=====================================================";
+        echo "# ERROR: conda environment '${ENV_NAME}' not found."
+        echo "# Run install_miniforge.sh first (PY=${PY}), or activate your env."
+        echo "#=====================================================";
+        exit 1
+    fi
+    CONDA_RUN="$CONDA_BIN/conda run -n ${ENV_NAME}"
+    echo "# conda environment: ${ENV_NAME}  (via $HOME/miniforge3)"
 fi
-
-ENV_NAME="anuga_env_${PY}"
-if ! "$CONDA_BIN/conda" env list | grep -q "^${ENV_NAME}"; then
-    echo "#=====================================================";
-    echo "# ERROR: conda environment '${ENV_NAME}' not found."
-    echo "# Run install_miniforge.sh first (PY=${PY})."
-    echo "#=====================================================";
-    exit 1
-fi
-
-echo "# conda environment: ${ENV_NAME}"
 echo " "
 
 # ------------------------------------------------------------------
@@ -126,7 +139,7 @@ echo "# Removing any stale meson build directory (build/cp*) for a clean nvc con
 rm -rf "${ANUGA_CORE_PATH}"/build/cp*
 echo " "
 
-"$CONDA_BIN/conda" run -n "${ENV_NAME}" bash -c \
+$CONDA_RUN bash -c \
     "CC='$NVC' pip install --no-build-isolation -v -e . \
      -Csetup-args=-Dgpu_offload=true \
      -Csetup-args=-Dgpu_arch=${GPU_ARCH}"
@@ -145,7 +158,7 @@ echo "#   'pip install -e .' does not place on PATH)."
 echo "#============================================================"
 echo " "
 
-"$CONDA_BIN/conda" run -n "${ENV_NAME}" \
+$CONDA_RUN \
     python "${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"
 
 echo " "
@@ -154,7 +167,7 @@ echo "# Congratulations! ANUGA GPU build succeeded."
 echo "#"
 echo "# To use GPU mode activate the environment and set multiprocessor_mode=2:"
 echo "#"
-echo "#   source ~/miniforge3/bin/activate ${ENV_NAME}"
+echo "#   conda activate ${ENV_NAME}"
 echo "#   python -c \\"
 echo "#     \"import anuga; d = anuga.rectangular_cross_domain(100,100); \\"
 echo "#      d.set_boundary({b: anuga.Reflective_boundary(d) for b in d.get_boundary_tags()}); \\"


### PR DESCRIPTION
Two develop-side fixes that accompany the docs overhaul (#157):

- **Docstring RST fixes** (`Quantity.get_vertex_values` / `set_values_from_function` / `set_values`; `Domain.compute_capabilities` / `diagnose_timestep` / `set_compute_mode`): the docs now build with autodoc members + napoleon, so these method docstrings render on the API-reference pages. Reformat the informal `Input:` / `Keys:` / "Calling convention" blocks as valid RST. No behaviour change.
- **`tools/install_anuga_nvc.sh`**: build into an already-activated conda env if one is present (via `CONDA_PREFIX`/`CONDA_DEFAULT_ENV`), falling back to `$HOME/miniforge3` + `anuga_env_$PY` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)