### PR TITLE
docs(session-guide,progress): record the operator-timing fixes (DE1/DE2)

### DIFF
--- a/claude/PROGRESS.md
+++ b/claude/PROGRESS.md
@@ -27,7 +27,8 @@ Future work recommendations: `claude/FUTURE_WORK.md`
 | Mode-2 test triage + isolated runner tooling | 4 | 4 | 0 |
 | Documentation overhaul (session 47) | 15 | 15 | 0 |
 | GPU mode-2 Time_boundary fix | 2 | 1 | 1 |
-| **Total** | **226** | **217** | **9** |
+| Operator-timing fixes (DE1 rk2, DE2 rk3) | 2 | 2 | 0 |
+| **Total** | **228** | **219** | **9** |
 
 ---
 

--- a/claude/PROGRESS_ARCHIVE.md
+++ b/claude/PROGRESS_ARCHIVE.md
@@ -388,3 +388,35 @@ Merged to `anuga-community/develop` as PRs **#157–#164** (admin-merged by numb
   (pure-Python change).
 - [ ] **Option A** — proper per-substep evaluation inside the C RK loop: tracked
   as **issue #170** (see Remaining / Deferred in `PROGRESS.md`).
+
+## Fractional-step operator evaluation timing ✅ Complete (session 47, 2026-07-08)
+
+Fractional-step operators are applied by the evolve loop *before* it advances
+`relative_time` from t to t+dt, so they should evaluate forcing at the pre-step
+time **t** (the mode-2 code documents that t+dt is "one step too far"). First
+confirmed operators/structures are applied **every inner timestep** in both modes
+(13/13 and 46/46 evals ≫ yieldsteps — not a yieldstep-only issue). Then found and
+fixed an operator-*time* bug in the RK schemes:
+
+- [x] **OT.1 — DE1 (rk2), PR #174.** The mode-1 rk2 body advanced `relative_time`
+  mid-step (for the substep-2 boundary) and never restored it, so its operators
+  evaluated forcing at **t+dt**, diverging from mode-2 (which uses t) by ~4e-4 for
+  a time-varying `Rate_operator`/`Inlet`. Restore the pre-step time at the end of
+  the mode-1 rk2 body → DE1 matches DE0/DE2/DE_ader2 and mode-2 (0.0). Added
+  `Test_GPU_OperatorTimeAlignment` (cross-mode, all algorithms).
+- [x] **OT.2 — CPU regression test, PR #175.** The cross-mode guard is GPU-only
+  (skips on standard builds), so added `test_operator_timing.py` — a mode-1-only
+  test that runs anywhere: a time-varying operator must be evaluated at t
+  (last inner step's eval < finaltime). Reverting a fix fails it. Registered in
+  `tests/meson.build`.
+- [x] **OT.3 — DE2 (rk3), PR #177 (closes #176).** Subtler than DE1: **all three**
+  rk3 paths left time advanced (mode-1 body, mode-2 C loop, mode-2 GPU loop), so
+  DE2 was post-step in *both* modes — self-consistent (mode-1 == mode-2), so the
+  cross-mode check missed it. Restore the pre-step time in the mode-1 body and
+  mode-2 GPU loop; drop the advance in the mode-2 C loop (matching the rk2 C loop).
+  DE2 now evaluates operators at t in both modes. Added
+  `test_rk3_operator_evaluated_at_pre_step_time`.
+
+Result: all four flow algorithms evaluate fractional-step operators at the
+pre-step time t, mode-1 == mode-2. No prior test used a time-varying operator, so
+the bug was invisible (coverage gap now closed). CPU suite 2610 pass, GPU 73/73.

--- a/claude/SESSION_GUIDE.md
+++ b/claude/SESSION_GUIDE.md
@@ -417,7 +417,23 @@ cross-linking, meta-pages, and a warning-free Read the Docs build.
   substep → bit-matches mode-1; benchmarked GPU cost ≤~4%, within noise). Added
   `Test_GPU_TimeBoundarySubstep`; 69/69 GPU tests green. Filed **issue #170** for
   the proper per-substep C-loop fix (option A).
-- All merged to `anuga-community/develop` (PRs **#157–#171**, admin-merged by
+- **Fractional-step operator/structure timing (PRs #174, #175, #177; issue #176).**
+  Checked operators/structures for the yieldstep-vs-inner-step concern — they are
+  fine (applied **every inner timestep** in both modes: 13/13 and 46/46 evals ≫
+  yieldsteps). But found a related **operator-evaluation-time** bug: fractional-step
+  operators (applied by the evolve loop *before* it advances time to t+dt) should
+  see the pre-step time **t**, and DE0/DE_ader2 do — but **DE1 (rk2)** and **DE2
+  (rk3)** left `relative_time` advanced, so operators evaluated forcing at t+dt
+  ("one step too far"), ~4e-4 for a time-varying rate. For **DE1** only mode-1 was
+  affected (diverged from mode-2), fixed by restoring the pre-step time in the
+  mode-1 rk2 body (**PR #174**). For **DE2** *both* modes advanced (mode-1 body +
+  mode-2 C **and** GPU loops), so it stayed self-consistent and the cross-mode
+  check missed it — fixed all three rk3 paths (**PR #177**, closes #176). Now all
+  four algorithms evaluate operators at t in both modes. Guards: `test_operator_timing.py`
+  (CPU, mode-1 — runs on any build) + `Test_GPU_OperatorTimeAlignment` (cross-mode);
+  the GPU-only guard was split out to a CPU test in **PR #175**. No prior test used
+  a time-varying operator (coverage gap). CPU suite 2610 pass, GPU 73/73.
+- All merged to `anuga-community/develop` (PRs **#157–#177**, admin-merged by
   number, except the one-off direct cherry-pick `014451da`); RTD `develop` HTML
   **and PDF** confirmed clean.
 


### PR DESCRIPTION
Records the fractional-step operator evaluation-timing work in SESSION_GUIDE (Session 47) and PROGRESS/PROGRESS_ARCHIVE: operators/structures are per-inner-step; the DE1 (rk2) and DE2 (rk3) pre-step-time fixes (PRs #174/#175/#177, issue #176); all algorithms now evaluate operators at t in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)