### PR TITLE
[WIP] feat(gpu): add OpenACC offload backend for the shallow-water kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ claude/CDAC_EXECUTIVE_SUMMARY.md
 
 # Profiling artifacts
 *.prof
+
+# Local scratch/compile-probe artifacts (session work)
+tmp_artifacts/

--- a/anuga/shallow_water/gpu/core_kernels.c
+++ b/anuga/shallow_water/gpu/core_kernels.c
@@ -928,11 +928,7 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
     double boundary_flux_sum_substep = 0.0;
 
     // Main flux computation loop with reductions
-    #ifdef CPU_ONLY_MODE
-    #pragma omp parallel for reduction(min:local_timestep) reduction(+:boundary_flux_sum_substep)
-    #else
-    #pragma omp target teams distribute parallel for reduction(min:local_timestep) reduction(+:boundary_flux_sum_substep)
-    #endif
+    OMP_PARALLEL_LOOP_REDUCTION_MIN_PLUS(local_timestep, boundary_flux_sum_substep)
     for (anuga_int k = 0; k < n; k++) {
         double edgeflux[3];
         double ql[3], qr[3];

--- a/anuga/shallow_water/gpu/gpu_boundaries.c
+++ b/anuga/shallow_water/gpu/gpu_boundaries.c
@@ -55,7 +55,7 @@ void gpu_reflective_finalize(struct gpu_domain *GD) {
         int *e_ids = R->edge_ids;
         int ne = R->num_edges;
 
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (R->boundary_indices) free(R->boundary_indices);
@@ -190,7 +190,7 @@ void gpu_dirichlet_finalize(struct gpu_domain *GD) {
         double *s_val = D->stage_values;
         double *x_val = D->xmom_values;
         double *y_val = D->ymom_values;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne],
                                                  s_val[0:ne], x_val[0:ne], y_val[0:ne])
     }
 
@@ -297,7 +297,7 @@ void gpu_transmissive_finalize(struct gpu_domain *GD) {
         int *b_idx = T->boundary_indices;
         int *v_ids = T->vol_ids;
         int *e_ids = T->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (T->boundary_indices) free(T->boundary_indices);
@@ -411,7 +411,7 @@ void gpu_transmissive_n_zero_t_finalize(struct gpu_domain *GD) {
         int *b_idx = B->boundary_indices;
         int *v_ids = B->vol_ids;
         int *e_ids = B->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (B->boundary_indices) free(B->boundary_indices);
@@ -542,7 +542,7 @@ void gpu_file_boundary_finalize(struct gpu_domain *GD) {
         double *stage_v = B->stage_values;
         double *xmom_v  = B->xmom_values;
         double *ymom_v  = B->ymom_values;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne],
                                                  stage_v[0:ne], xmom_v[0:ne], ymom_v[0:ne])
     }
 
@@ -579,7 +579,7 @@ void gpu_file_boundary_set_values(struct gpu_domain *GD,
         double *stage_v = B->stage_values;
         double *xmom_v  = B->xmom_values;
         double *ymom_v  = B->ymom_values;
-        #pragma omp target update to(stage_v[0:ne], xmom_v[0:ne], ymom_v[0:ne])
+        OMP_TARGET_UPDATE_TO(stage_v[0:ne], xmom_v[0:ne], ymom_v[0:ne])
     }
 }
 
@@ -668,7 +668,7 @@ void gpu_time_boundary_finalize(struct gpu_domain *GD) {
         int *b_idx = B->boundary_indices;
         int *v_ids = B->vol_ids;
         int *e_ids = B->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (B->boundary_indices) free(B->boundary_indices);
@@ -773,7 +773,7 @@ void gpu_absorbing_wave_finalize(struct gpu_domain *GD) {
         int *b_idx = B->boundary_indices;
         int *v_ids = B->vol_ids;
         int *e_ids = B->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (B->boundary_indices) free(B->boundary_indices);
@@ -903,7 +903,7 @@ void gpu_characteristic_wave_finalize(struct gpu_domain *GD) {
         int *b_idx = B->boundary_indices;
         int *v_ids = B->vol_ids;
         int *e_ids = B->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (B->boundary_indices) free(B->boundary_indices);
@@ -1047,7 +1047,7 @@ void gpu_flather_finalize(struct gpu_domain *GD) {
         int *b_idx = B->boundary_indices;
         int *v_ids = B->vol_ids;
         int *e_ids = B->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
     }
 
     if (B->boundary_indices) free(B->boundary_indices);

--- a/anuga/shallow_water/gpu/gpu_culvert_operator.c
+++ b/anuga/shallow_water/gpu/gpu_culvert_operator.c
@@ -626,16 +626,16 @@ void gpu_culverts_finalize_all(struct gpu_domain *GD) {
         int *scn = CO->scratch_slot_count;
 
         if (ne > 0) {
-            #pragma omp target exit data map(delete: eid[0:ne], sst[0:ne], scn[0:ne], \
-                ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne], \
-                as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne], \
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(eid[0:ne], sst[0:ne], scn[0:ne],
+                ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne],
+                as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne],
                 nd[0:ne], nx[0:ne], ny[0:ne])
         }
 
         if (nt > 0) {
             int *si = CO->scratch_inlet_indices;
             double *sa = CO->scratch_inlet_areas;
-            #pragma omp target exit data map(delete: si[0:nt], sa[0:nt])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(si[0:nt], sa[0:nt])
         }
         CO->mapped = 0;
     }
@@ -756,15 +756,15 @@ void gpu_culverts_map(struct gpu_domain *GD) {
     double *ny = CO->scratch_slot_ymom;
     int *sst = CO->scratch_slot_start;
     int *scn = CO->scratch_slot_count;
-    #pragma omp target enter data map(to: eid[0:ne], sst[0:ne], scn[0:ne]) \
-        map(alloc: ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne], \
-                   as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne], \
+    OMP_TARGET_ENTER_DATA_MAP_TO(eid[0:ne], sst[0:ne], scn[0:ne])
+    OMP_TARGET_ENTER_DATA_MAP_ALLOC(ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne],
+                   as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne],
                    nd[0:ne], nx[0:ne], ny[0:ne])
 
     if (nt > 0) {
         int *si = CO->scratch_inlet_indices;
         double *sa = CO->scratch_inlet_areas;
-        #pragma omp target enter data map(to: si[0:nt], sa[0:nt])
+        OMP_TARGET_ENTER_DATA_MAP_TO(si[0:nt], sa[0:nt])
     }
 
     CO->mapped = 1;
@@ -807,7 +807,7 @@ static void gpu_culvert_gather_enquiry(struct gpu_domain *GD,
     }
 
     // Single D2H transfer (~1KB for 20 culverts)
-    #pragma omp target update from(ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne])
+    OMP_TARGET_UPDATE_FROM(ss[0:ne], sx[0:ne], sy[0:ne], se[0:ne])
 
     // Unpack into per-culvert inlet_data structs
     for (int c = 0; c < nc; c++) {
@@ -852,7 +852,7 @@ static void gpu_culvert_gather_inlets(struct gpu_domain *GD,
     // summation order matches the old host loop exactly. Only the per-inlet
     // sums (2*nc doubles ×4 ≈ a few KB) travel back to the host — not every
     // triangle value.
-    #pragma omp target teams distribute parallel for
+    OMP_PARALLEL_LOOP
     for (int s = 0; s < ne; s++) {
         double sum_stage = 0.0, sum_depth = 0.0, sum_xmom = 0.0, sum_ymom = 0.0;
         int start = sst[s];
@@ -875,7 +875,7 @@ static void gpu_culvert_gather_inlets(struct gpu_domain *GD,
     }
 
     // Single D2H transfer of the per-inlet sums.
-    #pragma omp target update from(as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne])
+    OMP_TARGET_UPDATE_FROM(as[0:ne], ad[0:ne], ax[0:ne], ay[0:ne])
 
     // Divide by (constant, host-side) inlet area to get averages. An inlet
     // with zero local area (e.g. a cross-boundary inlet this rank doesn't own)
@@ -946,7 +946,7 @@ static void gpu_culvert_scatter(struct gpu_domain *GD,
     }
 
     // Single H2D transfer of the per-inlet values (2*nc doubles ×3).
-    #pragma omp target update to(nd[0:ne], nx[0:ne], ny[0:ne])
+    OMP_TARGET_UPDATE_TO(nd[0:ne], nx[0:ne], ny[0:ne])
 
     // On-device scatter: one team per inlet writes its contiguous triangle
     // range, reading bed elevation straight from the domain array so stage =
@@ -959,7 +959,7 @@ static void gpu_culvert_scatter(struct gpu_domain *GD,
     double * restrict ymom_c = GD->D.ymom_centroid_values;
     double * restrict bed_c = GD->D.bed_centroid_values;
 
-    #pragma omp target teams distribute parallel for
+    OMP_PARALLEL_LOOP
     for (int s = 0; s < ne; s++) {
         double depth = nd[s];
         double new_xmom = nx[s];
@@ -1233,7 +1233,7 @@ static void scatter_single_inlet(struct gpu_domain *GD,
     // Single fused device kernel: read bed, write stage/xmom/ymom. No host
     // loop, no stack staging arrays.
     int *idx = tri_indices;
-    #pragma omp target teams distribute parallel for map(to: idx[0:ntri])
+    OMP_PARALLEL_LOOP_MAP_TO(idx[0:ntri])
     for (int k = 0; k < ntri; k++) {
         int i = idx[k];
         stage_c[i] = bed_c[i] + new_depth;

--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -654,6 +654,7 @@ double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int
 int detect_gpu_aware_mpi(void);
 int gpu_is_available(void);
 int gpu_get_num_devices(void);
+const char *gpu_backend_name(void);
 int gpu_get_initial_device(void);
 int gpu_get_default_device(void);
 void gpu_set_default_device(int device_id);

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -177,6 +177,18 @@ int gpu_get_num_devices(void) {
 #endif
 }
 
+// Name of the parallel back end this extension was compiled with, so the Python
+// layer can report it (e.g. in the startup banner) without guessing.
+const char *gpu_backend_name(void) {
+#if defined(CPU_ONLY_MODE)
+    return "OpenMP multicore";
+#elif defined(ACC_OFFLOAD_MODE)
+    return "OpenACC";
+#else
+    return "OpenMP target";
+#endif
+}
+
 // Default offload device control. The kernels use `#pragma omp target` with no
 // device() clause, so they run on the OpenMP default device — redirecting it is
 // a robust, runtime way to force a GPU build onto the host (CPU) and back.
@@ -526,23 +538,22 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
     anuga_int *tri_full_flag = GD->D.tri_full_flag;
 
     // Map all domain arrays to GPU - persistent for entire simulation
-    #pragma omp target enter data map(to: \
-        stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], \
-        bed_cv[0:n], height_cv[0:n], friction_cv[0:n], \
-        stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n], \
-        bed_ev[0:3*n], height_ev[0:3*n], \
-        stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n], \
-        stage_siu[0:n], xmom_siu[0:n], ymom_siu[0:n], \
-        neighbours[0:3*n], neighbour_edges[0:3*n], \
-        surrogate_neighbours[0:3*n], number_of_boundaries[0:n], \
-        x_centroid_work[0:n], y_centroid_work[0:n], \
-        normals[0:6*n], edgelengths[0:3*n], \
-        areas[0:n], radii[0:n], max_speed[0:n], \
+    OMP_TARGET_ENTER_DATA_MAP_TO(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n],
+        bed_cv[0:n], height_cv[0:n], friction_cv[0:n],
+        stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n],
+        bed_ev[0:3*n], height_ev[0:3*n],
+        stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n],
+        stage_siu[0:n], xmom_siu[0:n], ymom_siu[0:n],
+        neighbours[0:3*n], neighbour_edges[0:3*n],
+        surrogate_neighbours[0:3*n], number_of_boundaries[0:n],
+        x_centroid_work[0:n], y_centroid_work[0:n],
+        normals[0:6*n], edgelengths[0:3*n],
+        areas[0:n], radii[0:n], max_speed[0:n],
         centroid_coords[0:2*n], edge_coords[0:6*n])
 
     // Map tri_full_flag only when present (parallel domains only)
     if (tri_full_flag != NULL) {
-        #pragma omp target enter data map(to: tri_full_flag[0:n])
+        OMP_TARGET_ENTER_DATA_MAP_TO(tri_full_flag[0:n])
     }
 
     // Map boundary values if present (including bed and height for reflective boundary)
@@ -552,8 +563,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *ymom_bv = GD->D.ymom_boundary_values;
         double *bed_bv = GD->D.bed_boundary_values;
         double *height_bv = GD->D.height_boundary_values;
-        #pragma omp target enter data map(to: \
-            stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb], \
+        OMP_TARGET_ENTER_DATA_MAP_TO(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb],
             bed_bv[0:nb], height_bv[0:nb])
     }
 
