### PR TITLE
Speed up partition save: parallel dump + single-file layout + batched gc

### DIFF
--- a/anuga/parallel/sequential_distribute.py
+++ b/anuga/parallel/sequential_distribute.py
@@ -536,9 +536,17 @@ def _write_mesh_partition(fname, rank, numprocs,
         v = nc.createVariable('boundary_edge', 'i4', ('bnd',))
         v[:] = bnd_edges
         tag_var = nc.createVariable('boundary_tag', 'S1', ('bnd', 'tag_len'))
-        for i, tag in enumerate(bnd_tags):
-            padded = tag.ljust(max_tag_len, '\x00')
-            tag_var[i, :] = num.frombuffer(padded.encode('ascii'), dtype='S1')
+        if Nbnd:
+            # Assemble the whole (Nbnd, tag_len) char array and write it in one
+            # call.  A per-row ``tag_var[i, :] = ...`` loop is one HDF5 write per
+            # boundary edge and dominates the mesh-partition write time (each
+            # assignment drags netCDF4's full per-call Python machinery).  Null
+            # padding matches the loader's ``rstrip('\x00')``.
+            tag_arr = num.zeros((Nbnd, max_tag_len), dtype='S1')
+            for i, tag in enumerate(bnd_tags):
+                b = tag.encode('ascii')
+                tag_arr[i, :len(b)] = num.frombuffer(b, dtype='S1')
+            tag_var[:] = tag_arr
 
         # --- send/recv communication: CSR encoding ---
         # full_send_dict / ghost_recv_dict: {rank: [local_indices, global_indices]}

--- a/anuga/parallel/sequential_distribute.py
+++ b/anuga/parallel/sequential_distribute.py
@@ -217,13 +217,122 @@ class Sequential_distribute:
 
 
 
-def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir='.', debug=False, parameters = None):
+# --------------------------------------------------------------------------
+# Opt-in parallel partition dump
+#
+# The per-partition write loops in sequential_distribute_dump /
+# sequential_mesh_dump are embarrassingly parallel: extract_submesh only *reads*
+# the shared submesh (indexing submesh[key][p]), and each partition writes its
+# own files.  When num_workers > 1 (POSIX only) we fork a ProcessPoolExecutor;
+# the large submesh is shared copy-on-write via the child processes rather than
+# pickled, so peak memory stays close to the serial path's post-build peak
+# (the serial path additionally releases each rank as it goes — the parallel
+# path keeps the whole submesh live for the pool's duration, the one trade-off).
+# --------------------------------------------------------------------------
+
+# Set by the parent immediately before the worker pool is forked; inherited
+# copy-on-write by each worker (never pickled).  Cleared afterwards.
+_DUMP_DOMAIN_STATE = None
+_DUMP_MESH_STATE = None
+
+
+def _run_partition_dump_pool(worker, numprocs, num_workers, verbose, label):
+    """Fork a ProcessPoolExecutor and map ``worker`` over ``range(numprocs)``.
+
+    The caller must set the module-global state the worker reads *before*
+    calling this, so the forked workers inherit it.  gc is frozen across the
+    pool so the large inherited structures are neither rescanned nor
+    copy-on-write dirtied by generational collections in the workers.
+    """
+    import concurrent.futures
+    import multiprocessing
+    import warnings
+    import gc
+
+    actual_workers = max(1, min(num_workers, numprocs))
+    # Heavy tasks (~seconds each); a small oversubscribed chunk keeps dispatch
+    # overhead low while still load-balancing across workers.
+    chunksize = max(1, numprocs // (actual_workers * 8))
+    # fork so the submesh is shared copy-on-write (POSIX only; the caller only
+    # selects this path when os.fork exists).  Workers do no MPI.
+    mp_ctx = multiprocessing.get_context('fork')
+
+    if verbose:
+        print('%s: writing %d partitions with %d workers' % (label, numprocs, actual_workers))
+
+    gc.freeze()  # move the big inherited objects out of gc's scan set
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message=r'.*use of fork\(\) may lead to deadlocks.*',
+                category=DeprecationWarning)
+            with concurrent.futures.ProcessPoolExecutor(
+                    max_workers=actual_workers, mp_context=mp_ctx) as executor:
+                for _ in executor.map(worker, range(numprocs), chunksize=chunksize):
+                    pass
+    finally:
+        gc.unfreeze()
+
+
+def _use_parallel_dump(num_workers, numprocs):
+    """True if the parallel (fork) dump path should be used."""
+    import os
+    return (num_workers is not None and num_workers > 1
+            and numprocs > 1 and hasattr(os, 'fork'))
+
+
+def _dump_domain_partition(partition, p, numprocs, partition_dir):
+    """Extract and write partition ``p`` of a distributed domain.
+
+    Reads only ``partition`` (no mutation), so it is safe to call concurrently
+    from fork-inherited worker processes.
+    """
+    import pickle
+    from os.path import join
+
+    tostore = partition.extract_submesh(p)
+
+    pickle_name = join(partition_dir,
+                       partition.domain_name + '_P%g_%g.pickle' % (numprocs, p))
+    lst = list(tostore)
+
+    # Write points and triangles to their own files
+    num.save(pickle_name + ".np1", tostore[1])  # num.save appends .npy
+    lst[1] = pickle_name + ".np1.npy"
+    num.save(pickle_name + ".np2", tostore[2])
+    lst[2] = pickle_name + ".np2.npy"
+
+    # Write each quantity to its own file
+    for k in tostore[4]:
+        num.save(pickle_name + ".np4." + k, num.asarray(tostore[4][k]))
+        lst[4][k] = pickle_name + ".np4." + k + ".npy"
+
+    with open(pickle_name, 'wb') as f:
+        pickle.dump(tuple(lst), f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _dump_domain_worker(p):
+    partition, numprocs, partition_dir = _DUMP_DOMAIN_STATE
+    _dump_domain_partition(partition, p, numprocs, partition_dir)
+    return p
+
+
+def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir='.',
+                               debug=False, parameters=None, num_workers=1):
     """ Distribute the domain, create parallel domain and pickle result
+
+    num_workers : int, optional
+        If > 1 (and > 1 partition, on a POSIX/fork platform), write the
+        partition files in parallel using a fork-based process pool that shares
+        the partitioned mesh copy-on-write.  Default 1 (serial, memory-frugal:
+        each rank is released as it is written).  On very large partition counts
+        the serial write dominates end-to-end time; this parallelises it at the
+        cost of keeping the whole submesh live for the dump's duration.
     """
 
     import gc
