### PR TITLE
docs: make the Read the Docs build clean (notebook lexer + operator docstrings)

### DIFF
--- a/anuga/structures/internal_boundary_operator.py
+++ b/anuga/structures/internal_boundary_operator.py
@@ -13,20 +13,23 @@ import scipy.optimize as sco
 
 
 class Internal_boundary_operator(anuga.Structure_operator):
-    """
-       The internal_boundary_function must accept 2 input arguments (hw, tw). It
-       returns Q:
-       - hw will always be the stage (or energy) at the enquiry_point[0]
-       - tw will always be the stage (or energy) at the enquiry_point[1]
-       - If flow is from hw to tw, then Q should be positive, otherwise Q
-         should be negative
+    """Internal boundary operator driven by a user-supplied discharge function.
 
-       def internal_boundary_function(hw, tw):
-           # Compute Q here from headwater hw and tailwater hw
-           return(Q)
+    The ``internal_boundary_function`` must accept 2 input arguments ``(hw, tw)``
+    and return ``Q``:
 
-       smoothing_timescale>0. can be used to make Q vary more slowly
+    - ``hw`` is the stage (or energy) at ``enquiry_point[0]``
+    - ``tw`` is the stage (or energy) at ``enquiry_point[1]``
+    - if flow is from ``hw`` to ``tw``, ``Q`` should be positive, otherwise
+      negative
 
+    ::
+
+        def internal_boundary_function(hw, tw):
+            # Compute Q here from headwater hw and tailwater tw
+            return Q
+
+    ``smoothing_timescale > 0`` can be used to make ``Q`` vary more slowly.
     """
 
 
@@ -219,20 +222,20 @@ class Internal_boundary_operator(anuga.Structure_operator):
 
 
     def discharge_routine_implicit(self):
-        """Uses semi-implicit discharge estimation:
-          Discharge = (1-theta)*Q(H0, T0) + theta*Q(H0 + delta_H, T0+delta_T))
-        where H0 = headwater stage, T0 = tailwater stage, delta_H = change in
-        headwater stage over a timestep, delta_T = change in tailwater stage over a
-        timestep, and Q is the discharge function, and theta is a constant in
-        [0,1] determining the degree of implicitness (currently hard-coded).
+        """Estimate discharge semi-implicitly.
 
-        Note this is effectively assuming:
-        1) Q is a function of stage, not energy (so we can relate mass change directly to delta_H, delta_T). We
-           could generalise it to the energy case ok.
-        2) The stage is computed on the exchange line (or the change in
-            stage at the enquiry point is effectively the same as that on the exchange
-            line)
+        ``Discharge = (1-theta)*Q(H0, T0) + theta*Q(H0 + delta_H, T0 + delta_T)``
+        where H0 = headwater stage, T0 = tailwater stage, delta_H / delta_T are the
+        changes in headwater / tailwater stage over a timestep, Q is the discharge
+        function, and theta is a constant in [0, 1] setting the degree of
+        implicitness (currently hard-coded).
 
+        This effectively assumes:
+
+        1. Q is a function of stage, not energy (so mass change relates directly to
+           delta_H, delta_T). This could be generalised to the energy case.
+        2. The stage is computed on the exchange line (or the change in stage at the
+           enquiry point is effectively the same as on the exchange line).
         """
 
         # Compute energy head or stage at inlets 0 and 1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,11 @@ autosummary_generate = True
 # .. attribute:: directives, so an attribute that is also a property (e.g.
 # Geo_reference.epsg) is not documented twice (avoids a duplicate-object warning).
 napoleon_use_ivar = True
+
+# Notebook code cells declare the 'ipython3' Pygments lexer, which is only
+# available when IPython is installed (it is not on the RTD docs env). Highlight
+# code cells with the always-available 'python3' lexer instead.
+nbsphinx_codecell_lexer = 'python3'
 autosectionlabel_prefix_document = True
 
 # Suppress duplicate-label warnings from autosectionlabel on autodoc-generated


### PR DESCRIPTION
The RTD `develop` build succeeded but reported **62 warnings** (hidden in local builds by `nbsphinx_execute=never` + a locally-installed IPython). This clears the two real causes:

- **56× `Pygments lexer name 'ipython3' is not known`** — notebook code cells request the `ipython3` lexer, which requires IPython (not in the RTD docs env). Set `nbsphinx_codecell_lexer = 'python3'`.
- **4× malformed RST** in `structures/internal_boundary_operator.py` (`Internal_boundary_operator` docstring + `discharge_routine_implicit`) — reformat the informal code/enumerated blocks as valid RST.

The remaining `Could not import mpi4py` line is a harmless anuga runtime message on the MPI-less RTD environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)