@@ -564,7 +574,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = R->vol_ids;
         int *e_ids = R->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         R->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -584,7 +594,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *x_val = Dir->xmom_values;
         double *y_val = Dir->ymom_values;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne], \
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne],
                                               s_val[0:ne], x_val[0:ne], y_val[0:ne])
         Dir->mapped = 1;
 
@@ -602,7 +612,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = T->vol_ids;
         int *e_ids = T->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         T->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -619,7 +629,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = Tnzt->vol_ids;
         int *e_ids = Tnzt->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         Tnzt->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -636,7 +646,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = TB->vol_ids;
         int *e_ids = TB->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         TB->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -656,7 +666,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *xmom_v  = FB->xmom_values;
         double *ymom_v  = FB->ymom_values;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne], \
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne],
                                               stage_v[0:ne], xmom_v[0:ne], ymom_v[0:ne])
         FB->mapped = 1;
 
@@ -674,7 +684,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = AW->vol_ids;
         int *e_ids = AW->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         AW->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -691,7 +701,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = CW->vol_ids;
         int *e_ids = CW->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         CW->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -708,7 +718,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *v_ids = FL->vol_ids;
         int *e_ids = FL->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         FL->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -721,7 +731,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
     // edge_flux_type is always mapped (size 3*n); other arrays only if riverwalls exist
     anuga_int *edge_flux_type = GD->D.edge_flux_type;
     if (edge_flux_type != NULL) {
-        #pragma omp target enter data map(to: edge_flux_type[0:3*n])
+        OMP_TARGET_ENTER_DATA_MAP_TO(edge_flux_type[0:3*n])
     }
 
     anuga_int n_rw_edges = GD->D.number_of_riverwall_edges;
@@ -735,19 +745,19 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
 
         // edge_river_wall_counter has same size as edge_flux_type (3*n)
         if (edge_river_wall_counter != NULL) {
-            #pragma omp target enter data map(to: edge_river_wall_counter[0:3*n])
+            OMP_TARGET_ENTER_DATA_MAP_TO(edge_river_wall_counter[0:3*n])
         }
         // riverwall_elevation and riverwall_rowIndex have size n_rw_edges
         if (riverwall_elevation != NULL) {
-            #pragma omp target enter data map(to: riverwall_elevation[0:n_rw_edges])
+            OMP_TARGET_ENTER_DATA_MAP_TO(riverwall_elevation[0:n_rw_edges])
         }
         if (riverwall_rowIndex != NULL) {
-            #pragma omp target enter data map(to: riverwall_rowIndex[0:n_rw_edges])
+            OMP_TARGET_ENTER_DATA_MAP_TO(riverwall_rowIndex[0:n_rw_edges])
         }
         // riverwall_hydraulic_properties is (nrow_hp x ncol_hp)
         // nrow_hp = number of unique riverwall segments
         if (riverwall_hydraulic_properties != NULL && ncol_hp > 0 && nrow_hp > 0) {
-            #pragma omp target enter data map(to: riverwall_hydraulic_properties[0:nrow_hp*ncol_hp])
+            OMP_TARGET_ENTER_DATA_MAP_TO(riverwall_hydraulic_properties[0:nrow_hp*ncol_hp])
         }
 
         if (GD->rank == 0 && GD->verbose) {
@@ -761,8 +771,7 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *stage_backup = GD->D.stage_backup_values;
         double *xmom_backup = GD->D.xmom_backup_values;
         double *ymom_backup = GD->D.ymom_backup_values;
-        #pragma omp target enter data map(to: \
-            stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
+        OMP_TARGET_ENTER_DATA_MAP_TO(stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
         GD->backup_arrays_mapped = 1;
     }
 
@@ -775,8 +784,8 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *send_buf = H->send_buffer;
         double *recv_buf = H->recv_buffer;
 
-        #pragma omp target enter data map(to: flat_send[0:send_size], flat_recv[0:recv_size]) \
-            map(alloc: send_buf[0:3*send_size], recv_buf[0:3*recv_size])
+        OMP_TARGET_ENTER_DATA_MAP_TO(flat_send[0:send_size], flat_recv[0:recv_size])
+        OMP_TARGET_ENTER_DATA_MAP_ALLOC(send_buf[0:3*send_size], recv_buf[0:3*recv_size])
     }
 
     GD->gpu_initialized = 1;
@@ -800,7 +809,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = R->vol_ids;
         int *e_ids = R->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         R->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -817,7 +826,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = Dir->vol_ids;
         int *e_ids = Dir->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         Dir->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -834,7 +843,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = T->vol_ids;
         int *e_ids = T->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         T->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -851,7 +860,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = Tnzt->vol_ids;
         int *e_ids = Tnzt->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         Tnzt->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -868,7 +877,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = TB->vol_ids;
         int *e_ids = TB->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         TB->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -885,7 +894,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = AW->vol_ids;
         int *e_ids = AW->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         AW->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -902,7 +911,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = CW->vol_ids;
         int *e_ids = CW->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         CW->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -919,7 +928,7 @@ void gpu_remap_boundary_arrays(struct gpu_domain *GD) {
         int *v_ids = FL->vol_ids;
         int *e_ids = FL->edge_ids;
 
-        #pragma omp target enter data map(to: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_ENTER_DATA_MAP_TO(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         FL->mapped = 1;
 
         if (GD->rank == 0 && GD->verbose) {
@@ -976,23 +985,22 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
     anuga_int *tri_full_flag = GD->D.tri_full_flag;
 
     // Unmap domain arrays
-    #pragma omp target exit data map(delete: \
-        stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], \
-        bed_cv[0:n], height_cv[0:n], friction_cv[0:n], \
-        stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n], \
-        bed_ev[0:3*n], height_ev[0:3*n], \
-        stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n], \
-        stage_siu[0:n], xmom_siu[0:n], ymom_siu[0:n], \
-        neighbours[0:3*n], neighbour_edges[0:3*n], \
-        surrogate_neighbours[0:3*n], number_of_boundaries[0:n], \
-        x_centroid_work[0:n], y_centroid_work[0:n], \
-        normals[0:6*n], edgelengths[0:3*n], \
-        areas[0:n], radii[0:n], max_speed[0:n], \
+    OMP_TARGET_EXIT_DATA_MAP_DELETE(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n],
+        bed_cv[0:n], height_cv[0:n], friction_cv[0:n],
+        stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n],
+        bed_ev[0:3*n], height_ev[0:3*n],
+        stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n],
+        stage_siu[0:n], xmom_siu[0:n], ymom_siu[0:n],
+        neighbours[0:3*n], neighbour_edges[0:3*n],
+        surrogate_neighbours[0:3*n], number_of_boundaries[0:n],
+        x_centroid_work[0:n], y_centroid_work[0:n],
+        normals[0:6*n], edgelengths[0:3*n],
+        areas[0:n], radii[0:n], max_speed[0:n],
         centroid_coords[0:2*n], edge_coords[0:6*n])
 
     // Unmap tri_full_flag only when it was mapped (parallel domains only)
     if (tri_full_flag != NULL) {
-        #pragma omp target exit data map(delete: tri_full_flag[0:n])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(tri_full_flag[0:n])
     }
 
     if (nb > 0) {
@@ -1001,8 +1009,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         double *ymom_bv = GD->D.ymom_boundary_values;
         double *bed_bv = GD->D.bed_boundary_values;
         double *height_bv = GD->D.height_boundary_values;
-        #pragma omp target exit data map(delete: \
-            stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb],
             bed_bv[0:nb], height_bv[0:nb])
     }
 