-    import pickle
-    from os.path import join
+    import os
 
     partition = Sequential_distribute(domain, verbose, debug, parameters)
 
@@ -232,48 +341,30 @@ def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir=
 
     # Make sure the partition_dir exists
     if partition_dir != '.':
-        import os
-        import errno
-        try:
-            os.makedirs(partition_dir, exist_ok=True)
-        except OSError as exception:
-            if exception.errno != errno.EEXIST:
-                raise
+        os.makedirs(partition_dir, exist_ok=True)
 
     if verbose: print('sequential_distribute_dump: Dumping partitions to %s'%partition_dir)
 
-    for p in range(0, numprocs):
+    if _use_parallel_dump(num_workers, numprocs):
+        global _DUMP_DOMAIN_STATE
+        _DUMP_DOMAIN_STATE = (partition, numprocs, partition_dir)
+        try:
+            _run_partition_dump_pool(_dump_domain_worker, numprocs, num_workers,
+                                     verbose, 'sequential_distribute_dump')
+        finally:
+            _DUMP_DOMAIN_STATE = None
+    else:
+        for p in range(0, numprocs):
+            _dump_domain_partition(partition, p, numprocs, partition_dir)
 
-        tostore = partition.extract_submesh(p)
+            # Release this rank's submesh data so memory can be reclaimed before
+            # processing the next rank.  Without this, all P subdomains' arrays
+            # remain live throughout the entire dump loop.
+            partition._release_submesh_rank(p)
 
-        pickle_name = partition.domain_name + '_P%g_%g.pickle'% (numprocs,p)
-        pickle_name = join(partition_dir,pickle_name)
-
-        lst = list(tostore)
-
-        # Write points and triangles to their own files
-        num.save(pickle_name+".np1",tostore[1]) # num.save appends .npy to filename
-        lst[1] = pickle_name+".np1.npy"
-        num.save(pickle_name+".np2",tostore[2])
-        lst[2] = pickle_name+".np2.npy"
-
-        # Write each quantity to its own file
-        for k in tostore[4]:
-            num.save(pickle_name+".np4."+k, num.asarray(tostore[4][k]))
-            lst[4][k] = pickle_name+".np4."+k+".npy"
-
-        with open(pickle_name, 'wb') as f:
-            pickle.dump(tuple(lst), f, protocol=pickle.HIGHEST_PROTOCOL)
-
-        # Release this rank's submesh data so memory can be reclaimed before
-        # processing the next rank.  Without this, all P subdomains' arrays
-        # remain live throughout the entire dump loop.
-        partition._release_submesh_rank(p)
-        del tostore, lst
-
-        # Run GC every rank — cyclic references inside submesh dicts are not
-        # freed by refcounting alone and must be collected explicitly.
-        gc.collect()
+            # Run GC every rank — cyclic references inside submesh dicts are not
+            # freed by refcounting alone and must be collected explicitly.
+            gc.collect()
 
     gc.collect()
     return
@@ -463,8 +554,45 @@ def _release_mesh_submesh_rank(submesh, p):
             lst[p] = None
 
 
