### PR TITLE
Legacy structure-operator fixes for 3.3.8 (parallel logging + weir gravity)

### DIFF
--- a/anuga/parallel/parallel_operator_factory.py
+++ b/anuga/parallel/parallel_operator_factory.py
@@ -277,6 +277,11 @@ def Boyd_box_operator(domain,
                                          inlet_procs = inlet_procs,
                                          enquiry_proc = enquiry_proc)
     else:
+        # This proc owns no part of the structure, so the constructor above is
+        # not called here. Still advance the shared counter so every rank stays
+        # in lockstep with the participating procs (which advance it in the
+        # operator constructor) — the factory is entered collectively.
+        Parallel_Structure_operator.counter += 1
         return None
 
 
@@ -441,6 +446,11 @@ def Boyd_pipe_operator(domain,
                                          inlet_procs = inlet_procs,
                                          enquiry_proc = enquiry_proc)
     else:
+        # This proc owns no part of the structure, so the constructor above is
+        # not called here. Still advance the shared counter so every rank stays
+        # in lockstep with the participating procs (which advance it in the
+        # operator constructor) — the factory is entered collectively.
+        Parallel_Structure_operator.counter += 1
         return None
 
 
@@ -626,6 +636,11 @@ def Weir_orifice_trapezoid_operator(domain,
                                          inlet_procs = inlet_procs,
                                          enquiry_proc = enquiry_proc)
     else:
+        # This proc owns no part of the structure, so the constructor above is
+        # not called here. Still advance the shared counter so every rank stays
+        # in lockstep with the participating procs (which advance it in the
+        # operator constructor) — the factory is entered collectively.
+        Parallel_Structure_operator.counter += 1
         return None
 
 
@@ -794,6 +809,11 @@ def Internal_boundary_operator(domain,
                                          inlet_procs = inlet_procs,
                                          enquiry_proc = enquiry_proc)
     else:
+        # This proc owns no part of the structure, so the constructor above is
+        # not called here. Still advance the shared counter so every rank stays
+        # in lockstep with the participating procs (which advance it in the
+        # operator constructor) — the factory is entered collectively.
+        Parallel_Structure_operator.counter += 1
         return None
 
 

--- a/anuga/parallel/parallel_structure_operator.py
+++ b/anuga/parallel/parallel_structure_operator.py
@@ -140,20 +140,24 @@ class Parallel_Structure_operator(anuga.Operator):
             self.description = description
         
         if label is None:
-            self.label = "structure_%g" % Parallel_Structure_operator.counter + "_P" + str(self.myid)
+            self.label = "structure_%g" % Parallel_Structure_operator.counter
         else:
-            self.label = label + '_%g' % Parallel_Structure_operator.counter + "_P" + str(self.myid)
+            self.label = label + '_%g' % Parallel_Structure_operator.counter
 
         if structure_type is None:
             self.structure_type = 'generic structure'
         else:
             self.structure_type = structure_type
-            
-        self.verbose = verbose        
-        
-        # Keep count of structures
-        if self.myid == master_proc:
-            Parallel_Structure_operator.counter += 1
+
+        self.verbose = verbose
+
+        # Keep count of structures. Advance on every participating proc (not
+        # just the master) so this rank's counter stays in lockstep with the
+        # ranks that own no part of the structure — those advance it in the
+        # factory's ``return None`` branch. Because the factory is entered
+        # collectively by all ranks in the same order, every operator ends up
+        # with a unique, rank-consistent number matching the sequential label.
+        Parallel_Structure_operator.counter += 1
 
         # Slots for recording current statistics
         self.accumulated_flow = 0.0
@@ -677,7 +681,7 @@ class Parallel_Structure_operator(anuga.Operator):
         if self.logging and self.myid == self.master_proc:
             self.log_filename = self.domain.get_datadir() + '/' + self.label + '.log'
             log_to_file(self.log_filename, stats, mode='w')
-            log_to_file(self.log_filename, 'time,discharge_instantaneous,discharge_abs_timemean,velocity_instantaneous,driving_energy_instantaneous,delta_total_energy_instantaneous')
+            log_to_file(self.log_filename, 'time, discharge_instantaneous, discharge_abs_timemean, velocity, accumulated_flow, driving_energy_instantaneous, delta_total_energy_instantaneous')
 
             #log_to_file(self.log_filename, self.culvert_type)
 
@@ -703,6 +707,7 @@ class Parallel_Structure_operator(anuga.Operator):
         message += '%.5f, ' % self.discharge
         message += '%.5f, ' % self.discharge_abs_timemean
         message += '%.5f, ' % self.velocity
+        message += '%.5f, ' % self.accumulated_flow
         message += '%.5f, ' % self.driving_energy
         message += '%.5f' % self.delta_total_energy
 

