### PR TITLE
GPU mode-2: refresh time-varying boundaries per RK substep (fix ~4e-3 mode-1/mode-2 divergence)

### DIFF
--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -3126,6 +3126,38 @@ class Domain(Generic_Domain):
         pass
 
 
+    # Boundary types whose values are produced by a Python callback each step
+    # (Time/File/Field, transmissive-set-stage, and the wave/Flather boundaries).
+    # The single-call C RK loop (_evolve_one_rk*_step_c) sets these on the device
+    # once per step, so with a multi-substep method (RK2/RK3) they are NOT
+    # refreshed between substeps — unlike the legacy (mode-1) solver, which calls
+    # update_boundary() before every substep. For time-varying boundaries this
+    # gives an O(dt) boundary-forcing error (see issue #170). Until the
+    # C RK loop evaluates them per substep, domains using such boundaries are
+    # routed through the Python-orchestrated GPU loop, which refreshes them each
+    # substep and so bit-matches mode-1 (at negligible GPU cost, ~<=4%).
+    _PYTHON_EVALUATED_GPU_BOUNDARY_TYPES = frozenset((
+        'Time_boundary', 'File_boundary', 'Field_boundary',
+        'Transmissive_n_momentum_zero_t_momentum_set_stage_boundary',
+        'Absorbing_wave_boundary', 'Characteristic_wave_boundary',
+        'Flather_external_stage_zero_velocity_boundary',
+    ))
+
+    def _has_python_evaluated_gpu_boundaries(self):
+        """True if any boundary's value is set from a Python callback each step.
+
+        Single-substep methods (Euler, ADER2) are unaffected — they impose the
+        boundary once per step in both paths — so this is only consulted by the
+        multi-substep RK2/RK3 dispatch.
+        """
+        bmap = getattr(self, 'boundary_map', None) or {}
+        return any(
+            B is not None
+            and B.__class__.__name__ in self._PYTHON_EVALUATED_GPU_BOUNDARY_TYPES
+            for B in bmap.values()
+        )
+
+
     def evolve_one_euler_step(self, yieldstep, finaltime):
         """One Euler Time Step
         Q^{n+1} = E(h) Q^n
@@ -3167,9 +3199,12 @@ class Domain(Generic_Domain):
         vertices and edges
         """
 
-        # GPU mode: use C RK loop (faster) or Python-orchestrated GPU loop
+        # GPU mode: use C RK loop (faster) or Python-orchestrated GPU loop.
+        # Fall back to the Python-orchestrated loop when a Python-evaluated
+        # (possibly time-varying) boundary is present, so it is refreshed every
+        # substep and matches mode-1 (the C RK loop only sets it once per step).
         if self.multiprocessor_mode == MULTIPROCESSOR_GPU and self.gpu_interface is not None:
-            if self.use_c_rk_loop:
+            if self.use_c_rk_loop and not self._has_python_evaluated_gpu_boundaries():
                 self._evolve_one_rk2_step_c(yieldstep, finaltime)
             else:
                 self._evolve_one_rk2_step_gpu(yieldstep, finaltime)