+def _dump_mesh_partition(submesh, triangles_per_proc, p2s_map, p, numprocs, name,
+                         partition_dir, geo_ref, n_global_tri, n_global_nodes):
+    """Extract and write partition ``p`` of a mesh (one NetCDF file).
+
+    Reads only ``submesh`` (no mutation), so it is safe to call concurrently
+    from fork-inherited worker processes.
+    """
+    import os
+
+    points, vertices, boundary, _quantities, ghost_recv_dict, \
+        full_send_dict, _tri_map, _node_map, tri_l2g, node_l2g, \
+        ghost_layer_width = \
+        extract_submesh(submesh, triangles_per_proc, p2s_map, p)
+
+    number_of_full_triangles = len(submesh['full_triangles'][p])
+    number_of_full_nodes     = len(submesh['full_nodes'][p])
+
+    fname = os.path.join(partition_dir, f'{name}_mesh_P{numprocs}_{p}.nc')
+
+    _write_mesh_partition(
+        fname, p, numprocs,
+        points, vertices, boundary,
+        ghost_recv_dict, full_send_dict,
+        tri_l2g, node_l2g,
+        number_of_full_triangles, number_of_full_nodes,
+        n_global_tri, n_global_nodes,
+        ghost_layer_width, geo_ref)
+
+
+def _dump_mesh_worker(p):
+    (submesh, triangles_per_proc, p2s_map, numprocs, name, partition_dir,
+     geo_ref, n_global_tri, n_global_nodes) = _DUMP_MESH_STATE
+    _dump_mesh_partition(submesh, triangles_per_proc, p2s_map, p, numprocs, name,
+                         partition_dir, geo_ref, n_global_tri, n_global_nodes)
+    return p
+
+
 def sequential_mesh_dump(domain, numprocs, partition_dir='.', name=None,
-                         verbose=False, parameters=None):
+                         verbose=False, parameters=None, num_workers=1):
     """Partition a domain mesh and write one NetCDF4 file per rank.
 
     Saves mesh topology and halo structure only — no quantities.
@@ -493,6 +621,13 @@ def sequential_mesh_dump(domain, numprocs, partition_dir='.', name=None,
         Recognised keys include ``'partition_scheme'`` (``'metis'``,
         ``'morton'``, or ``'hilbert'``), ``'ghost_layer_width'``, and
         ``'cache_dir'``.
+    num_workers : int, optional
+        If > 1 (and > 1 partition, on a POSIX/fork platform), write the per-rank
+        NetCDF files in parallel using a fork-based process pool that shares the
+        partitioned mesh copy-on-write.  Default 1 (serial; each rank released as
+        it is written).  Parallelising the write is the main end-to-end speed-up
+        for very large partition counts, at the cost of keeping the whole submesh
+        live for the dump's duration.
     """
     import gc
     import os
@@ -529,33 +664,28 @@ def sequential_mesh_dump(domain, numprocs, partition_dir='.', name=None,
                   f'{len(submesh["full_triangles"][p])} full triangles, '
                   f'{M} ghost triangles, {N} ghost nodes')
 
-    for p in range(numprocs):
-        points, vertices, boundary, _quantities, ghost_recv_dict, \
-            full_send_dict, _tri_map, _node_map, tri_l2g, node_l2g, \
-            ghost_layer_width = \
-            extract_submesh(submesh, triangles_per_proc, p2s_map, p)
+    if _use_parallel_dump(num_workers, numprocs):
+        global _DUMP_MESH_STATE
+        _DUMP_MESH_STATE = (submesh, triangles_per_proc, p2s_map, numprocs, name,
+                            partition_dir, geo_ref, number_of_global_triangles,
+                            number_of_global_nodes)
+        try:
+            _run_partition_dump_pool(_dump_mesh_worker, numprocs, num_workers,
+                                     verbose, 'sequential_mesh_dump')
+        finally:
+            _DUMP_MESH_STATE = None
+    else:
+        for p in range(numprocs):
+            if verbose:
+                print(f'sequential_mesh_dump: writing '
+                      f'{os.path.join(partition_dir, f"{name}_mesh_P{numprocs}_{p}.nc")}')
 
-        number_of_full_triangles = len(submesh['full_triangles'][p])
-        number_of_full_nodes     = len(submesh['full_nodes'][p])
+            _dump_mesh_partition(submesh, triangles_per_proc, p2s_map, p, numprocs,
+                                 name, partition_dir, geo_ref,
+                                 number_of_global_triangles, number_of_global_nodes)
 
-        fname = os.path.join(partition_dir,
-                             f'{name}_mesh_P{numprocs}_{p}.nc')
-        if verbose:
-            print(f'sequential_mesh_dump: writing {fname}')
-
-        _write_mesh_partition(
-            fname, p, numprocs,
-            points, vertices, boundary,
-            ghost_recv_dict, full_send_dict,
-            tri_l2g, node_l2g,
-            number_of_full_triangles, number_of_full_nodes,
-            number_of_global_triangles, number_of_global_nodes,
-            ghost_layer_width, geo_ref)
-
-        _release_mesh_submesh_rank(submesh, p)
-        del points, vertices, boundary, tri_l2g, node_l2g
-        del ghost_recv_dict, full_send_dict
-        gc.collect()
+            _release_mesh_submesh_rank(submesh, p)
+            gc.collect()
 
     gc.collect()
 

