### PR TITLE
docs: reorder Appendices and shorten two nav labels

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,13 +49,13 @@ It is now developed and maintained by a community of volunteers.
    :caption: Appendices:
 
    installation/install_anuga_developers
-   appendices/install_gpu
-   appendices/contributing
-   parallel/advanced
-   appendices/compute_modes
-   appendices/profiling_gpu
+   Installing for GPU <appendices/install_gpu>
    appendices/advanced_script
+   parallel/advanced
+   Compute modes: legacy vs unified <appendices/compute_modes>
+   appendices/profiling_gpu
    mathematical_background
+   appendices/contributing
 
 
    


### PR DESCRIPTION
Small docs-nav tidy-up for the **Appendices** toctree in `docs/source/index.rst`.

**Before**, the appendices were somewhat scattered — the GPU-related pages
(GPU install, compute modes, GPU profiling) were split apart, Contributing sat
in the middle between technical pages, and the two "Advanced …" pages were far
apart.

**After**, they are grouped logically:

1. Install ANUGA for Developers
2. Installing for GPU
3. Advanced Simulation Features
4. Advanced Parallel Methods
5. Compute modes: legacy vs unified
6. Profiling the GPU build
7. Mathematical Background
8. Contributing

i.e. builds → advanced usage → GPU internals → theory → community (Contributing
as the closer).

Also shortens the two long toctree entries to cleaner nav labels
("Installing for GPU", "Compute modes: legacy vs unified") via custom entry
titles, leaving each page's own descriptive H1 unchanged.

Docs-only (one toctree block); Sphinx build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)