### PR TITLE
Fix rk3 (DE2) fractional-step operator timing in both modes (evaluate forcing at t)

### DIFF
--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -4481,7 +4481,10 @@ class Domain(Generic_Domain):
         # Final: Q^{n+1} = (2*Q^(3) + Q^n) / 3
         saxpy3_conserved_quantities_gpu(gpu_dom, 2.0, 1.0, 3.0)
 
-        self.set_relative_time(initial_relative_time + self.timestep)
+        # Restore the pre-step time so fractional-step operators evaluate forcing
+        # at t (not t+dt); see evolve_one_rk3_step. The evolve loop advances
+        # relative_time to t+dt after apply_fractional_steps().
+        self.set_relative_time(initial_relative_time)
 
         # Post-step ghost exchange — update_ghosts() is a no-op in GPU mode
         if self.ghost_layer_width < 4:
@@ -4604,8 +4607,9 @@ class Domain(Generic_Domain):
         # apply_forcing=1 enables Manning friction on GPU
         self.timestep = evolve_one_rk3_step_gpu(gpu_dom, max_timestep, 1)
 
-        # Update internal time tracking
-        self.set_relative_time(self.get_relative_time() + self.timestep)
+        # Do NOT advance relative_time here — the evolve loop advances it to t+dt
+        # after apply_fractional_steps(), so fractional-step operators evaluate
+        # forcing at the pre-step time t (matching the rk2 C loop, DE0, DE_ader2).
 
         # Record the CFL-constrained step (pre yield/final cap), matching legacy
         # update_timestep(), rather than the yield-limited step actually taken.
@@ -4749,8 +4753,13 @@ class Domain(Generic_Domain):
         # So do this instead!
         self.saxpy_conserved_quantities(2.0, 1.0, 3.0)
 
-        # Set new time
-        self.set_relative_time(initial_relative_time + self.timestep)
+        # Restore the pre-step time so fractional-step operators (applied by the
+        # evolve loop before it advances relative_time to t+dt) evaluate forcing
+        # at t, not t+dt — consistent with rk2 (DE1), DE0 and DE_ader2. The
+        # mid-step set_relative_time() calls above advance time for the substep
+        # boundary evaluations; the evolve loop sets the final t+dt after
+        # apply_fractional_steps().
+        self.set_relative_time(initial_relative_time)
 
 
     def backup_conserved_quantities(self):

--- a/anuga/shallow_water/tests/test_operator_timing.py
+++ b/anuga/shallow_water/tests/test_operator_timing.py
@@ -7,12 +7,13 @@ extension required) — unlike the mode-1-vs-mode-2 checks in
 
 Background: fractional-step operators are applied by the evolve loop *before* it
 advances ``relative_time`` from t to t+dt, so they should evaluate forcing at the
-pre-step time ``t``. A latent bug left the mode-1 rk2 (DE1) body with
-``relative_time`` advanced to t+dt, so DE1's operators evaluated forcing "one step
-too far" (t+dt) — unlike DE0/DE_ader2 (and the mode-2 GPU loops), and diverging
-from mode-2 by ~4e-4 for a time-varying rate. No prior test used a time-varying
-operator, so the bug was invisible. Reverting the mode-1 rk2 fix makes
-``test_rk2_operator_evaluated_at_pre_step_time`` fail.
+pre-step time ``t``. Latent bugs left the rk2 (DE1) and rk3 (DE2) paths with
+``relative_time`` advanced to t+dt, so their operators evaluated forcing "one step
+too far" (t+dt) — unlike DE0/DE_ader2. For DE1 only mode-1 was affected (it
+diverged from mode-2 by ~4e-4); for DE2 *both* modes advanced (mode-1 body,
+mode-2 C and GPU loops), so it stayed self-consistent and the cross-mode check
+never caught it. No prior test used a time-varying operator. Reverting either fix
+makes the corresponding test below fail.
 """
 
 import tempfile
@@ -56,6 +57,20 @@ def test_rk2_operator_evaluated_at_pre_step_time():
     mx, ft = _max_operator_eval_time('DE1')
     assert mx < ft, (
         'DE1 evaluated a time-varying operator at t=%r (>= finaltime=%r); '
+        'expected the pre-step time t (< finaltime).' % (mx, ft))
+
+
+def test_rk3_operator_evaluated_at_pre_step_time():
+    """DE2 (rk3) must evaluate a time-varying operator at the pre-step time t.
+
+    All three rk3 paths (mode-1 body, mode-2 C loop, mode-2 GPU loop) previously
+    left relative_time advanced to t+dt, so operators evaluated forcing one step
+    too far in *both* modes (self-consistent, so uncaught). Reverting the rk3
+    restore-time fix makes this fail (max eval lands on finaltime).
+    """
+    mx, ft = _max_operator_eval_time('DE2')
+    assert mx < ft, (
+        'DE2 evaluated a time-varying operator at t=%r (>= finaltime=%r); '
         'expected the pre-step time t (< finaltime).' % (mx, ft))
 
 


### PR DESCRIPTION
Follow-up to #174 (rk2/DE1). The **rk3 (DE2)** paths left `relative_time` advanced to t+dt at step end, so fractional-step operators evaluated forcing "one step too far" — but in **both** compute modes (mode-1 body, mode-2 C loop, mode-2 GPU loop), so DE2 stayed self-consistent (mode-1 == mode-2) and the cross-mode check never caught it.

**Fix:** restore the pre-step time at the end of the mode-1 rk3 body and mode-2 GPU rk3 loop, and drop the advance in the mode-2 C rk3 loop (matching the rk2 C loop). DE2 now evaluates operators at t in both modes, consistent with DE0/DE1/DE_ader2.

**Tests:** `test_rk3_operator_evaluated_at_pre_step_time` (CPU, mode-1) added; `Test_GPU_OperatorTimeAlignment` already covers DE2 mode-1==mode-2. Full CPU suite **2610 pass**, GPU file **73/73** — no regressions (nothing depended on the post-step timing).

Fixes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)