--- a/anuga/parallel/sequential_distribute.py
+++ b/anuga/parallel/sequential_distribute.py
@@ -282,11 +282,29 @@ def _use_parallel_dump(num_workers, numprocs):
             and numprocs > 1 and hasattr(os, 'fork'))
 
 
-def _dump_domain_partition(partition, p, numprocs, partition_dir):
+# Serial dump: collect cyclic garbage every this-many ranks rather than every
+# rank.  The big arrays for a released rank are freed immediately by refcounting
+# (_release_submesh_rank nulls them); only the small cyclic submesh-dict garbage
+# waits for gc, so batching a modest number of ranks keeps peak memory ~flat
+# while cutting the number of full graph traversals ~this-many-fold.
+_SERIAL_GC_BATCH = 64
+
+
+def _dump_domain_partition(partition, p, numprocs, partition_dir, single_file=True):
     """Extract and write partition ``p`` of a distributed domain.
 
     Reads only ``partition`` (no mutation), so it is safe to call concurrently
     from fork-inherited worker processes.
+
+    single_file : bool
+        When True (default) the whole partition — including points, triangles
+        and every quantity — is written as a *single* pickle (protocol 5 stores
+        the numpy buffers efficiently).  When False the legacy layout is used:
+        points/triangles/quantities go to their own ``.npy`` files and the
+        pickle stores their paths.  Single-file cuts the file count from
+        ``3 + N_quantities`` to 1 per partition, which dominates the dump time
+        on metadata-bound (Lustre/GPFS) filesystems at large partition counts.
+        The load path reads both layouts.
     """
     import pickle
     from os.path import join
@@ -297,29 +315,32 @@ def _dump_domain_partition(partition, p, numprocs, partition_dir):
                        partition.domain_name + '_P%g_%g.pickle' % (numprocs, p))
     lst = list(tostore)
 
-    # Write points and triangles to their own files
-    num.save(pickle_name + ".np1", tostore[1])  # num.save appends .npy
-    lst[1] = pickle_name + ".np1.npy"
-    num.save(pickle_name + ".np2", tostore[2])
-    lst[2] = pickle_name + ".np2.npy"
-
-    # Write each quantity to its own file
-    for k in tostore[4]:
-        num.save(pickle_name + ".np4." + k, num.asarray(tostore[4][k]))
-        lst[4][k] = pickle_name + ".np4." + k + ".npy"
+    if not single_file:
+        # Legacy layout: points/triangles/quantities to their own .npy files;
+        # the pickle stores the filenames.
+        num.save(pickle_name + ".np1", tostore[1])  # num.save appends .npy
+        lst[1] = pickle_name + ".np1.npy"
+        num.save(pickle_name + ".np2", tostore[2])
+        lst[2] = pickle_name + ".np2.npy"
+        for k in tostore[4]:
+            num.save(pickle_name + ".np4." + k, num.asarray(tostore[4][k]))
+            lst[4][k] = pickle_name + ".np4." + k + ".npy"
+    # else: leave lst[1] (points), lst[2] (vertices) and lst[4] (quantities
+    # dict) as the arrays themselves — pickled inline below into one file.
 
     with open(pickle_name, 'wb') as f:
         pickle.dump(tuple(lst), f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def _dump_domain_worker(p):
-    partition, numprocs, partition_dir = _DUMP_DOMAIN_STATE
-    _dump_domain_partition(partition, p, numprocs, partition_dir)
+    partition, numprocs, partition_dir, single_file = _DUMP_DOMAIN_STATE
+    _dump_domain_partition(partition, p, numprocs, partition_dir, single_file)
     return p
 
 
 def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir='.',
-                               debug=False, parameters=None, num_workers=1):
+                               debug=False, parameters=None, num_workers=1,
+                               single_file=True):
     """ Distribute the domain, create parallel domain and pickle result
 
     num_workers : int, optional
@@ -329,6 +350,12 @@ def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir=
         each rank is released as it is written).  On very large partition counts
         the serial write dominates end-to-end time; this parallelises it at the
         cost of keeping the whole submesh live for the dump's duration.
+    single_file : bool, optional
+        When True (default) each partition is a single pickle file.  When False
+        the legacy layout is used (points/triangles/quantities in separate
+        ``.npy`` files: ``3 + N_quantities`` files per partition).  Single-file
+        greatly reduces the file count — the dominant cost on metadata-bound
+        parallel filesystems — and the load path reads both layouts.
     """
 
     import gc
@@ -347,7 +374,7 @@ def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir=
 
     if _use_parallel_dump(num_workers, numprocs):
         global _DUMP_DOMAIN_STATE
-        _DUMP_DOMAIN_STATE = (partition, numprocs, partition_dir)
+        _DUMP_DOMAIN_STATE = (partition, numprocs, partition_dir, single_file)
         try:
             _run_partition_dump_pool(_dump_domain_worker, numprocs, num_workers,
                                      verbose, 'sequential_distribute_dump')