--- a/anuga/parallel/parallel_weir_orifice_trapezoid_operator.py
+++ b/anuga/parallel/parallel_weir_orifice_trapezoid_operator.py
@@ -313,7 +313,8 @@ class Parallel_Weir_orifice_trapezoid_operator(Parallel_Structure_operator):
                                                 delta_total_energy  =self.delta_total_energy,
                                                 outlet_enquiry_depth=outflow_enq_depth,
                                                 sum_loss            =self.sum_loss,
-                                                manning             =self.manning)
+                                                manning             =self.manning,
+                                                g                   =self.domain.g)
 
                 ################################################
                 # Smooth discharge. This can reduce oscillations

--- a/anuga/structures/weir_orifice_trapezoid_operator.py
+++ b/anuga/structures/weir_orifice_trapezoid_operator.py
@@ -314,7 +314,8 @@ class Weir_orifice_trapezoid_operator(anuga.Structure_operator):
                                                 delta_total_energy  =self.delta_total_energy,
                                                 outlet_enquiry_depth=self.outflow.get_enquiry_depth(),
                                                 sum_loss            =self.sum_loss,
-                                                manning             =self.manning)
+                                                manning             =self.manning,
+                                                g                   =self.domain.g)
 
             #
             # Update 02/07/2014 -- using time-smoothed discharge
@@ -370,13 +371,20 @@ def weir_orifice_trapezoid_function(
                         delta_total_energy,
                         outlet_enquiry_depth,
                         sum_loss,
-                        manning):
+                        manning,
+                        g=None):
 
     # intially assume the culvert flow is controlled by the inlet
     # check unsubmerged and submerged condition and use Min Q
     # but ensure the correct flow area and wetted perimeter are used
 
     local_debug = False
+
+    # Gravity: use the domain's g when the caller supplies it (so non-Earth g
+    # works, and the mode-2 C kernel — which uses domain.g — matches bit-for-bit).
+    # Fall back to the global config g for direct callers that don't pass one.
+    if g is None:
+        g = anuga.g
 
     bf = 1 - blockage
 
