### PR TITLE
docs: fix the two Sphinx build warnings (static path + Geo_reference.epsg duplicate)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,11 @@ autodoc_default_options = {
     'show-inheritance': True,
 }
 autosummary_generate = True
+
+# Render NumPy-style 'Attributes' sections as :ivar: fields rather than
+# .. attribute:: directives, so an attribute that is also a property (e.g.
+# Geo_reference.epsg) is not documented twice (avoids a duplicate-object warning).
+napoleon_use_ivar = True
 autosectionlabel_prefix_document = True
 
 # Suppress duplicate-label warnings from autosectionlabel on autodoc-generated
@@ -102,4 +107,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['../_static']
+html_static_path = ['_static']


### PR DESCRIPTION
Makes the docs build warning-free.

- **`html_static_path`** pointed at `../_static` (i.e. `docs/_static`), which doesn't exist → warning. Point it at the conventional `docs/source/_static` and add a `.gitkeep`.
- **`napoleon_use_ivar = True`**: `Geo_reference.epsg` is documented both as a class-docstring *Attribute* (which napoleon renders as a `.. attribute::` directive) and as the real `@property` (via autodoc members), producing a `duplicate object description of anuga.Geo_reference.epsg` warning. Rendering Attributes as `:ivar:` fields (no py-object) removes the collision without losing the docs.

`sphinx-build` now reports "build succeeded." with **zero warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)