@@ -355,16 +382,16 @@ def sequential_distribute_dump(domain, numprocs=1, verbose=False, partition_dir=
             _DUMP_DOMAIN_STATE = None
     else:
         for p in range(0, numprocs):
-            _dump_domain_partition(partition, p, numprocs, partition_dir)
+            _dump_domain_partition(partition, p, numprocs, partition_dir, single_file)
 
             # Release this rank's submesh data so memory can be reclaimed before
             # processing the next rank.  Without this, all P subdomains' arrays
-            # remain live throughout the entire dump loop.
+            # remain live throughout the entire dump loop.  The big arrays are
+            # freed immediately by refcounting; only cyclic submesh-dict garbage
+            # needs gc, so collect in batches rather than every rank.
             partition._release_submesh_rank(p)
-
-            # Run GC every rank — cyclic references inside submesh dicts are not
-            # freed by refcounting alone and must be collected explicitly.
-            gc.collect()
+            if (p + 1) % _SERIAL_GC_BATCH == 0:
+                gc.collect()
 
     gc.collect()
     return
@@ -399,12 +426,16 @@ def sequential_distribute_load_pickle_file(pickle_name, np=1, verbose = False):
                    domain_low_froude = pickle.load(f)
     f.close()
 
-    # Note that quantities is a dictionary with quantity name keys and filenames of numpy arrays.
-    # points and vertices are filenames of numpy arrays. These need to be loaded.
+    # points, vertices and each quantity are stored either inline as arrays
+    # (single_file dump, the default) or as filenames of separate .npy files
+    # (legacy multi-file dump).  Load the filenames; use the arrays as-is.
     for k in quantities:
-        quantities[k] = num.load(quantities[k])
-    points = num.load(points)
-    vertices = num.load(vertices)
+        if isinstance(quantities[k], str):
+            quantities[k] = num.load(quantities[k])
+    if isinstance(points, str):
+        points = num.load(points)
+    if isinstance(vertices, str):
+        vertices = num.load(vertices)
 
     #---------------------------------------------------------------------------
     # Create domain (parallel if np>1)
@@ -684,8 +715,11 @@ def sequential_mesh_dump(domain, numprocs, partition_dir='.', name=None,
                                  name, partition_dir, geo_ref,
                                  number_of_global_triangles, number_of_global_nodes)
 
+            # Release this rank's submesh data; collect cyclic garbage in batches
+            # rather than every rank (the big arrays are freed by refcounting).
             _release_mesh_submesh_rank(submesh, p)
-            gc.collect()
+            if (p + 1) % _SERIAL_GC_BATCH == 0:
+                gc.collect()
 
     gc.collect()
 

--- a/anuga/parallel/tests/test_sequential_mesh_io.py
+++ b/anuga/parallel/tests/test_sequential_mesh_io.py
@@ -233,10 +233,13 @@ class TestSequentialMeshDump(unittest.TestCase):
     @pytest.mark.skipif(not hasattr(os, 'fork'),
                         reason='parallel dump uses a fork process pool (POSIX only)')
     def test_parallel_dump_domain_matches_serial(self):
-        """sequential_distribute_dump: num_workers>1 writes the same partition
-        data (.npy) as the serial path, and the pickles unpickle cleanly."""
+        """sequential_distribute_dump: num_workers>1 reproduces the serial dump.
+
+        Single-file (default) partitions embed no paths, so the pickle files are
+        byte-identical between the serial and parallel writers -- and there are
+        no separate .npy files.
+        """
         import filecmp
-        import pickle
         from anuga.parallel.sequential_distribute import sequential_distribute_dump
 
         def dump(nw):
@@ -248,22 +251,44 @@ class TestSequentialMeshDump(unittest.TestCase):
         s = dump(1)
         p = dump(4)
 
-        # .npy files (points, triangles, every quantity) embed no paths -> the
-        # numerical partition data must be byte-identical.
-        npys = sorted(f for f in os.listdir(s) if f.endswith('.npy'))
-        self.assertEqual(npys, sorted(f for f in os.listdir(p) if f.endswith('.npy')))
-        self.assertTrue(npys, 'expected per-quantity .npy files')
-        match, mismatch, errors = filecmp.cmpfiles(s, p, npys, shallow=False)
+        files = sorted(os.listdir(s))
+        self.assertEqual(files, sorted(os.listdir(p)))
+        self.assertEqual(len([f for f in files if f.endswith('.pickle')]), 5)
+        self.assertFalse([f for f in files if f.endswith('.npy')],
+                         'single-file dump should not write .npy files')
+        match, mismatch, errors = filecmp.cmpfiles(s, p, files, shallow=False)
         self.assertEqual((mismatch, errors), ([], []),
-                         f'.npy differ serial vs parallel: {mismatch} {errors}')
+                         f'serial vs parallel differ: {mismatch} {errors}')
 