@@ -4578,9 +4613,12 @@ class Domain(Generic_Domain):
         vertices and edges
         """
 
-        # GPU mode: use C RK loop (faster) or Python-orchestrated GPU loop
+        # GPU mode: use C RK loop (faster) or Python-orchestrated GPU loop.
+        # Fall back to the Python-orchestrated loop when a Python-evaluated
+        # (possibly time-varying) boundary is present, so it is refreshed every
+        # substep and matches mode-1 (the C RK loop only sets it once per step).
         if self.multiprocessor_mode == MULTIPROCESSOR_GPU and self.gpu_interface is not None:
-            if self.use_c_rk_loop:
+            if self.use_c_rk_loop and not self._has_python_evaluated_gpu_boundaries():
                 self._evolve_one_rk3_step_c(yieldstep, finaltime)
             else:
                 self._evolve_one_rk3_step_gpu(yieldstep, finaltime)

--- a/anuga/shallow_water/tests/test_DE_gpu_omp.py
+++ b/anuga/shallow_water/tests/test_DE_gpu_omp.py
@@ -2131,6 +2131,85 @@ class Test_TimestepTimeAdvance(unittest.TestCase):
         self._assert_modes_agree('DE_ader2')
 
 
+@pytest.mark.skipif(not gpu_available(), reason=_gpu_skip_reason())
+class Test_GPU_TimeBoundarySubstep(unittest.TestCase):
+    """Mode-2 with a time-varying boundary must match mode-1 for multi-substep
+    algorithms (DE1/DE2).
+
+    The single-call C RK loop (_evolve_one_rk*_step_c) sets Python-evaluated
+    boundaries (Time/File/wave/Flather) on the device once per step, so it would
+    reuse that step-start value across every RK substep — whereas mode-1 calls
+    update_boundary() before each substep. For a time-varying boundary that is an
+    O(dt) boundary-forcing error on RK2/RK3 (~4e-3 m in a rising-tide test).
+
+    Fix (option B): a domain with any Python-evaluated boundary is routed to the
+    Python-orchestrated GPU loop, which refreshes the boundary per substep and so
+    bit-matches mode-1. This test guards that routing; reverting it makes DE1/DE2
+    disagree by O(1e-3).
+    """
+
+    def _make_domain(self, name, algorithm):
+        import math
+        d = rectangular_cross_domain(12, 8, len1=150., len2=100.)
+        d.set_flow_algorithm(algorithm)
+        d.set_low_froude(0)
+        d.set_name(name)
+        d.set_datadir(tempfile.mkdtemp())
+        d.store = False
+        d.set_quantity('elevation', lambda x, y: (x / 150.0) * 2.0 - 1.0)
+        d.set_quantity('friction', 0.03)
+        d.set_quantity('stage', 1.5)                       # fully wet (isolates the boundary)
+
+        def tide(t):
+            return [0.4 * math.sin(0.3 * t), 0.0, 0.0]     # time-varying stage
+
+        Br = Reflective_boundary(d)
+        d.set_boundary({'left': anuga.Time_boundary(domain=d, function=tide),
+                        'right': Br, 'top': Br, 'bottom': Br})
+        return d
+
+    def _run(self, algorithm, mode):
+        d = self._make_domain(f'{algorithm}_m{mode}', algorithm)
+        d.set_multiprocessor_mode(mode)
+        for t in d.evolve(yieldstep=1.0, finaltime=6.0):
+            pass
+        return d.quantities['stage'].centroid_values.copy()
+
+    def _assert_agree(self, algorithm):
+        s1 = self._run(algorithm, 1)
+        s2 = self._run(algorithm, 2)
+        np.testing.assert_allclose(
+            s2, s1, atol=1e-6, rtol=0.0,
+            err_msg=f'{algorithm}: mode-2 Time_boundary diverges from mode-1 '
+                    f'(max diff {np.abs(s2 - s1).max():.3e})')
+
+    def test_DE1_rk2_time_boundary(self):
+        self._assert_agree('DE1')
+
+    def test_DE2_rk3_time_boundary(self):
+        self._assert_agree('DE2')
+
+    def test_routing_time_boundary_off_c_loop(self):
+        """A Time_boundary must be flagged so the multi-substep dispatch avoids
+        the single-call C RK loop."""
+        d = self._make_domain('route_time', 'DE1')
+        d.set_multiprocessor_mode(2)
+        self.assertTrue(d._has_python_evaluated_gpu_boundaries())
+
+    def test_routing_reflective_keeps_c_loop(self):
+        """Reflective-only domains keep the fast C RK loop."""
+        d = rectangular_cross_domain(8, 8, len1=100., len2=100.)
+        d.set_flow_algorithm('DE1')
+        d.set_name('route_refl')
+        d.set_datadir(tempfile.mkdtemp())
+        d.store = False
+        d.set_quantity('elevation', 0.0)
+        d.set_quantity('stage', 1.0)
+        d.set_boundary({b: Reflective_boundary(d) for b in d.get_boundary_tags()})
+        d.set_multiprocessor_mode(2)
+        self.assertFalse(d._has_python_evaluated_gpu_boundaries())
+
+
 class Test_GPU_NonGPUBoundaryFallback(unittest.TestCase):
     """Mode 2 must fall back to host boundary evaluation for boundary types the
     C loop cannot evaluate on the device — for EVERY flow algorithm, including


### PR DESCRIPTION
Fixes a mode‑1 vs mode‑2 divergence with **time‑varying boundaries** on multi‑substep algorithms.

**Cause:** the single‑call C RK loop (`_evolve_one_rk*_step_c`) sets Python‑evaluated boundaries (`Time_boundary`, `File_/Field_boundary`, wave/Flather, transmissive‑set‑stage) on the device **once per step**, reusing that value for every RK substep; mode‑1 calls `update_boundary()` before **each** substep. For DE1/DE2 with a time‑varying boundary that's an O(dt) forcing error (~4e‑3 m in a rising‑tide test). DE0/DE_ader2 (single substep) and reflective/steady boundaries are already exact.

**Fix (option B):** route domains with any Python‑evaluated boundary to the already‑correct Python‑orchestrated GPU loop (refreshes the boundary per substep → bit‑matches mode‑1). Reflective/steady keep the fast C loop. Benchmarked GPU cost ≤ ~4% (within noise, 14k–640k triangles), and only for the affected case.

**Tests:** new `Test_GPU_TimeBoundarySubstep` (DE1/DE2 mode‑1==mode‑2 to atol 1e‑6, plus routing checks). Full `test_DE_gpu_omp.py` green (69/69) via the isolated runner.

The proper per‑substep fix inside the C RK loop is filed as #170 (option A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)