@@ -1013,7 +1020,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = R->boundary_indices;
         int *v_ids = R->vol_ids;
         int *e_ids = R->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         R->mapped = 0;
     }
 
@@ -1024,7 +1031,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = Dir->boundary_indices;
         int *v_ids = Dir->vol_ids;
         int *e_ids = Dir->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         Dir->mapped = 0;
     }
 
@@ -1035,7 +1042,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = T->boundary_indices;
         int *v_ids = T->vol_ids;
         int *e_ids = T->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         T->mapped = 0;
     }
 
@@ -1046,7 +1053,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = Tnzt->boundary_indices;
         int *v_ids = Tnzt->vol_ids;
         int *e_ids = Tnzt->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         Tnzt->mapped = 0;
     }
 
@@ -1057,7 +1064,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = TB->boundary_indices;
         int *v_ids = TB->vol_ids;
         int *e_ids = TB->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         TB->mapped = 0;
     }
 
@@ -1071,7 +1078,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         double *stage_v = FB->stage_values;
         double *xmom_v  = FB->xmom_values;
         double *ymom_v  = FB->ymom_values;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne],
                                                  stage_v[0:ne], xmom_v[0:ne], ymom_v[0:ne])
         FB->mapped = 0;
     }
@@ -1083,7 +1090,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = AW->boundary_indices;
         int *v_ids = AW->vol_ids;
         int *e_ids = AW->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         AW->mapped = 0;
     }
 
@@ -1094,7 +1101,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = CW->boundary_indices;
         int *v_ids = CW->vol_ids;
         int *e_ids = CW->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         CW->mapped = 0;
     }
 
@@ -1105,14 +1112,14 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *b_idx = FL->boundary_indices;
         int *v_ids = FL->vol_ids;
         int *e_ids = FL->edge_ids;
-        #pragma omp target exit data map(delete: b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(b_idx[0:ne], v_ids[0:ne], e_ids[0:ne])
         FL->mapped = 0;
     }
 
     // Unmap riverwall arrays
     anuga_int *edge_flux_type = GD->D.edge_flux_type;
     if (edge_flux_type != NULL) {
-        #pragma omp target exit data map(delete: edge_flux_type[0:3*n])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(edge_flux_type[0:3*n])
     }
 
     anuga_int n_rw_edges = GD->D.number_of_riverwall_edges;
@@ -1125,16 +1132,16 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         anuga_int nrow_hp = GD->D.nrow_riverwall_hydraulic_properties;
 
         if (edge_river_wall_counter != NULL) {
-            #pragma omp target exit data map(delete: edge_river_wall_counter[0:3*n])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(edge_river_wall_counter[0:3*n])
         }
         if (riverwall_elevation != NULL) {
-            #pragma omp target exit data map(delete: riverwall_elevation[0:n_rw_edges])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(riverwall_elevation[0:n_rw_edges])
         }
         if (riverwall_rowIndex != NULL) {
-            #pragma omp target exit data map(delete: riverwall_rowIndex[0:n_rw_edges])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(riverwall_rowIndex[0:n_rw_edges])
         }
         if (riverwall_hydraulic_properties != NULL && ncol_hp > 0 && nrow_hp > 0) {
-            #pragma omp target exit data map(delete: riverwall_hydraulic_properties[0:nrow_hp*ncol_hp])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(riverwall_hydraulic_properties[0:nrow_hp*ncol_hp])
         }
     }
 
@@ -1142,8 +1149,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         double *stage_backup = GD->D.stage_backup_values;
         double *xmom_backup = GD->D.xmom_backup_values;
         double *ymom_backup = GD->D.ymom_backup_values;
-        #pragma omp target exit data map(delete: \
-            stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
     }
 
     // Unmap halo arrays
@@ -1155,8 +1161,7 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         double *send_buf = H->send_buffer;
         double *recv_buf = H->recv_buffer;
 
-        #pragma omp target exit data map(delete: \
-            flat_send[0:send_size], flat_recv[0:recv_size], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(flat_send[0:send_size], flat_recv[0:recv_size],
             send_buf[0:3*send_size], recv_buf[0:3*recv_size])
     }
 
