### PR TITLE
docs: install IPython for the notebook ipython3 Pygments lexer (clean RTD build)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,6 +23,7 @@ affine
 pytest
 matplotlib
 
+ipython   # provides the ipython3 Pygments lexer for notebook code cells
 nbsphinx
 sphinx_rtd_theme
 sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,10 +78,6 @@ autosummary_generate = True
 # Geo_reference.epsg) is not documented twice (avoids a duplicate-object warning).
 napoleon_use_ivar = True
 
-# Notebook code cells declare the 'ipython3' Pygments lexer, which is only
-# available when IPython is installed (it is not on the RTD docs env). Highlight
-# code cells with the always-available 'python3' lexer instead.
-nbsphinx_codecell_lexer = 'python3'
 autosectionlabel_prefix_document = True
 
 # Suppress duplicate-label warnings from autosectionlabel on autodoc-generated


### PR DESCRIPTION
Clears the remaining 56 RTD warnings.

`Pygments lexer name 'ipython3' is not known` — notebook code cells declare the `ipython3` lexer, provided by IPython, which isn't in the RTD docs env. `nbsphinx_codecell_lexer = 'python3'` (tried in #160) didn't help (the lexer is requested outside code cells too), so add `ipython` to `docs/requirements.txt` (registers the lexer) and drop the ineffective override.

The 4 operator-docstring warnings were fixed in #160; after this the only remaining log line is the harmless `Could not import mpi4py` on the MPI-less RTD env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)