@@ -387,7 +395,7 @@ def weir_orifice_trapezoid_function(
         return Q, barrel_velocity, outlet_culvert_depth, flow_area, case
     else:
         Q_inlet_unsubmerged = 1.7*bf*barrels*((2*width+depth*(z1+z2))/2)*driving_energy**1.50 # Flow based on Inlet Ctrl Inlet Unsubmerged (weir flow equation)
-        Q_inlet_submerged = 0.8*bf*barrels*anuga.g**0.5*(0.5*depth*(2*width+depth*(z1+z2)))*driving_energy**0.5  # Flow based on Inlet Ctrl Inlet Submerged (orifice equation)
+        Q_inlet_submerged = 0.8*bf*barrels*g**0.5*(0.5*depth*(2*width+depth*(z1+z2)))*driving_energy**0.5  # Flow based on Inlet Ctrl Inlet Submerged (orifice equation)
 
 
 
@@ -403,7 +411,7 @@ def weir_orifice_trapezoid_function(
             Pc=bf*barrels*width+((z1**2+1)**0.5+(z2**2+1)**0.5)*dcrit
             Ac=0.5*dcrit*(bf*barrels*width+Tc)
             Rc=Ac/Pc
-            fc=Ac**1.5*Tc**-0.5-Q/(9.81**0.5)
+            fc=Ac**1.5*Tc**-0.5-Q/(g**0.5)
             ffc=Ac**1.5*-0.5*Tc**-1.5*(z1+z2)+Tc**-0.5*1.5*Ac**0.5*Tc
             dyc=-fc/ffc
             dcrit=dcrit+dyc
@@ -429,7 +437,7 @@ def weir_orifice_trapezoid_function(
             Pc=bf*barrels*width+((z1**2+1)**0.5+(z2**2+1)**0.5)*dcrit
             Ac=0.5*dcrit*(bf*barrels*width+Tc)
             Rc=Ac/Pc
-            fc=Ac**1.5*Tc**-0.5-Q/(9.81**0.5)
+            fc=Ac**1.5*Tc**-0.5-Q/(g**0.5)
             ffc=Ac**1.5*-0.5*Tc**-1.5*(z1+z2)+Tc**-0.5*1.5*Ac**0.5*Tc
             dyc=-fc/ffc
             dcrit=dcrit+dyc
@@ -453,7 +461,7 @@ def weir_orifice_trapezoid_function(
         Pc=bf*barrels*width+((z1**2+1)**0.5+(z2**2+1)**0.5)*dcrit
         Ac=0.5*dcrit*(bf*barrels*width+Tc)
         Rc=Ac/Pc
-        fc=Ac**1.5*Tc**-0.5-Q/(9.81**0.5)
+        fc=Ac**1.5*Tc**-0.5-Q/(g**0.5)
         ffc=Ac**1.5*-0.5*Tc**-1.5*(z1+z2)+Tc**-0.5*1.5*Ac**0.5*Tc
         dyc=-fc/ffc
         dcrit=dcrit+dyc
@@ -473,7 +481,7 @@ def weir_orifice_trapezoid_function(
     # Initial Estimate of Flow for Outlet Control using energy slope
     #( may need to include Culvert Bed Slope Comparison)
     hyd_rad = flow_area/perimeter
-    culvert_velocity = math.sqrt(delta_total_energy/((sum_loss/2/anuga.g) \
+    culvert_velocity = math.sqrt(delta_total_energy/((sum_loss/2/g) \
                                                           +(manning**2*length)/hyd_rad**1.33333))
     Q_outlet_tailwater = flow_area * culvert_velocity
 
@@ -498,7 +506,7 @@ def weir_orifice_trapezoid_function(
                 Pc=bf*barrels*width+((z1**2+1)**0.5+(z2**2+1)**0.5)*dcrit
                 Ac=0.5*dcrit*(bf*barrels*width+Tc)
                 Rc=Ac/Pc
-                fc=Ac**1.5*Tc**-0.5-Q/(9.81**0.5)
+                fc=Ac**1.5*Tc**-0.5-Q/(g**0.5)
                 ffc=Ac**1.5*-0.5*Tc**-1.5*(z1+z2)+Tc**-0.5*1.5*Ac**0.5*Tc
                 dyc=-fc/ffc
                 dcrit=dcrit+dyc
@@ -535,7 +543,7 @@ def weir_orifice_trapezoid_function(
         hyd_rad = flow_area/perimeter
 
         # Final Outlet control velocity using tail water
-        culvert_velocity = math.sqrt(delta_total_energy/((sum_loss/2/anuga.g)\
+        culvert_velocity = math.sqrt(delta_total_energy/((sum_loss/2/g)\
                                                           +(manning**2*length)/hyd_rad**1.33333))
         Q_outlet_tailwater = flow_area * culvert_velocity
 
@@ -548,7 +556,7 @@ def weir_orifice_trapezoid_function(
     if  flow_area <= 0.0 :
         culv_froude = 0.0
     else:
-        culv_froude=math.sqrt(Q**2*flow_width*barrels/(anuga.g*flow_area**3))
+        culv_froude=math.sqrt(Q**2*flow_width*barrels/(g*flow_area**3))
 
     if local_debug:
         anuga.log.critical('FLOW AREA = %s' % str(flow_area))


### PR DESCRIPTION
Backports two **legacy** (non-GPU) structure-operator bug fixes to the 3.3.x
line, targeting a **3.3.8** patch release. Both were found and fixed on
`develop` while resolving a mode-1/mode-2 culvert-reporting mismatch; these are
the portions that apply to the legacy code on `main`.

## Fixes

**1. Parallel structure-operator logging** (`268a3d76`)
- Add the `accumulated_flow` column to the parallel `.log` header and
  `timestepping_statistics()` — the value was already computed on the master
  proc but never written, so parallel logs lacked a column the sequential logs
  have.
- Fix the operator counter so every rank advances it in lockstep (participants
  in the constructor, non-participants in the factory `return None` branch),
  giving each structure a unique, rank-consistent number. Previously only the
  master advanced it, mis-numbering structures when a culvert and a trap had
  different master procs (e.g. at higher rank counts).
- Drop the `_P<rank>` suffix from the log filename so it matches the sequential
  name (`culvert_0.log`, `trap_1.log`); the log is already a single combined,
  master-written file.

**2. Weir/orifice-trapezoid critical-depth gravity** (`2b35a814`)
- `weir_orifice_trapezoid_function` hardcoded `9.81` in the critical-depth Newton
  solve (inconsistent with the `anuga.g` it used elsewhere in the same
  function), so weir `flow_area` / reported velocity were wrong for any non-9.81
  gravity. It now takes a `g` argument (default `anuga.g` for direct callers)
  and uses it for every gravity term; the serial and parallel discharge routines
  pass `self.domain.g`.

## Behaviour notes (for a patch release)
- Parallel structure log **filenames drop `_P<rank>`** and structure numbering
  changes — output only, no physics; no test references the old names.
- Weir results **shift ~0.034%** in partly-full flow (9.81 → `domain.g`, e.g. the
  9.8 default). Correctness fix; no test bakes in the old values.

## Not included
The GPU/mode-2 counterparts from the same `develop` work (boyd_pipe critical-depth
translation fix, and the mode-2 GPU stats write-back) are **omitted** — that
machinery (`shallow_water/gpu/`, `gpu_culvert_manager.py`) does not exist on the
3.3.x line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)