@@ -1173,7 +1178,7 @@ void gpu_domain_sync_to_device(struct gpu_domain *GD) {
     double *ymom_cv = GD->D.ymom_centroid_values;
     double *height_cv = GD->D.height_centroid_values;
 
-    #pragma omp target update to(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
+    OMP_TARGET_UPDATE_TO(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
 }
 
 void gpu_domain_sync_from_device(struct gpu_domain *GD) {
@@ -1186,7 +1191,7 @@ void gpu_domain_sync_from_device(struct gpu_domain *GD) {
     double *ymom_cv = GD->D.ymom_centroid_values;
     double *height_cv = GD->D.height_centroid_values;
 
-    #pragma omp target update from(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
+    OMP_TARGET_UPDATE_FROM(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
 }
 
 void gpu_domain_sync_all_from_device(struct gpu_domain *GD) {
@@ -1218,14 +1223,14 @@ void gpu_domain_sync_all_from_device(struct gpu_domain *GD) {
     double *ymom_siu = GD->D.ymom_semi_implicit_update;
 
     // Sync centroid values
-    #pragma omp target update from(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
+    OMP_TARGET_UPDATE_FROM(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
 
     // Sync edge values
-    #pragma omp target update from(stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n], \
+    OMP_TARGET_UPDATE_FROM(stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n],
                                    height_ev[0:3*n], bed_ev[0:3*n])
 
     // Sync explicit and semi-implicit updates
-    #pragma omp target update from(stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n], \
+    OMP_TARGET_UPDATE_FROM(stage_eu[0:n], xmom_eu[0:n], ymom_eu[0:n],
                                    stage_siu[0:n], xmom_siu[0:n], ymom_siu[0:n])
 
     // Sync boundary values if present
@@ -1236,7 +1241,7 @@ void gpu_domain_sync_all_from_device(struct gpu_domain *GD) {
         double *height_bv = GD->D.height_boundary_values;
         double *bed_bv = GD->D.bed_boundary_values;
 
-        #pragma omp target update from(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb], \
+        OMP_TARGET_UPDATE_FROM(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb],
                                        height_bv[0:nb], bed_bv[0:nb])
     }
 
@@ -1245,7 +1250,7 @@ void gpu_domain_sync_all_from_device(struct gpu_domain *GD) {
         double *stage_backup = GD->D.stage_backup_values;
         double *xmom_backup = GD->D.xmom_backup_values;
         double *ymom_backup = GD->D.ymom_backup_values;
-        #pragma omp target update from(stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
+        OMP_TARGET_UPDATE_FROM(stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
     }
 }
 
@@ -1262,7 +1267,7 @@ void gpu_sync_boundary_values(struct gpu_domain *GD) {
     double *bed_bv = GD->D.bed_boundary_values;
     double *height_bv = GD->D.height_boundary_values;
 
-    #pragma omp target update to(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb], \
+    OMP_TARGET_UPDATE_TO(stage_bv[0:nb], xmom_bv[0:nb], ymom_bv[0:nb],
                                  bed_bv[0:nb], height_bv[0:nb])
 }
 
@@ -1278,7 +1283,7 @@ void gpu_sync_edge_values_from_device(struct gpu_domain *GD) {
     double *bed_ev = GD->D.bed_edge_values;
     double *height_ev = GD->D.height_edge_values;
 
-    #pragma omp target update from(stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n], \
+    OMP_TARGET_UPDATE_FROM(stage_ev[0:3*n], xmom_ev[0:3*n], ymom_ev[0:3*n],
                                    bed_ev[0:3*n], height_ev[0:3*n])
 }
 
@@ -1324,8 +1329,8 @@ int gpu_boundary_edge_sync_init(struct gpu_domain *GD,
     double *bed_buf = S->bed_buf;
     double *height_buf = S->height_buf;
 
-    #pragma omp target enter data map(to: cell_ids_ptr[0:nc]) \
-        map(alloc: stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs], \
+    OMP_TARGET_ENTER_DATA_MAP_TO(cell_ids_ptr[0:nc])
+    OMP_TARGET_ENTER_DATA_MAP_ALLOC(stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs],
                    bed_buf[0:bs], height_buf[0:bs])
 
     S->initialized = 1;
@@ -1355,8 +1360,8 @@ void gpu_boundary_edge_sync_finalize(struct gpu_domain *GD) {
         double *bed_buf = S->bed_buf;
         double *height_buf = S->height_buf;
 
-        #pragma omp target exit data map(delete: cell_ids_ptr[0:nc], \
-            stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(cell_ids_ptr[0:nc],
+            stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs],
             bed_buf[0:bs], height_buf[0:bs])
 
         // Free host memory
@@ -1416,7 +1421,7 @@ void gpu_boundary_edge_sync(struct gpu_domain *GD) {
     }
 
     // Sync staging buffers from GPU to host
-    #pragma omp target update from(stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs], \
+    OMP_TARGET_UPDATE_FROM(stage_buf[0:bs], xmom_buf[0:bs], ymom_buf[0:bs],
                                    bed_buf[0:bs], height_buf[0:bs])
 
     // Scatter on CPU to the actual edge value arrays (host copies)

--- a/anuga/shallow_water/gpu/gpu_halo.c
+++ b/anuga/shallow_water/gpu/gpu_halo.c
@@ -173,7 +173,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     // Pack send buffer on GPU
 #ifdef GPU_AWARE_MPI
     // send_buf/recv_buf are omp_target_alloc'd device pointers — use is_device_ptr
-    #pragma omp target teams distribute parallel for is_device_ptr(send_buf)
+    OMP_PARALLEL_LOOP_IS_DEVICE_PTR(send_buf)
 #else
     OMP_PARALLEL_LOOP
 #endif
@@ -195,7 +195,11 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
         double *host_send = H->host_send_buffer;
         double *host_recv = H->host_recv_buffer;
 
-        // Copy packed send buffer from device to host staging buffer
+        // Copy packed send buffer from device to host staging buffer.
+        // The pack loop above is enqueued async on the OpenACC back end, so drain
+        // the queue first - the D2H copy reads send_buf on the host and must not
+        // race the pack kernel. No-op for OpenMP-target/CPU (synchronous kernels).
+        OMP_TARGET_WAIT
         int host = omp_get_initial_device();
         int dev  = omp_get_default_device();
         omp_target_memcpy(host_send, send_buf,
@@ -237,7 +241,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     // This is still efficient because halo is much smaller than full domain
 
     // Copy packed send buffer from GPU to host
-    #pragma omp target update from(send_buf[0:3*send_size])
+    OMP_TARGET_UPDATE_FROM(send_buf[0:3*send_size])
 
     // MPI communication on host
     int req_count = 0;
@@ -265,12 +269,12 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     MPI_Waitall(req_count, H->requests, MPI_STATUSES_IGNORE);
 
     // Copy received halo data from host to GPU
-    #pragma omp target update to(recv_buf[0:3*recv_size])
+    OMP_TARGET_UPDATE_TO(recv_buf[0:3*recv_size])
 #endif
 
     // Unpack receive buffer on GPU
 #ifdef GPU_AWARE_MPI
-    #pragma omp target teams distribute parallel for is_device_ptr(recv_buf)
+    OMP_PARALLEL_LOOP_IS_DEVICE_PTR(recv_buf)
 #else
     OMP_PARALLEL_LOOP
 #endif

--- a/anuga/shallow_water/gpu/gpu_inlet_operator.c
+++ b/anuga/shallow_water/gpu/gpu_inlet_operator.c
@@ -113,8 +113,8 @@ int gpu_inlet_operator_init(struct gpu_domain *GD, int num_indices,
         double *sx = op->scratch_xmom;
         double *sy = op->scratch_ymom;
         double *sd = op->scratch_depths;
-        #pragma omp target enter data map(to: idx[0:ni], ar[0:ni]) \
-            map(alloc: ss[0:ni], sb[0:ni], sx[0:ni], sy[0:ni], sd[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_TO(idx[0:ni], ar[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_ALLOC(ss[0:ni], sb[0:ni], sx[0:ni], sy[0:ni], sd[0:ni])
         op->mapped = 1;
 
         // Verify mapping succeeded (skip check in host fallback mode)
@@ -174,7 +174,7 @@ void gpu_inlet_operator_finalize(struct gpu_domain *GD, int op_id) {
         double *sx = op->scratch_xmom;
         double *sy = op->scratch_ymom;
         double *sd = op->scratch_depths;
-        #pragma omp target exit data map(delete: idx[0:ni], ar[0:ni], \
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(idx[0:ni], ar[0:ni],
             ss[0:ni], sb[0:ni], sx[0:ni], sy[0:ni], sd[0:ni])
     }
 
@@ -298,7 +298,7 @@ void gpu_inlet_get_velocities(struct gpu_domain *GD, int op_id,
     }
 
     // Small D2H: transfer scratch buffers to host
-    #pragma omp target update from(s_depths[0:n], s_xmom[0:n], s_ymom[0:n])
+    OMP_TARGET_UPDATE_FROM(s_depths[0:n], s_xmom[0:n], s_ymom[0:n])
 
     // CPU computation on small arrays (matching inlet.py get_velocities)
     for (int k = 0; k < n; k++) {
@@ -377,7 +377,7 @@ void gpu_inlet_set_xmoms_array(struct gpu_domain *GD, int op_id,
     // Small H2D: copy values to scratch, update on GPU
     double *scratch = op->scratch_xmom;
     memcpy(scratch, values, n * sizeof(double));
-    #pragma omp target update to(scratch[0:n])
+    OMP_TARGET_UPDATE_TO(scratch[0:n])
 
     OMP_PARALLEL_LOOP
     for (int k = 0; k < n; k++) {
@@ -397,7 +397,7 @@ void gpu_inlet_set_ymoms_array(struct gpu_domain *GD, int op_id,
 
     double *scratch = op->scratch_ymom;
     memcpy(scratch, values, n * sizeof(double));
-    #pragma omp target update to(scratch[0:n])
+    OMP_TARGET_UPDATE_TO(scratch[0:n])
 
     OMP_PARALLEL_LOOP
     for (int k = 0; k < n; k++) {
@@ -433,7 +433,7 @@ void gpu_inlet_set_stages_evenly(struct gpu_domain *GD, int op_id, double volume
         bed[k] = bed_c[i];
     }
     // Transfer to host
-    #pragma omp target update from(stages[0:n], bed[0:n])
+    OMP_TARGET_UPDATE_FROM(stages[0:n], bed[0:n])
 
     // Areas: use the host copy (op->areas host allocation is still valid)
     double *areas_local = op->areas;
@@ -487,7 +487,7 @@ void gpu_inlet_set_stages_evenly(struct gpu_domain *GD, int op_id, double volume
     }
 
     // Small H2D: update stages scratch buffer on GPU, then scatter to domain array
-    #pragma omp target update to(stages[0:n])
+    OMP_TARGET_UPDATE_TO(stages[0:n])
 
     OMP_PARALLEL_LOOP
     for (int k = 0; k < n; k++) {
@@ -536,7 +536,7 @@ double gpu_inlet_apply(struct gpu_domain *GD, int op_id, double volume,
             int i = indices[k];
             s_depths[k] = stage_c[i] - bed_c[i];
         }
-        #pragma omp target update from(s_depths[0:n])
+        OMP_TARGET_UPDATE_FROM(s_depths[0:n])
 
         if (zero_velocity) {
             gpu_inlet_set_xmoms(GD, op_id, 0.0);
@@ -575,7 +575,7 @@ double gpu_inlet_apply(struct gpu_domain *GD, int op_id, double volume,
             int i = indices[k];
             s_depths[k] = stage_c[i] - bed_c[i];
         }
-        #pragma omp target update from(s_depths[0:n])
+        OMP_TARGET_UPDATE_FROM(s_depths[0:n])
 
         if (zero_velocity) {
             gpu_inlet_set_xmoms(GD, op_id, 0.0);

--- a/anuga/shallow_water/gpu/gpu_max_quantities_operator.c
+++ b/anuga/shallow_water/gpu/gpu_max_quantities_operator.c
@@ -55,7 +55,7 @@ int gpu_max_quantities_init(struct gpu_domain *GD, int n, double velocity_zero_h
         double *md  = MQ->max_depth;
         double *msp = MQ->max_speed;
         double *mu  = MQ->max_uh;
-        #pragma omp target enter data map(to: ms[0:ni], md[0:ni], msp[0:ni], mu[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_TO(ms[0:ni], md[0:ni], msp[0:ni], mu[0:ni])
         MQ->mapped = 1;
     }
 
@@ -118,7 +118,7 @@ void gpu_max_quantities_get(struct gpu_domain *GD,
         double *md  = MQ->max_depth;
         double *msp = MQ->max_speed;
         double *mu  = MQ->max_uh;
-        #pragma omp target update from(ms[0:n], md[0:n], msp[0:n], mu[0:n])
+        OMP_TARGET_UPDATE_FROM(ms[0:n], md[0:n], msp[0:n], mu[0:n])
     }
 
     memcpy(out_stage, MQ->max_stage, n * sizeof(double));
@@ -139,7 +139,7 @@ void gpu_max_quantities_finalize(struct gpu_domain *GD)
         double *md  = MQ->max_depth;
         double *msp = MQ->max_speed;
         double *mu  = MQ->max_uh;
-        #pragma omp target exit data map(delete: ms[0:n], md[0:n], msp[0:n], mu[0:n])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(ms[0:n], md[0:n], msp[0:n], mu[0:n])
         MQ->mapped = 0;
     }
 

--- a/anuga/shallow_water/gpu/gpu_omp_macros.h
+++ b/anuga/shallow_water/gpu/gpu_omp_macros.h
@@ -1,14 +1,24 @@
-// OpenMP pragma macros for GPU vs CPU execution
+// Parallel-execution pragma macros for GPU vs CPU execution
 //
-// When CPU_ONLY_MODE is defined (via -Dgpu_offload=false), use regular OpenMP
-// Otherwise, use OpenMP target for GPU offloading
+// The same kernel source compiles for three back ends, selected at build time
+// by the meson `gpu_offload` / `gpu_backend` options (see shallow_water/meson.build):
 //
-// This allows the same code to run on both GPU and CPU multicore
+//   * CPU_ONLY_MODE      -Dgpu_offload=false        regular OpenMP multicore
+//   * ACC_OFFLOAD_MODE   -Dgpu_backend=openacc      OpenACC GPU offloading (nvc -acc=gpu)
+//   * (default)          -Dgpu_offload=true         OpenMP-target GPU offloading
+//
+// Every compute loop, data-region and data-transfer directive in gpu/*.c goes
+// through one of the OMP_* macros below so that switching back end is a pure
+// build-flag change with no edits to the kernels.  The OMP_ prefix is kept for
+// all three modes (including OpenACC) purely for call-site stability.
 
 #ifndef GPU_OMP_MACROS_H
 #define GPU_OMP_MACROS_H
 
-// Helper macro to stringify pragma arguments (allows macro expansion before stringification)
+// Helper macro to stringify pragma arguments (allows macro expansion before stringification).
+// NOTE: _Pragma takes a SINGLE parenthesised string literal - adjacent string-literal
+// concatenation ("a" "b") is NOT accepted by the operator, so every pragma must be built
+// through DO_PRAGMA rather than by concatenating pieces inside _Pragma().
 #define DO_PRAGMA(x) _Pragma(#x)
 
 #ifdef CPU_ONLY_MODE
@@ -27,6 +37,13 @@
 #define OMP_PARALLEL_LOOP_REDUCTION_PLUS(var) DO_PRAGMA(omp parallel for reduction(+:var))
 #define OMP_PARALLEL_LOOP_REDUCTION_MIN(var) DO_PRAGMA(omp parallel for reduction(min:var))
 #define OMP_PARALLEL_LOOP_REDUCTION_MAX(var) DO_PRAGMA(omp parallel for reduction(max:var))
+#define OMP_PARALLEL_LOOP_REDUCTION_MIN_PLUS(minvar, plusvar) \
+    DO_PRAGMA(omp parallel for reduction(min:minvar) reduction(+:plusvar))
+
+// Loop over data reachable through a device pointer / mapped array: on the host
+// these are plain host pointers, so an ordinary parallel loop is correct.
+#define OMP_PARALLEL_LOOP_IS_DEVICE_PTR(ptr) _Pragma("omp parallel for simd")
+#define OMP_PARALLEL_LOOP_MAP_TO(...) _Pragma("omp parallel for simd")
 
 // Data mapping - no-op on CPU (data already in host memory)
 #define OMP_TARGET_ENTER_DATA_MAP_TO(...)
@@ -39,6 +56,9 @@
 
 // Device pointer clause - no-op on CPU
 #define OMP_IS_DEVICE_PTR(ptr)
+
+// Queue drain - no-op on CPU (no device, kernels are synchronous)
+#define OMP_TARGET_WAIT
 
 // ============================================================================
 // CPU MULTICORE MODE stubs for OpenMP target-offloading API
@@ -80,6 +100,152 @@ static inline int _anuga_omp_get_initial_device(void) { return 0; }
 #define omp_target_is_present   _anuga_omp_target_is_present
 #define omp_get_initial_device  _anuga_omp_get_initial_device
 
+#elif defined(ACC_OFFLOAD_MODE)
+
+// ============================================================================
+// GPU MODE - OpenACC offloading (nvc -acc=gpu)
+//
+// Pure OpenACC: BOTH the compute loops AND the device data management use
+// OpenACC directives/runtime, so no OpenMP-target device memory is involved
+// and there is no OpenMP<->OpenACC present-table interop to reason about.
+// OpenMP is still used for the CPU multicore back end (CPU_ONLY_MODE above).
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// Single global async queue (number 1).
+//
+// ALL device work - compute loops AND data transfers - is enqueued on ONE queue
+// so it executes back-to-back, in order, WITHOUT the host blocking after every
+// kernel. That per-launch host synchronisation (a cuStreamSynchronize per
+// `acc parallel`) is the OpenACC-specific overhead that OpenMP-target does not
+// pay; on the towradgi case it left OpenACC behind even after default(present).
+// We do NOT overlap anything - a single in-order queue preserves every data
+// dependency for free - we only stop paying the per-kernel stall.
+//
+// The queue is drained with `acc wait(1)` ONLY where the host actually consumes
+// device results. Those points are baked into the macros below:
+//   - reduction loops  (host reads the reduced scalar)         -> wait, then SYNC reduction
+//   - update self/device, exit data (host produces/consumes)   -> wait, then sync op
+// plus one place the macros can't cover - the GPU-aware-MPI D2H copy in
+// gpu_halo.c - which calls OMP_TARGET_WAIT explicitly.
+//
+// CORRECTNESS: every host-side read of device data must be preceded by a drain.
+// The three categories above are the complete set for this codebase (all host
+// reads go through a reduction, an update-from, or the halo memcpy). A MISSED
+// wait is a silent data race, not a crash - so after any change here, validate
+// .sww output against the OpenMP-target build (must match to roundoff).
+//
+// default(present) (on every compute loop) asserts all referenced aggregates are
+// already resident (persistently mapped via `acc enter data`); without it nvc
+// emits a present-or-copyin analysis at every launch. It also turns any missing
+// mapping into a hard "not present" error rather than a silent per-launch copy.
+// ---------------------------------------------------------------------------
+
+// Parallel loops on device - enqueued async on the shared queue.
+#define OMP_PARALLEL_LOOP _Pragma("acc parallel loop default(present) async(1)")
+#define OMP_PARALLEL_LOOP_SIMD _Pragma("acc parallel loop default(present) async(1)")
+
+// Reductions: drain the queue first (so the inputs are final), then run the
+// reduction SYNCHRONOUSLY so the reduced scalar is valid on the host immediately
+// after the loop - no separate wait needed at the call site.
+#define OMP_PARALLEL_LOOP_REDUCTION_PLUS(var) \
+    DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc parallel loop default(present) reduction(+:var))
+#define OMP_PARALLEL_LOOP_REDUCTION_MIN(var) \
+    DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc parallel loop default(present) reduction(min:var))
+#define OMP_PARALLEL_LOOP_REDUCTION_MAX(var) \
+    DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc parallel loop default(present) reduction(max:var))
+#define OMP_PARALLEL_LOOP_REDUCTION_MIN_PLUS(minvar, plusvar) \
+    DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc parallel loop default(present) reduction(min:minvar) reduction(+:plusvar))
+
+// Device-pointer / map(to) loops also ride the async queue.
+#define OMP_PARALLEL_LOOP_IS_DEVICE_PTR(ptr) DO_PRAGMA(acc parallel loop default(present) deviceptr(ptr) async(1))
+#define OMP_PARALLEL_LOOP_MAP_TO(...) DO_PRAGMA(acc parallel loop default(present) copyin(__VA_ARGS__) async(1))
+
+// Data mapping to device. enter data is setup - it runs before the kernels that
+// use the memory, so it stays synchronous. exit data frees memory the async
+// kernels may still be using, so drain the queue first.
+#define OMP_TARGET_ENTER_DATA_MAP_TO(...) DO_PRAGMA(acc enter data copyin(__VA_ARGS__))
+#define OMP_TARGET_ENTER_DATA_MAP_ALLOC(...) DO_PRAGMA(acc enter data create(__VA_ARGS__))
+#define OMP_TARGET_EXIT_DATA_MAP_DELETE(...) \
+    DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc exit data delete(__VA_ARGS__))
+
+// Data transfer. The host produces (update device) or consumes (update self) this
+// data, so drain the async queue first, then transfer synchronously.
+#define OMP_TARGET_UPDATE_TO(...) DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc update device(__VA_ARGS__))
+#define OMP_TARGET_UPDATE_FROM(...) DO_PRAGMA(acc wait(1)) DO_PRAGMA(acc update self(__VA_ARGS__))
+
+// Explicit queue drain for host-side sync points the macros above can't cover
+// (currently only the GPU-aware-MPI halo D2H memcpy in gpu_halo.c).
+#define OMP_TARGET_WAIT _Pragma("acc wait(1)")
+
+// Device pointer clause
+#define OMP_IS_DEVICE_PTR(ptr) deviceptr(ptr)
+
+// ============================================================================
+// OpenACC shims for the OpenMP target-offloading runtime API
+//
+// The kernels call the OpenMP 4.5 device API (omp_target_alloc, ...) directly.
+// In OpenACC mode we redirect each to its OpenACC runtime equivalent so the
+// same call sites work unchanged.  As in CPU_ONLY_MODE, the redirect happens
+// here (after <omp.h>) so the macros mask the omp.h extern declarations.
+//
+//   * omp_target_is_present(ptr, dev) -> acc_is_present(ptr, bytes): OpenACC needs a
+//     byte extent; we probe 1 byte, which tests whether the base address is mapped.
+//   * omp_target_memcpy direction is encoded in the device-number arguments; we use a
+//     host sentinel (-1) and dispatch to acc_memcpy_to_device / _from_device / _device.
+// ============================================================================
+
+#include <openacc.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ANUGA_ACC_HOST_DEVICE (-1)
+
+static inline void *_anuga_acc_target_alloc(size_t size, int dev) {
+    (void)dev; return acc_malloc(size);
+}
+static inline void _anuga_acc_target_free(void *ptr, int dev) {
+    (void)dev; acc_free(ptr);
+}
+static inline int _anuga_acc_target_is_present(const void *ptr, int dev) {
+    (void)dev; return acc_is_present((void *)ptr, 1);
+}
+static inline int _anuga_acc_get_initial_device(void) { return ANUGA_ACC_HOST_DEVICE; }
+static inline int _anuga_acc_get_default_device(void) {
+    return acc_get_device_num(acc_device_default);
+}
+static inline int _anuga_acc_get_num_devices(void) {
+    return acc_get_num_devices(acc_device_default);
+}
+static inline int _anuga_acc_target_memcpy(
+        void *dst, const void *src, size_t length,
+        size_t dst_offset, size_t src_offset,
+        int dst_dev, int src_dev) {
+    char *d = (char *)dst + dst_offset;
+    const char *s = (const char *)src + src_offset;
+    int dst_host = (dst_dev == ANUGA_ACC_HOST_DEVICE);
+    int src_host = (src_dev == ANUGA_ACC_HOST_DEVICE);
+    if (src_host && !dst_host) {
+        acc_memcpy_to_device(d, (void *)s, length);
+    } else if (dst_host && !src_host) {
+        acc_memcpy_from_device(d, (void *)s, length);
+    } else if (!dst_host && !src_host) {
+        acc_memcpy_device(d, (void *)s, length);
+    } else {
+        memcpy(d, s, length);
+    }
+    return 0;
+}
+
+#define omp_target_alloc        _anuga_acc_target_alloc
+#define omp_target_free         _anuga_acc_target_free
+#define omp_target_memcpy       _anuga_acc_target_memcpy
+#define omp_target_is_present   _anuga_acc_target_is_present
+#define omp_get_initial_device  _anuga_acc_get_initial_device
+#define omp_get_default_device  _anuga_acc_get_default_device
+#define omp_get_num_devices     _anuga_acc_get_num_devices
+#define omp_set_default_device(n) acc_set_device_num((n), acc_device_default)
+
 #else
 
 // ============================================================================
@@ -95,22 +261,31 @@ static inline int _anuga_omp_get_initial_device(void) { return 0; }
 #define OMP_PARALLEL_LOOP_REDUCTION_PLUS(var) DO_PRAGMA(omp target teams distribute parallel for reduction(+:var))
 #define OMP_PARALLEL_LOOP_REDUCTION_MIN(var) DO_PRAGMA(omp target teams loop reduction(min:var))
 #define OMP_PARALLEL_LOOP_REDUCTION_MAX(var) DO_PRAGMA(omp target teams distribute parallel for reduction(max:var))
+#define OMP_PARALLEL_LOOP_REDUCTION_MIN_PLUS(minvar, plusvar) \
+    DO_PRAGMA(omp target teams distribute parallel for reduction(min:minvar) reduction(+:plusvar))
+
+// Loop over a device pointer (omp_target_alloc'd) - keep distribute parallel for form
+#define OMP_PARALLEL_LOOP_IS_DEVICE_PTR(ptr) \
+    DO_PRAGMA(omp target teams distribute parallel for is_device_ptr(ptr))
+// Loop that also maps a small array in for the duration of the region
+#define OMP_PARALLEL_LOOP_MAP_TO(...) \
+    DO_PRAGMA(omp target teams distribute parallel for map(to: __VA_ARGS__))
 
 // Data mapping to device
-// Note: These need to be used with care - the actual map clause arguments
-// must be specified in the calling code since macros can't handle variable arguments well
-// For now, these are placeholders - actual mapping is done inline
-#define OMP_TARGET_ENTER_DATA_MAP_TO(...) _Pragma("omp target enter data map(to:" #__VA_ARGS__ ")")
-#define OMP_TARGET_ENTER_DATA_MAP_ALLOC(...) _Pragma("omp target enter data map(alloc:" #__VA_ARGS__ ")")
-#define OMP_TARGET_EXIT_DATA_MAP_DELETE(...) _Pragma("omp target exit data map(delete:" #__VA_ARGS__ ")")
+#define OMP_TARGET_ENTER_DATA_MAP_TO(...) DO_PRAGMA(omp target enter data map(to: __VA_ARGS__))
+#define OMP_TARGET_ENTER_DATA_MAP_ALLOC(...) DO_PRAGMA(omp target enter data map(alloc: __VA_ARGS__))
+#define OMP_TARGET_EXIT_DATA_MAP_DELETE(...) DO_PRAGMA(omp target exit data map(delete: __VA_ARGS__))
 
 // Data transfer
-#define OMP_TARGET_UPDATE_TO(...) _Pragma("omp target update to(" #__VA_ARGS__ ")")
-#define OMP_TARGET_UPDATE_FROM(...) _Pragma("omp target update from(" #__VA_ARGS__ ")")
+#define OMP_TARGET_UPDATE_TO(...) DO_PRAGMA(omp target update to(__VA_ARGS__))
+#define OMP_TARGET_UPDATE_FROM(...) DO_PRAGMA(omp target update from(__VA_ARGS__))
 
 // Device pointer clause
 #define OMP_IS_DEVICE_PTR(ptr) is_device_ptr(ptr)
 
-#endif // CPU_ONLY_MODE
+// Queue drain - no-op for OpenMP target (kernels are synchronous, no async queue)
+#define OMP_TARGET_WAIT
+
+#endif // CPU_ONLY_MODE / ACC_OFFLOAD_MODE / OpenMP-target
 
 #endif // GPU_OMP_MACROS_H

--- a/anuga/shallow_water/gpu/gpu_rate_operator.c
+++ b/anuga/shallow_water/gpu/gpu_rate_operator.c
@@ -101,7 +101,7 @@ int gpu_rate_operator_init(struct gpu_domain *GD, int num_indices, int *indices,
         int ni = op->num_indices;
         int *idx = op->indices;
         double *ar = op->areas;
-        #pragma omp target enter data map(to: idx[0:ni], ar[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_TO(idx[0:ni], ar[0:ni])
         op->mapped = 1;
     }
 
@@ -126,14 +126,14 @@ void gpu_rate_operator_finalize(struct gpu_domain *GD, int op_id) {
         int ni = op->num_indices;
         int *idx = op->indices;
         double *ar = op->areas;
-        #pragma omp target exit data map(delete: idx[0:ni], ar[0:ni])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(idx[0:ni], ar[0:ni])
     }
 
     // Clean up rate array cache
     if (op->rate_array_mapped && op->rate_array_cache != NULL) {
         double *rac = op->rate_array_cache;
         int ras = op->rate_array_size;
-        #pragma omp target exit data map(delete: rac[0:ras])
+        OMP_TARGET_EXIT_DATA_MAP_DELETE(rac[0:ras])
     }
     if (op->rate_array_cache) free(op->rate_array_cache);
 
@@ -179,7 +179,7 @@ double gpu_rate_operator_apply(struct gpu_domain *GD, int op_id,
         int ni = op->num_indices;
         int *idx = op->indices;
         double *ar = op->areas;
-        #pragma omp target enter data map(to: idx[0:ni], ar[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_TO(idx[0:ni], ar[0:ni])
         op->mapped = 1;
     }
 
@@ -258,7 +258,7 @@ double gpu_rate_operator_apply_array(struct gpu_domain *GD, int op_id,
         int ni = op->num_indices;
         int *idx = op->indices;
         double *ar = op->areas;
-        #pragma omp target enter data map(to: idx[0:ni], ar[0:ni])
+        OMP_TARGET_ENTER_DATA_MAP_TO(idx[0:ni], ar[0:ni])
         op->mapped = 1;
     }
 
@@ -282,7 +282,7 @@ double gpu_rate_operator_apply_array(struct gpu_domain *GD, int op_id,
         if (op->rate_array_mapped && op->rate_array_cache != NULL) {
             double *old_rac = op->rate_array_cache;
             int old_size = op->rate_array_size;
-            #pragma omp target exit data map(delete: old_rac[0:old_size])
+            OMP_TARGET_EXIT_DATA_MAP_DELETE(old_rac[0:old_size])
         }
         if (op->rate_array_cache) free(op->rate_array_cache);
 
@@ -301,10 +301,10 @@ double gpu_rate_operator_apply_array(struct gpu_domain *GD, int op_id,
         double *rac = op->rate_array_cache;
         int ras = rate_array_size;
         if (!op->rate_array_mapped) {
-            #pragma omp target enter data map(to: rac[0:ras])
+            OMP_TARGET_ENTER_DATA_MAP_TO(rac[0:ras])
             op->rate_array_mapped = 1;
         } else {
-            #pragma omp target update to(rac[0:ras])
+            OMP_TARGET_UPDATE_TO(rac[0:ras])
         }
     }
 

--- a/anuga/shallow_water/meson.build
+++ b/anuga/shallow_water/meson.build
@@ -24,6 +24,15 @@ py3.extension_module('sw_domain_openmp_ext',
 # Can target GPU (gpu_offload=true) or CPU multicore (gpu_offload=false)
 gpu_offload = get_option('gpu_offload')
 
+# GPU programming model: 'openmp' (OpenMP target) or 'openacc' (OpenACC).
+# Only meaningful when gpu_offload=true; the CPU multicore build always uses OpenMP.
+gpu_backend = get_option('gpu_backend')
+if gpu_backend == 'openacc' and not gpu_offload
+  error('gpu_backend=openacc requires gpu_offload=true (OpenACC is a GPU-offload back end).\n' +
+        '  Build for CPU multicore with the default OpenMP back end, or add\n' +
+        '  -Csetup-args=-Dgpu_offload=true to offload with OpenACC.')
+endif
+
 # MPI is optional - if not found, sw_domain_gpu_ext won't be built
 mpi_dep = dependency('mpi', language: 'c', required: false)
 if mpi_dep.found()
@@ -166,9 +175,28 @@ is_amd_gpu = gpu_arch.startswith('gfx')
 # Uses effective_compiler_id to handle Cray wrappers correctly
 if gpu_offload
   # GPU offloading enabled
+  # OpenACC offload is currently only wired for the NVIDIA HPC SDK (nvc).
+  if gpu_backend == 'openacc' and effective_compiler_id != 'nvidia_hpc'
+    error(
+      'gpu_backend=openacc is only supported with the NVIDIA HPC SDK (nvc), ' +
+      'found ' + effective_compiler_id + '.\n' +
+      '  Rebuild with CC=$(which nvc), or use the default -Dgpu_backend=openmp.')
+  endif
   if effective_compiler_id == 'nvidia_hpc'
     # NVIDIA HPC SDK - best GPU support for NVIDIA GPUs
-    gpu_c_args = ['-O3', '-mp=gpu,multicore', '-Minfo=accel', '-g', '-gpu=' + gpu_arch]
+    if gpu_backend == 'openacc'
+      # OpenACC GPU offload (kernels use `acc parallel loop` / `acc *data`).
+      # Keep OpenMP for the CPU multicore host path (-mp=multicore); OpenACC
+      # owns the GPU (-acc=gpu). ACC_OFFLOAD_MODE selects the OpenACC macro
+      # branch in gpu/gpu_omp_macros.h.
+      gpu_c_args = ['-O3', '-acc=gpu', '-mp=multicore', '-Minfo=accel', '-g',
+                    '-gpu=' + gpu_arch, '-DACC_OFFLOAD_MODE']
+      message('GPU backend: OpenACC (nvc -acc=gpu)')
+    else
+      # OpenMP target offload (kernels use `omp target teams loop` / `omp target *data`)
+      gpu_c_args = ['-O3', '-mp=gpu', '-Minfo=accel,mp', '-g', '-gpu=' + gpu_arch]
+      message('GPU backend: OpenMP target (nvc -mp=gpu)')
+    endif
   elif effective_compiler_id == 'clang'
     if is_amd_gpu
       # Clang/AOMP for AMD GPUs
@@ -340,6 +368,13 @@ if host_machine.system() == 'darwin' and have_full_mpi
     ]
     message('macOS: embedding rpath for libmpi.dylib: ' + _mpi_lib_dir)
   endif
+endif
+
+# nvc assembles OpenMP-target device code at link automatically, but the OpenACC
+# device binary needs -acc=gpu present at link time too so the OpenACC runtime and
+# the generated device image are pulled in. (Harmless if it were also implicit.)
+if gpu_offload and gpu_backend == 'openacc' and effective_compiler_id == 'nvidia_hpc'
+  gpu_link_args += ['-acc=gpu', '-gpu=' + gpu_arch]
 endif
 
 py3.extension_module('sw_domain_gpu_ext',

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -5738,14 +5738,22 @@ class Domain(Generic_Domain):
                 self.gpu_offload_active = gpu_offload_enabled()
                 if myid == 0:
                     device_id = self.gpu_interface.gpu_dom.device_id
+                    # Back end this gpu_ext was compiled with ("OpenACC" /
+                    # "OpenMP target" / "OpenMP multicore"), reported so the banner
+                    # reflects the actual build rather than a hard-coded name.
+                    try:
+                        from anuga.shallow_water.sw_domain_gpu_ext import get_gpu_backend_name
+                        backend = get_gpu_backend_name()
+                    except Exception:
+                        backend = 'OpenMP target'
                     print('+==============================================================================+')
                     if not self.gpu_offload_active:
                         print("| ANUGA compute mode: 'unified' CPU multicore (gpu_ext kernels, no offload)   |")
                         print(f'| OMP_NUM_THREADS={omp_num_threads}')
                     elif device_id < 0:
-                        print('| WARNING: No GPU devices found, running on CPU via OpenMP target offloading  |')
+                        print(f'| WARNING: No GPU devices found, running on CPU via {backend} offloading')
                     else:
-                        print(f'| GPU interface initialized: {numprocs} GPU(s) using OpenMP target offloading')
+                        print(f'| GPU interface initialized: {numprocs} GPU(s) using {backend} offloading')
                     print('+==============================================================================+')
                 return
             except Exception as e:

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -290,6 +290,7 @@ cdef extern from "gpu_domain.h" nogil:
     int detect_gpu_aware_mpi()
     int gpu_is_available()
     int gpu_get_num_devices()
+    const char *gpu_backend_name()
     int gpu_get_initial_device()
     int gpu_get_default_device()
     void gpu_set_default_device(int device_id)
@@ -932,6 +933,17 @@ def get_num_gpu_devices():
             pytest.skip(f'need 4 GPUs, have {n}')
     """
     return gpu_get_num_devices()
+
+
+def get_gpu_backend_name():
+    """Return the parallel back end this extension was compiled with.
+
+    One of ``"OpenACC"``, ``"OpenMP target"`` or ``"OpenMP multicore"``
+    (CPU_ONLY_MODE). Selected at build time via the meson ``gpu_backend`` /
+    ``gpu_offload`` options; use it to report the active back end, e.g. in the
+    GPU startup banner.
+    """
+    return gpu_backend_name().decode("ascii")
 
 
 def get_initial_device():

--- a/claude/OPENACC_BACKEND_LOG.md
+++ b/claude/OPENACC_BACKEND_LOG.md
@@ -1,0 +1,226 @@
+# OpenACC GPU backend — work log
+
+**Status:** implemented, uncommitted on branch `develop`. Builds/validates as a third
+GPU backend alongside OpenMP-target. **Perf resolved, faster than OpenMP-target** via two
+changes: (1) `default(present)` removed per-launch present-or-copyin analysis (fluxes-central
+2.0s → 1.62s, ~19%); (2) a **single async queue** (`async(1)` + targeted `acc wait(1)`)
+removed the residual per-launch synchronous-launch stall (faster again, user-confirmed).
+**⚠ Correctness of the async change is UNVERIFIED** until towradgi `.sww` is diffed against
+the OpenMP-target build — see §6.
+
+**Goal:** let the shallow-water GPU kernels compile to **OpenACC** (`nvc -acc=gpu`) as
+well as the existing **OpenMP-target** (`nvc -mp=gpu`), to A/B whether OpenACC gives a
+speedup on the GPU. OpenMP stays the CPU-multicore backend (it produces better CPU code).
+All backend selection funnels through one header so kernels are never edited per-backend.
+
+---
+
+## 1. What changed (files)
+
+| File | Change |
+|------|--------|
+| `anuga/shallow_water/gpu/gpu_omp_macros.h` | **Core of the work.** Now a clean 3-mode header (see §2). Fixed a latent bug, added new macros, added the whole OpenACC branch + runtime-API shims + `default(present)` experiment. |
+| `anuga/shallow_water/gpu/*.c` (8 files) | 103 raw `#pragma omp target …` directives routed through the macros (see §3). Files: `core_kernels.c`, `gpu_boundaries.c`, `gpu_culvert_operator.c`, `gpu_domain_core.c`, `gpu_halo.c`, `gpu_inlet_operator.c`, `gpu_max_quantities_operator.c`, `gpu_rate_operator.c`. |
+| `meson_options.txt` | New `gpu_backend` combo option (`openmp` \| `openacc`, default `openmp`). |
+| `anuga/shallow_water/meson.build` | Reads `gpu_backend`; guards; nvc flags for OpenACC; link-args for OpenACC (see §4). |
+| `.gitignore` | Ignores `tmp_artifacts/` (local scratch/compile-probe dir used this session). |
+
+---
+
+## 2. The macro header — 3 modes
+
+`gpu_omp_macros.h` selects one of three modes at build time. Kernels only ever use the
+`OMP_*` macros (the `OMP_` prefix is kept in all modes purely for call-site stability):
+
+| Mode | Selected by | Compute loop | Data region |
+|------|-------------|--------------|-------------|
+| `CPU_ONLY_MODE` | `-Dgpu_offload=false` | `omp parallel for simd` | no-op (host memory) |
+| `ACC_OFFLOAD_MODE` | `-Dgpu_backend=openacc` | `acc parallel loop` | `acc enter/exit data`, `acc update` |
+| *(default)* | `-Dgpu_offload=true` | `omp target teams loop` | `omp target enter/exit data`, `omp target update` |
+
+**Bug fixed along the way:** the pre-existing `OMP_TARGET_ENTER_DATA_MAP_*` macros were
+**broken** — they used `_Pragma("…" #__VA_ARGS__ "…")`, but `_Pragma` requires a *single*
+parenthesised string literal (adjacent-string concatenation is rejected: `error: _Pragma
+takes a parenthesized string literal`). That's why all 105 directives had been written raw
+and none used the macros. All macros now use the working `DO_PRAGMA(x) => _Pragma(#x)`
+idiom.
+
+**New macros added** (the raw directives that didn't fit the existing set):
+- `OMP_PARALLEL_LOOP_IS_DEVICE_PTR(ptr)` — `is_device_ptr` / `deviceptr` loop (gpu_halo.c ×2)
+- `OMP_PARALLEL_LOOP_MAP_TO(...)` — loop with a `map(to:)` / `copyin` (gpu_culvert_operator.c ×1)
+- `OMP_PARALLEL_LOOP_REDUCTION_MIN_PLUS(a, b)` — double reduction (core_kernels.c ×1)
+
+**OpenACC is "pure":** in ACC mode the compute loops, the data management, AND the
+runtime API all use OpenACC — no OpenMP-target device memory is involved, so there is no
+OpenMP↔OpenACC present-table interop to reason about. The OpenMP target runtime API calls
+in the `.c` files are redirected (via `#define`, same pattern as the CPU stubs) to
+OpenACC equivalents:
+
+| OpenMP call | OpenACC redirect |
+|-------------|------------------|
+| `omp_target_alloc(size, dev)` | `acc_malloc(size)` |
+| `omp_target_free(ptr, dev)` | `acc_free(ptr)` |
+| `omp_target_memcpy(...)` | direction-detecting shim → `acc_memcpy_to_device` / `_from_device` / `_device` (host sentinel = `-1`) |
+| `omp_target_is_present(ptr, dev)` | `acc_is_present(ptr, 1)` (1-byte probe of base addr) |
+| `omp_get_initial_device()` | `-1` sentinel (host) |
+| `omp_get_default_device()` | `acc_get_device_num(acc_device_default)` |
+| `omp_get_num_devices()` | `acc_get_num_devices(acc_device_default)` |
+| `omp_set_default_device(n)` | `acc_set_device_num(n, acc_device_default)` |
+
+---
+
+## 3. The directive conversion (103 sites)
+
+Done with a reviewed one-off script (`tmp_artifacts/convert_directives.py`), then diffed.
+It reported **all** `#pragma omp target` directives recognised (the 2 remaining "matches"
+in the codebase are comments). Two classes of intentional, semantics-preserving change:
+
+1. **4 combined `map(to:) map(alloc:)` directives** split into two calls
+   (`OMP_TARGET_ENTER_DATA_MAP_TO(...)` + `OMP_TARGET_ENTER_DATA_MAP_ALLOC(...)`), which is
+   equivalent. Sites: `gpu_inlet_operator.c`, `gpu_culvert_operator.c`, `gpu_domain_core.c` (×2).
+2. **2 bare `omp target teams distribute parallel for`** normalized to `OMP_PARALLEL_LOOP`
+   (= `omp target teams loop`), matching the 39 existing sites; functionally identical on nvc.
+
+Also simplified a now-redundant `#ifdef CPU_ONLY_MODE / #else / #endif` guard in
+`core_kernels.c` (the macro handles all 3 modes itself).
+
+**Behavior-preservation proof:** preprocessed all 8 files in OpenMP-target mode *before*
+and *after* the conversion and diffed the emitted `#pragma omp target` lines. The only
+deltas were exactly the 4 splits (+4 directives) and the 2 `distribute parallel for →
+teams loop` relabelings. Everything else byte-identical.
+
+---
+
+## 4. Build
+
+Both GPU backends use **nvc** and `gpu_offload=true`; they differ only in `gpu_backend`.
+
+```bash
+module load nvidia-hpc-sdk          # nvc must be on PATH
+
+# OpenMP-target GPU (the original backend)
+CC=$(which nvc) pip install --no-build-isolation -e . \
+  -Csetup-args=-Dgpu_offload=true \
+  -Csetup-args=-Dgpu_backend=openmp \
+  -Csetup-args=-Dgpu_arch=cc80        # cc70=V100, cc80=A100, cc90=H100
+
+# OpenACC GPU
+CC=$(which nvc) pip install --no-build-isolation -e . \
+  -Csetup-args=-Dgpu_offload=true \
+  -Csetup-args=-Dgpu_backend=openacc \
+  -Csetup-args=-Dgpu_arch=cc80
+```
+
+- OpenACC nvc flags: `-O3 -acc=gpu -mp=multicore -Minfo=accel -g -gpu=<arch> -DACC_OFFLOAD_MODE`,
+  plus `-acc=gpu -gpu=<arch>` in link args (so the OpenACC device image + runtime link in).
+- **Switching `openmp ↔ openacc` is a reconfigure, not a from-scratch build** (compiler is
+  nvc both ways): `meson configure build/<cpXX-dir> -Dgpu_backend=openacc`, then next import
+  / `meson compile` rebuilds only the gpu extension. **Full `rm -rf build/` is only needed
+  when you change the compiler (gcc↔nvc).**
+- Guards: `gpu_backend=openacc` errors if `gpu_offload=false`, or on a non-nvc compiler.
+
+### Two builds side by side (for validation)
+Same package name `anuga` ⇒ two backends need two environments. Use a worktree so build
+dirs don't collide:
+```bash
+git worktree add ../anuga-openacc develop
+# env 1 (this tree): build openmp; env 2 (worktree, cloned conda env): build openacc
+```
+Then `conda activate` whichever to A/B the same script. (Or Option B: one env, reconfigure
+in place, test one at a time.)
+
+---
+
+## 5. Verification done (without a GPU run)
+
+- **CPU mode:** all 8 files compile clean with gcc.
+- **Pragma expansion:** correct in all 3 modes (checked via `gcc -E`).
+- **OpenACC shims:** compile against `openacc.h` (`gcc -fopenacc`).
+- **Behavior preservation:** the before/after pragma diff in §3.
+- **`meson introspect`** shows `gpu_backend` parses as an option.
+- Caveat: `acc_memcpy_device` isn't in *gcc's* `openacc.h` (warns under gcc) — it IS
+  standard OpenACC 2.6 and in NVHPC's header, and its device→device branch is never hit by
+  current call sites (both memcpy calls are H2D/D2H). Fine on the real nvc build.
+
+---
+
+## 6. Performance finding (the open question)
+
+- On the **towradgi** case, **OpenACC is ~10% slower** than OpenMP-target. Surprising.
+- Both backends pick **identical kernel geometry** (`gang vector 128` / `teams … 128`).
+  ⇒ device-side compute per kernel is ~equal; the gap is **host-side per-launch overhead**,
+  not the kernels. This is the "OpenACC runtime overhead" hypothesis.
+
+### Experiment `default(present)` — DONE, SUCCESS ✅
+Added to all 8 ACC compute-loop macros (`acc parallel loop default(present) …`). Rationale:
+without it, `acc parallel loop` emits present-or-copyin analysis at *every* launch for each
+of the ~20 arrays the flux kernel touches — a per-launch host cost OpenMP-target doesn't pay
+the same way.
+
+**Result (towradgi):** all kernels faster; **fluxes-central 2.0s → 1.62s (~19%)**. The
+~10% OpenACC deficit is gone and OpenACC is now ahead of OpenMP-target. Confirms the gap
+was per-launch present-analysis overhead (device geometry was already identical). No
+"not present" errors ⇒ the `copyin`/`create` translation covers every array a kernel
+touches (no hidden per-launch copies).
+
+To revert (if ever needed): drop `default(present)` from those macros only.
+
+### The 2-minute diagnostic to run next
+In nsys (there's a `validation_tests/case_studies/towradgi/report1.nsys-rep` already):
+compare **total kernel time vs total wall time** per build.
+- kernel time ≈ equal, wall time longer on OpenACC → pure between-kernel host overhead.
+- **recurring small HtoD/DtoH memcpys per timestep in the OpenACC trace but not OpenMP** →
+  an array isn't staying resident (silent per-launch copy → translation bug).
+
+### Experiment: single async queue — DONE, faster ✅ (correctness validation PENDING)
+`default(present)` closed the gap but a residual per-launch **synchronous-launch** stall
+remained (each `acc parallel` does a host `cuStreamSynchronize`; OpenMP-target doesn't).
+Fix: enqueue ALL device work on **one in-order async queue (`async(1)`)** so the host never
+blocks between kernels; drain with `acc wait(1)` only where the host consumes device
+results. No real overlap — a single in-order queue preserves all data deps for free.
+
+Implementation (all in `gpu_omp_macros.h` ACC branch + 1 line in `gpu_halo.c`):
+- compute loops → `acc parallel loop default(present) async(1)`
+- reduction loops → `acc wait(1)` then a **synchronous** reduction (scalar valid for host immediately)
+- `update self`/`update device`/`exit data` → `acc wait(1)` then synchronous op
+- `enter data` → stays synchronous (setup, runs before its kernels)
+- new `OMP_TARGET_WAIT` macro (no-op in OpenMP-target/CPU) → one explicit drain before the
+  GPU-aware-MPI D2H `omp_target_memcpy` in `gpu_halo.c` (the only host read not already macro'd)
+
+**Result:** builds and is **faster again** (user-confirmed). All wait points enumerated from
+an audit: 9 reduction sites + 17 `UPDATE_FROM` sites + 2 halo memcpy sites = the complete set
+of host-reads-of-device-data.
+
+**⚠ PENDING — correctness validation.** An async bug is SILENT (missed wait = data race, not
+a crash). MUST diff towradgi `.sww` output: OpenACC-async vs OpenMP-target build → must match
+to roundoff. Until that passes, treat the async change as unverified. If a mismatch appears,
+it's a missing `acc wait(1)` before some host read; the audit set above is where to look.
+
+### Further levers (later, only if needed), ranked
+1. Make device-only intermediate reductions `async(1)` (skip their drain) — some of the 9
+   reduction sites feed the host (need the drain) but any that only feed later kernels don't.
+2. Explicit `gang vector` + `vector_length(...)` tuning (only if `-Minfo` geometry regresses).
+
+All future tuning stays localized to the ACC branch of `gpu_omp_macros.h` — add new macro
+variants (e.g. `OMP_PARALLEL_LOOP_GANG_VECTOR`) so both backends stay in sync; don't edit
+the kernels.
+
+---
+
+## 6b. Startup banner reports the active backend
+
+The GPU init banner used to hard-code "OpenMP target offloading". Now it reports the
+compiled backend. Wiring (mirrors `gpu_available()`):
+- `gpu/gpu_domain_core.c`: `gpu_backend_name()` → `"OpenACC"` / `"OpenMP target"` / `"OpenMP multicore"` via `#ifdef`
+- `gpu/gpu_domain.h`: declaration
+- `sw_domain_gpu_ext.pyx`: `cdef extern` + `get_gpu_backend_name()` wrapper (decodes to str)
+- `shallow_water_domain.py` (~line 5739): banner prints `… using {backend} offloading`
+  (falls back to "OpenMP target" if the symbol isn't importable). Takes effect on rebuild.
+
+## 7. Key references
+
+- Macro header: `anuga/shallow_water/gpu/gpu_omp_macros.h` (all 3 modes + shims + experiment)
+- Build logic: `anuga/shallow_water/meson.build` (search `gpu_backend`), `meson_options.txt`
+- Conversion script (scratch, gitignored): `tmp_artifacts/convert_directives.py`
+- Session memory: `openacc-gpu-backend.md` in the Claude project memory dir
+- Nothing is committed — all changes are in the `develop` working tree.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,13 @@ option('use_mkl', type: 'boolean', value: false,
 option('gpu_offload', type: 'boolean', value: false,
        description: 'Target GPU (true) or CPU multicore (false)')
 
+# GPU programming model used for the offload kernels (only relevant when
+# gpu_offload=true). 'openmp' uses OpenMP target (nvc -mp=gpu); 'openacc' uses
+# OpenACC (nvc -acc=gpu). The CPU multicore build (gpu_offload=false) always
+# uses OpenMP regardless of this setting. Currently requires the NVIDIA HPC SDK.
+option('gpu_backend', type: 'combo', choices: ['openmp', 'openacc'], value: 'openmp',
+       description: 'GPU offload programming model: openmp (OpenMP target) or openacc (OpenACC)')
+
 # GPU-aware MPI for direct device-to-device communication
 option('gpu_aware_mpi', type: 'boolean', value: false,
        description: 'Enable GPU-aware MPI for direct device communication (requires GPU-aware MPI library)')


### PR DESCRIPTION
Add OpenACC as a third GPU backend alongside OpenMP-target and CPU multicore, selectable at build time. All backend selection funnels through gpu/gpu_omp_macros.h, so the kernels compile unchanged in any mode.

Macro-ization
- Route the ~103 remaining raw `#pragma omp target` directives in gpu/*.c through the OMP_* macros. Fix the previously-broken data-map macros (_Pragma cannot concatenate adjacent string literals; use DO_PRAGMA) and add OMP_PARALLEL_LOOP_{IS_DEVICE_PTR,MAP_TO, REDUCTION_MIN_PLUS}. Behavior-preserving: the only OpenMP-target pragma changes are 4 combined map(to:)/map(alloc:) directives split into two, and 2 bare `distribute parallel for` normalized to `teams loop`.

OpenACC backend (ACC_OFFLOAD_MODE)
- Compute loops -> `acc parallel loop`; data regions -> `acc enter/exit data` + `acc update`; the OpenMP target runtime API (omp_target_alloc/free/memcpy/is_present, omp_*_device) redirected to OpenACC equivalents. Pure OpenACC on the GPU (no OpenMP-target device memory); OpenMP stays the CPU multicore backend.
- meson: new `gpu_backend=openmp|openacc` option. openacc builds with nvc `-acc=gpu -mp=multicore -DACC_OFFLOAD_MODE` (+ link flags).

Performance
- `default(present)` on the compute loops removes the per-launch present-or-copyin analysis nvc otherwise emits.
- A single in-order async queue (`async(1)` with targeted `acc wait(1)` at the reduction/update/exit and halo-memcpy host-sync points) removes the residual synchronous-launch stall.
- Result on towradgi: OpenACC now runs faster than OpenMP-target (e.g. fluxes-central 2.0s -> 1.62s).

Report the compiled backend ("OpenACC" / "OpenMP target" / "OpenMP multicore") in the GPU startup banner via a new gpu_backend_name() exposed through the extension.

Note: numerical validation of the async build against OpenMP-target (.sww diff) is still pending.