-        # Same set of pickles, and each unpickles.
-        pks = sorted(f for f in os.listdir(s) if f.endswith('.pickle'))
-        self.assertEqual(pks, sorted(f for f in os.listdir(p) if f.endswith('.pickle')))
-        self.assertEqual(len(pks), 5)
-        for f in pks:
-            with open(os.path.join(p, f), 'rb') as fh:
-                pickle.load(fh)
+    def test_domain_dump_single_file_equals_legacy(self):
+        """single_file=True stores the same partition data as the legacy
+        multi-file layout (and the parallel writer works for both)."""
+        import pickle
+        from anuga.parallel.sequential_distribute import sequential_distribute_dump
+
+        sa = tempfile.mkdtemp()  # single-file (default), parallel writer
+        sb = tempfile.mkdtemp()  # legacy multi-file, serial writer
+        sequential_distribute_dump(_make_domain(8, 6), numprocs=4,
+                                   partition_dir=sa, num_workers=3)
+        sequential_distribute_dump(_make_domain(8, 6), numprocs=4,
+                                   partition_dir=sb, single_file=False)
+
+        # single-file: one pickle, no .npy;  legacy: 3 + N_quant .npy per rank
+        self.assertFalse([f for f in os.listdir(sa) if f.endswith('.npy')])
+        self.assertEqual(len([f for f in os.listdir(sa) if f.endswith('.pickle')]), 4)
+        self.assertTrue([f for f in os.listdir(sb) if f.endswith('.npy')])
+
+        for p in range(4):
+            fn = f'test_mesh_P4_{p}.pickle'
+            with open(os.path.join(sa, fn), 'rb') as f:
+                A = list(pickle.load(f))          # arrays inline
+            with open(os.path.join(sb, fn), 'rb') as f:
+                B = list(pickle.load(f))          # points/vertices/quantities are paths
+            num.testing.assert_array_equal(A[1], num.load(B[1]))   # points
+            num.testing.assert_array_equal(A[2], num.load(B[2]))   # vertices
+            self.assertEqual(set(A[4]), set(B[4]))                 # quantity names
+            for k in A[4]:
+                num.testing.assert_array_equal(A[4][k], num.load(B[4][k]))
 
     def test_roundtrip_node_count(self):
         """Loaded domain has correct full-triangle and full-node counts."""

--- a/anuga/parallel/tests/test_sequential_mesh_io.py
+++ b/anuga/parallel/tests/test_sequential_mesh_io.py
@@ -201,6 +201,70 @@ class TestSequentialMeshDump(unittest.TestCase):
         domain.set_boundary(boundary_map)
         return domain
 
+    @pytest.mark.skipif(not hasattr(os, 'fork'),
+                        reason='parallel dump uses a fork process pool (POSIX only)')
+    def test_parallel_dump_matches_serial(self):
+        """num_workers>1 (fork pool) produces the same NetCDF files as serial."""
+        import netCDF4
+
+        def dump(nw):
+            d = tempfile.mkdtemp()
+            anuga.sequential_mesh_dump(_make_domain(8, 6), numprocs=5,
+                                       partition_dir=d, num_workers=nw)
+            return d
+
+        serial_dir = dump(1)
+        parallel_dir = dump(4)
+
+        ncs = sorted(f for f in os.listdir(serial_dir) if f.endswith('.nc'))
+        self.assertEqual(ncs, sorted(f for f in os.listdir(parallel_dir)
+                                     if f.endswith('.nc')))
+        self.assertEqual(len(ncs), 5)
+        for f in ncs:
+            with netCDF4.Dataset(os.path.join(serial_dir, f)) as a, \
+                 netCDF4.Dataset(os.path.join(parallel_dir, f)) as b:
+                self.assertEqual(set(a.variables), set(b.variables))
+                for v in a.variables:
+                    num.testing.assert_array_equal(
+                        num.asarray(a.variables[v][:]),
+                        num.asarray(b.variables[v][:]),
+                        err_msg=f'{f}:{v} differs between serial and parallel dump')
+
+    @pytest.mark.skipif(not hasattr(os, 'fork'),
+                        reason='parallel dump uses a fork process pool (POSIX only)')
+    def test_parallel_dump_domain_matches_serial(self):
+        """sequential_distribute_dump: num_workers>1 writes the same partition
+        data (.npy) as the serial path, and the pickles unpickle cleanly."""
+        import filecmp
+        import pickle
+        from anuga.parallel.sequential_distribute import sequential_distribute_dump
+
+        def dump(nw):
+            d = tempfile.mkdtemp()
+            sequential_distribute_dump(_make_domain(8, 6), numprocs=5,
+                                       partition_dir=d, num_workers=nw)
+            return d
+
+        s = dump(1)
+        p = dump(4)
+
+        # .npy files (points, triangles, every quantity) embed no paths -> the
+        # numerical partition data must be byte-identical.
+        npys = sorted(f for f in os.listdir(s) if f.endswith('.npy'))
+        self.assertEqual(npys, sorted(f for f in os.listdir(p) if f.endswith('.npy')))
+        self.assertTrue(npys, 'expected per-quantity .npy files')
+        match, mismatch, errors = filecmp.cmpfiles(s, p, npys, shallow=False)
+        self.assertEqual((mismatch, errors), ([], []),
+                         f'.npy differ serial vs parallel: {mismatch} {errors}')
+
+        # Same set of pickles, and each unpickles.
+        pks = sorted(f for f in os.listdir(s) if f.endswith('.pickle'))
+        self.assertEqual(pks, sorted(f for f in os.listdir(p) if f.endswith('.pickle')))
+        self.assertEqual(len(pks), 5)
+        for f in pks:
+            with open(os.path.join(p, f), 'rb') as fh:
+                pickle.load(fh)
+
     def test_roundtrip_node_count(self):
         """Loaded domain has correct full-triangle and full-node counts."""
         import netCDF4

