### PR TITLE
docs: make Quick start a top-level section (fix PDF chapter nesting)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,31 +17,6 @@ ANUGA was created in a collaboration by Geoscience Australia
 and Mathematical Sciences Institute at the Australian National University. 
 It is now developed and maintained by a community of volunteers.
 
-Quick start
------------
-
-.. code-block:: bash
-
-   # 1. install (conda-forge, recommended)
-   conda create -n anuga -c conda-forge anuga
-   conda activate anuga
-
-.. code-block:: python
-
-   # 2. run a minimal model
-   import anuga
-   domain = anuga.rectangular_cross_domain(10, 5)
-   domain.set_quantity('elevation', lambda x, y: -x / 10)
-   domain.set_quantity('stage', 0.0)
-   domain.set_boundary({b: anuga.Reflective_boundary(domain)
-                        for b in domain.get_boundary_tags()})
-   for t in domain.evolve(yieldstep=1.0, finaltime=10.0):
-       print(domain.timestepping_statistics())
-
-Then view the ``.sww`` output (see :doc:`Visualisation <visualisation/index>`).
-The sections below build this up step by step; new to ANUGA? Start with
-:doc:`Examples <examples/index>`.
-
 .. note::
 
    The main documentation (**Contents**) covers the standard workflow most users
@@ -55,6 +30,7 @@ The sections below build this up step by step; new to ANUGA? Start with
    :maxdepth: 2
    :caption: Contents:
 
+   quickstart
    background
    installation/index
    examples/index

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,0 +1,28 @@
+.. _quickstart:
+
+.. currentmodule:: anuga
+
+Quick start
+===========
+
+.. code-block:: bash
+
+   # 1. install (conda-forge, recommended)
+   conda create -n anuga -c conda-forge anuga
+   conda activate anuga
+
+.. code-block:: python
+
+   # 2. run a minimal model
+   import anuga
+   domain = anuga.rectangular_cross_domain(10, 5)
+   domain.set_quantity('elevation', lambda x, y: -x / 10)
+   domain.set_quantity('stage', 0.0)
+   domain.set_boundary({b: anuga.Reflective_boundary(domain)
+                        for b in domain.get_boundary_tags()})
+   for t in domain.evolve(yieldstep=1.0, finaltime=10.0):
+       print(domain.timestepping_statistics())
+
+Then view the ``.sww`` output (see :doc:`Visualisation <visualisation/index>`).
+The sections below build this up step by step; new to ANUGA? Start with
+:doc:`Examples <examples/index>`.


### PR DESCRIPTION
In the PDF/LaTeX build every section was nested under a single **Quick start** chapter, because the `.. toctree::` directives sat inside the "Quick start" section on the landing page. Move Quick start to its own `quickstart.rst` (first in the Contents toctree); the master doc no longer has a titled section wrapping the toctree, so each section becomes its own chapter (Quick start included). HTML content unchanged; both builds are warning-free (HTML 0, LaTeX unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)