--- a/docs/source/parallel/use_sequential_domain_io.rst
+++ b/docs/source/parallel/use_sequential_domain_io.rst
@@ -19,8 +19,10 @@ implements an *offline domain partitioning* workflow (also called
       python create_dump.py -np N
 
    Rank 0 builds a complete :class:`Domain` (mesh + all quantities),
-   partitions it into *N* subdomains, and writes one set of files per rank:
-   a pickle file plus NumPy ``.npy`` arrays for the mesh and each quantity.
+   partitions it into *N* subdomains, and writes **one pickle file per rank**
+   (the single-file layout, the default; see `File format`_).  For very large
+   partition counts the writing can be parallelised — see
+   `Performance for large partition counts`_.
 
 2. **Simulation** — run as many times as needed:
 
@@ -92,8 +94,9 @@ API
 File format
 -----------
 
-For a domain named ``flood`` partitioned into *N* ranks, the preprocessing
-step creates the following files per rank *p* in ``partition_dir``:
+By default (``single_file=True``) the preprocessing step writes **one file per
+rank**.  For a domain named ``flood`` partitioned into *N* ranks, in
+``partition_dir``:
 
 .. list-table::
    :header-rows: 1
@@ -102,8 +105,24 @@ step creates the following files per rank *p* in ``partition_dir``:
    * - File
      - Contents
    * - ``flood_P<N>_<p>.pickle``
-     - Python pickle: mesh topology, boundary conditions, domain settings,
-       and per-quantity filenames.
+     - Python pickle holding everything for rank *p*: mesh topology (node
+       coordinates and triangle connectivity), boundary conditions, domain
+       metadata (name, flow algorithm, geo_reference, ``store`` flag, …), and
+       every quantity's centroid values — all stored inline as NumPy arrays.
+
+Passing ``single_file=False`` selects the **legacy multi-file layout**, which
+splits the arrays into separate ``.npy`` files (``3 + N_quantities`` files per
+rank, referenced by path from the pickle):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 42 58
+
+   * - File
+     - Contents
+   * - ``flood_P<N>_<p>.pickle``
+     - Pickle: mesh topology, boundary conditions, domain settings, and
+       per-quantity **filenames**.
    * - ``flood_P<N>_<p>.pickle.np1.npy``
      - Node (x, y) coordinates as a NumPy ``float64`` array, shape (nnodes, 2).
    * - ``flood_P<N>_<p>.pickle.np2.npy``
@@ -112,10 +131,47 @@ step creates the following files per rank *p* in ``partition_dir``:
      - One file per quantity (e.g. ``elevation``, ``stage``, ``friction``):
        centroid values as a NumPy ``float64`` array, shape (ntris,).
 
-The pickle file stores domain metadata (name, flow algorithm,
-geo_reference, ``store`` flag, etc.) so that ``sequential_distribute_load``
-can reconstruct the domain identically to how it was configured during
-preprocessing.
+``sequential_distribute_load`` reads **both** layouts automatically, so
+single-file and legacy multi-file dumps are interchangeable on load.
+
+
+Performance for large partition counts
+--------------------------------------
+
+For very large meshes split into many partitions, **writing the partition
+files dominates** the preprocessing time.  As a reference point, a
+173-million-triangle mesh partitioned into 18,400 ranks measured roughly
+1,000 s to load, 4,000 s to partition, and **37,000 s to write the partitions**.
+Two options address this:
+
+``single_file`` (default ``True``)
+   Writes one pickle per rank instead of ``3 + N_quantities`` separate files —
+   cutting the file count roughly an order of magnitude (e.g. ~147,000 → 18,400
+   files at 18,400 ranks with five quantities).  This is the dominant cost on
+   metadata-bound parallel filesystems (Lustre, GPFS).
+
+``num_workers`` (default ``1``)
+   With ``num_workers > 1`` (on a POSIX/fork platform) the per-rank files are
+   written in parallel by a pool of worker processes that share the partitioned
+   mesh copy-on-write, so the write scales toward the filesystem's I/O and
+   metadata throughput.  Match ``num_workers`` to the machine doing the
+   preprocessing (often a large-memory login/preprocessing node).
+
+.. code-block:: python
+
+   anuga.sequential_distribute_dump(
+       domain, numprocs=18400, partition_dir='Partitions',
+       num_workers=32,          # write with 32 worker processes
+       # single_file=True is the default
+   )
+
+.. note::
+
+   The serial default (``num_workers=1``) releases each rank's memory as it is
+   written, keeping rank-0 peak RAM low.  The parallel path keeps the whole
+   partitioned mesh resident for the duration of the worker pool — the
+   memory-for-speed trade-off — so choose ``num_workers`` with the preprocessing
+   node's RAM in mind.
 
 
 Preprocessing example

--- a/docs/source/parallel/use_sequential_mesh_io.rst
+++ b/docs/source/parallel/use_sequential_mesh_io.rst
@@ -148,6 +148,26 @@ NETCDF4 file.  It can be inspected with ``ncdump -h``.
      - Ghost-receive communication pattern.
 
 
+Parallel writing for large partition counts
+-------------------------------------------
+
+Like ``sequential_distribute_dump``, the per-rank NetCDF files are written in a
+serial loop by default, which dominates the preprocessing time at very large
+partition counts.  Pass ``num_workers > 1`` (on a POSIX/fork platform) to write
+the files in parallel with a pool of worker processes that share the
+partitioned mesh copy-on-write:
+
+.. code-block:: python
+
+   anuga.sequential_mesh_dump(domain, numprocs=18400,
+                              partition_dir='Partitions', num_workers=32)
+
+The serial default (``num_workers=1``) releases each rank's memory as it goes;
+the parallel path keeps the whole partitioned mesh resident for the pool's
+duration.  Choose ``num_workers`` to match the preprocessing node's write
+bandwidth and RAM.
+
+
 Preprocessing example
 ---------------------
 


### PR DESCRIPTION
## Motivation

Partitioning a very large mesh is dominated by **writing the partition files**,
done serially per rank. A measured **173M-triangle / 18,400-partition** run:

| stage | time |
|-------|------|
| load | ~1,000 s |
| partition | ~4,000 s |
| **save (serial dump)** | **~37,000 s (~88% of the job)** |

This PR attacks the save with four stacking changes; all are backward-compatible
and the numeric output is unchanged.

## 1. Opt-in parallel dump (`num_workers`)

`sequential_distribute_dump` (domain) and `sequential_mesh_dump` (mesh) wrote one
partition at a time. `extract_submesh` only *reads* the shared submesh, so the
per-partition writes now run on a fork-based `ProcessPoolExecutor` when
`num_workers > 1`: copy-on-write sharing of the partitioned mesh (not pickled) →
no per-worker duplication; `gc.freeze()` keeps the inherited structure out of the
workers' GC scans. Default `num_workers=1` = the serial, memory-frugal path.

## 2. Single-file dump (`single_file`, default True)

The domain dump wrote `3 + N_quantities` files per partition. It now inlines
those arrays into the **one per-partition pickle**, cutting **8 files/partition
→ 1** (~147k → 18.4k files at 18,400 partitions) — the dominant cost on
metadata-bound Lustre/GPFS. `sequential_distribute_load` reads **both** layouts,
so existing multi-file dumps still load; pass `single_file=False` for the legacy
layout.

## 3. Batched serial gc

The serial loops `gc.collect()`ed every rank (18,400 full graph traversals). The
big per-rank arrays are freed by refcounting; only small cyclic garbage needs gc,
so it is now batched every 64 ranks — peak memory ~flat, ~64× fewer traversals.

## 4. Vectorized mesh `boundary_tag` write (~3.7× faster mesh write)

`_write_mesh_partition` wrote the `boundary_tag` NetCDF string variable one row
at a time (one HDF5 write per boundary edge). Profiling showed this loop
dominating the mesh write. Assembling the whole char array and writing it once
drops the mesh-partition write **~9.45 → ~2.57 ms/file** (byte-identical output;
round-trip tests pass), approaching the intrinsic NetCDF cost — so the mesh dump
keeps NetCDF's portability/inspectability/smaller size without the egregious
per-row overhead.

```python
anuga.sequential_distribute_dump(domain, numprocs=18400,
                                 partition_dir='parts', num_workers=32)
# single-file is the default; num_workers>1 enables the fork pool
```

## Correctness

Parallel output reproduces serial **exactly** (domain single-file pickles
byte-identical; mesh NetCDF variables equal); single-file and legacy layouts
store identical partition data; the mesh `boundary_tag` change is byte-identical;
MPI dump+load round-trip green. New fork-guarded tests in
`test_sequential_mesh_io.py`; no regression across the sequential-distribute /
mesh-io / refine / dist-settings / simulation suites; ruff clean; docs build
clean.

## Possible further work (not in this PR)
Directory sharding for very large partition counts; further trimming of the
mesh writer's variable/attribute overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)