### PR TITLE
gpu: report the GPU count, not the rank count, in the mode-2 banner (fixes #194)

### DIFF
--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -204,6 +204,80 @@ def gpu_offload_enabled() -> bool:
     return bool(ge.get_offload_enabled()) if ge is not None else False
 
 
+def gpu_startup_banner(numprocs: int,
+                       num_devices: int,
+                       device_id: int,
+                       offload_active: bool,
+                       omp_num_threads: str = '1') -> list:
+    """Build the mode-2 ('unified') startup banner as a list of lines.
+
+    Pure function of its arguments so the rank/device mismatch warning can be tested
+    without an actual multi-GPU machine.
+
+    `numprocs` is the MPI rank count and `num_devices` the number of GPUs the runtime
+    can actually see.  These are DIFFERENT NUMBERS, and the banner used to print the
+    rank count labelled as "GPU(s)" — so a 4-rank run on a 1-GPU box cheerfully
+    reported "4 GPU(s)".  That mattered because ranks are assigned to devices
+    round-robin (``device_id = rank % num_devices``), so an oversubscribed run silently
+    puts several ranks on one device.  The banner was the natural place to notice that,
+    and instead it concealed it.  See issue #194.
+
+    Why the warning is worded the way it is.  Measured on one RTX 5070, a 160k-triangle
+    mode-2 evolve, ranks all sharing the single device:
+
+        ranks   no MPS     with MPS
+          1      3.80 s     3.51 s
+          2      7.13 s     3.48 s
+          4     11.21 s     3.72 s
+
+    So the *reliable* cost of oversubscribing is speed: without MPS the ranks time-slice
+    the device and it is ~3x slower.  NVIDIA MPS lets their kernels run concurrently and
+    restores parity — but never beats one rank per GPU, because a single rank with the
+    whole mesh already saturates the device; splitting it creates no new parallelism.
+    So MPS is a way to stop losing, not a way to go faster.
+
+    Hangs and garbled results have been reported in this configuration on real hardware,
+    but did NOT reproduce in the runs above (every rank count gave a bit-identical
+    checksum).  The warning therefore leads with the measured slowdown and reports the
+    hangs as a possibility, rather than promising a failure that may not arrive — an
+    oversubscribed run that quietly works but is 3x slow is the likelier outcome, and is
+    exactly the one a user would otherwise never notice.
+    """
+
+    bar = '+==============================================================================+'
+    lines = [bar]
+
+    if not offload_active:
+        lines.append("| ANUGA compute mode: 'unified' CPU multicore (gpu_ext kernels, no offload)   |")
+        lines.append(f'| OMP_NUM_THREADS={omp_num_threads}')
+    elif device_id < 0:
+        lines.append('| WARNING: No GPU devices found, running on CPU via OpenMP target offloading  |')
+    elif num_devices <= 0:
+        # Device count unavailable (query failed). Say so rather than inventing one —
+        # printing numprocs here is exactly the bug this function exists to remove.
+        lines.append(f'| GPU interface initialized: {numprocs} MPI rank(s), device count unknown, '
+                     f'OpenMP target offloading')
+    else:
+        lines.append(f'| GPU interface initialized: {numprocs} MPI rank(s) on {num_devices} GPU(s), '
+                     f'OpenMP target offloading')
+
+        if numprocs > num_devices:
+            lines.append(f'| WARNING: {numprocs} MPI ranks but only {num_devices} GPU(s). Ranks map round-robin')
+            lines.append(f'|          (rank % {num_devices}), so several ranks share one device. Mode-2 MPI')
+            lines.append('|          expects ONE RANK PER GPU. Measured: up to ~3x SLOWER than one')
+            lines.append('|          rank per GPU (the ranks time-slice the device); hangs and wrong')
+            lines.append('|          results have also been reported in this configuration.')
+            lines.append(f'|          Re-run with -np {num_devices}. NVIDIA MPS removes the slowdown')
+            lines.append('|          but never beats one rank per GPU, so it is not a way to go faster.')
+        elif numprocs < num_devices:
+            idle = num_devices - numprocs
+            lines.append(f'| NOTE: {idle} GPU(s) idle — {numprocs} rank(s) for {num_devices} device(s). '
+                         f'Use -np {num_devices} to use them all.')
+
+    lines.append(bar)
+    return lines
+
+
 def set_gpu_offload(enable: bool = True, verbose: bool = True) -> bool:
     """Enable or disable GPU offload for mode-2 ('unified') domains, process-wide.
 
@@ -5806,15 +5880,17 @@ class Domain(Generic_Domain):
                 self.gpu_offload_active = gpu_offload_enabled()
                 if myid == 0:
                     device_id = self.gpu_interface.gpu_dom.device_id
-                    print('+==============================================================================+')
-                    if not self.gpu_offload_active:
-                        print("| ANUGA compute mode: 'unified' CPU multicore (gpu_ext kernels, no offload)   |")
-                        print(f'| OMP_NUM_THREADS={omp_num_threads}')
-                    elif device_id < 0:
-                        print('| WARNING: No GPU devices found, running on CPU via OpenMP target offloading  |')
-                    else:
-                        print(f'| GPU interface initialized: {numprocs} GPU(s) using OpenMP target offloading')
-                    print('+==============================================================================+')
+
+                    # The number of GPUs the runtime can actually see — NOT numprocs.
+                    try:
+                        from anuga.shallow_water.sw_domain_gpu_ext import get_num_gpu_devices
+                        num_devices = get_num_gpu_devices()
+                    except Exception:
+                        num_devices = -1
+
+                    for line in gpu_startup_banner(numprocs, num_devices, device_id,
+                                                   self.gpu_offload_active, omp_num_threads):
+                        print(line)
                 return
             except Exception as e:
                 print(f'OpenMP GPU interface not available: {e}')

--- a/anuga/shallow_water/tests/test_DE_gpu_omp.py
+++ b/anuga/shallow_water/tests/test_DE_gpu_omp.py
@@ -2543,6 +2543,82 @@ class Test_GPU_SetQuantityReachesDevice(unittest.TestCase):
         self.assertAlmostEqual(float(gpu.max()), 2.0, places=6)
 
 
+class Test_GPU_StartupBanner(unittest.TestCase):
+    """The mode-2 banner must report the GPU count, not the rank count (issue #194).
+
+    It used to print `numprocs` labelled as "GPU(s)", so a 4-rank run on a 1-GPU box
+    reported "4 GPU(s)". That concealed the one thing the banner was best placed to
+    catch: mode-2 MPI assigns ranks to devices round-robin (rank % num_devices), so
+    running more ranks than GPUs silently puts several ranks on one device, which may
+    hang or return wrong results.
+
+    gpu_startup_banner() is a pure function precisely so this matrix is testable
+    without a multi-GPU machine.
+    """
+
+    def _banner(self, numprocs, num_devices, device_id=0, offload_active=True):
+        from anuga.shallow_water.shallow_water_domain import gpu_startup_banner
+        return '\n'.join(gpu_startup_banner(numprocs, num_devices, device_id,
+                                            offload_active))
+
+    def test_reports_device_count_not_rank_count(self):
+        """4 ranks on 1 GPU must not claim 4 GPUs."""
+        text = self._banner(numprocs=4, num_devices=1)
+        self.assertIn('4 MPI rank(s) on 1 GPU(s)', text)
+        self.assertNotIn('4 GPU(s)', text)
+
+    def test_warns_when_ranks_exceed_gpus(self):
+        """Oversubscription must warn, and lead with the cost we actually measured.
+
+        Measured on one RTX 5070 (160k-tri mode-2 evolve, all ranks on the one device):
+        without MPS, np=1/2/4 took 3.80/7.13/11.21 s — so the dependable consequence is
+        a ~3x slowdown, not a crash. Results were bit-identical at every rank count, so
+        the banner must not promise a failure that may never arrive; a run that quietly
+        works but is 3x slow is the likelier outcome and the one users would miss.
+        """
+        text = self._banner(numprocs=4, num_devices=1)
+        self.assertIn('WARNING', text)
+        self.assertIn('ONE RANK PER GPU', text)
+        self.assertIn('SLOWER', text)          # the measured, reliable consequence
+        self.assertIn('MPS', text)             # and the mitigation, if they must do it
+
+    def test_no_warning_when_ranks_match_gpus(self):
+        """The supported configuration must stay quiet."""
+        text = self._banner(numprocs=4, num_devices=4)
+        self.assertIn('4 MPI rank(s) on 4 GPU(s)', text)
+        self.assertNotIn('WARNING', text)
+        self.assertNotIn('NOTE', text)
+
+    def test_notes_idle_gpus(self):
+        """Fewer ranks than GPUs is safe (distinct devices) — a note, not a warning."""
+        text = self._banner(numprocs=1, num_devices=4)
+        self.assertNotIn('WARNING', text)
+        self.assertIn('3 GPU(s) idle', text)
+
+    def test_serial_on_one_gpu_is_quiet(self):
+        """The overwhelmingly common case must not nag."""
+        text = self._banner(numprocs=1, num_devices=1)
+        self.assertNotIn('WARNING', text)
+        self.assertNotIn('NOTE', text)
+
+    def test_unknown_device_count_does_not_invent_one(self):
+        """If the device query fails, say so — do NOT fall back to printing numprocs."""
+        text = self._banner(numprocs=4, num_devices=-1)
+        self.assertIn('device count unknown', text)
+        self.assertNotIn('4 GPU(s)', text)
+        self.assertNotIn('WARNING', text)
+
+    def test_no_offload_and_no_device_paths(self):
+        """The CPU-multicore and no-device banners must not claim any GPU count."""
+        cpu = self._banner(numprocs=4, num_devices=0, offload_active=False)
+        self.assertIn('CPU multicore', cpu)
+        self.assertNotIn('GPU(s)', cpu)
+
+        nodev = self._banner(numprocs=4, num_devices=0, device_id=-1)
+        self.assertIn('No GPU devices found', nodev)
+        self.assertNotIn('4 GPU(s)', nodev)
+
+
 class Test_GPU_RateOperatorGhostInflux(unittest.TestCase):
     """Rate_operator mass tracking must exclude ghost cells in mode 2 (issue #191).
 


### PR DESCRIPTION
Fixes #194.

The mode-2 startup banner printed `numprocs` labelled as **"GPU(s)"**, so a 4-rank run on a 1-GPU box reported:

```
| GPU interface initialized: 4 GPU(s) using OpenMP target offloading
```

There is one GPU. It said four.

That is worse than a cosmetic slip. Mode-2 MPI assigns ranks to devices round-robin (`device_id = rank % num_devices`), so running more ranks than GPUs silently puts several ranks on the same device. The banner is exactly where a user would notice that — and instead it concealed it, because the "device count" it printed always agreed with whatever rank count you chose.

## After

`np=4` on a 1-GPU box:

```
| GPU interface initialized: 4 MPI rank(s) on 1 GPU(s), OpenMP target offloading
| WARNING: 4 MPI ranks but only 1 GPU(s). Ranks map round-robin
|          (rank % 1), so several ranks share one device. Mode-2 MPI
|          expects ONE RANK PER GPU. Measured: up to ~3x SLOWER than one
|          rank per GPU (the ranks time-slice the device); hangs and wrong
|          results have also been reported in this configuration.
|          Re-run with -np 1. NVIDIA MPS removes the slowdown
|          but never beats one rank per GPU, so it is not a way to go faster.
```

`np=1` on 1 GPU (the normal case) stays quiet — one line, no nagging.

## What the warning claims, and why — I measured it

I first wrote this warning asserting that oversubscribed runs "may hang or produce incorrect results". Then I tested it, and **that did not reproduce**: a 160k-triangle mode-2 evolve on one RTX 5070 ran to completion at every rank count and returned a **bit-identical stage checksum** (199866.666667). No hang, no garbling.

What *did* show up is a reliable, large performance loss — and that MPS erases it:

| ranks on 1 GPU | no MPS | with MPS |
|---|---|---|
| np=1 | 3.80 s | 3.51 s |
| np=2 | 7.13 s | **3.48 s** |
| np=4 | 11.21 s | **3.72 s** |

Without MPS the ranks **time-slice** the device: ~3x slower at np=4, monotonically worsening. NVIDIA MPS lets kernels from separate processes run concurrently and restores parity — but **never beats one rank per GPU**, because a single rank holding the whole mesh already saturates the device. Splitting it across ranks on that same device creates no parallelism that was not already there; MPS merely lets the fragments overlap again. **MPS is a way to stop losing, not a way to go faster.**

So the banner now **leads with the measured slowdown** and reports hangs/wrong results as a possibility rather than a promise. Hangs *have* been seen on real hardware (larger meshes, GPU-aware MPI, memory pressure are all plausible triggers this small test does not reach), so the warning keeps them — but an oversubscribed run that quietly works and is merely 3x slow is the likelier outcome, and is precisely the one a user would otherwise never notice. A warning that predicts a crash that does not come is a warning people learn to ignore.

## Design notes

**Only oversubscription warns.** Ranks > GPUs is the dangerous direction. *Fewer* ranks than GPUs is harmless — `rank % num_devices` still yields distinct devices, you are merely leaving some idle — so that gets a `NOTE`, not a `WARNING`. Crying wolf on the safe side would train people to ignore the banner, which is how it failed in the first place.

**`gpu_startup_banner()` is a pure function** of `(numprocs, num_devices, device_id, offload_active)`. That is the point: this warning only ever fires on hardware CI does not have, so inlining the logic would ship it untested forever. As a pure function the whole matrix is covered in the ordinary serial suite — `Test_GPU_StartupBanner`, 7 cases: rank/device mismatch both ways, exact match, serial, unknown device count, no-offload, and no-device.

**If the device query fails** the banner says `device count unknown` rather than falling back to printing `numprocs` — that fallback *is* the bug being fixed, so it would be a poor thing to reintroduce in the error path.

## Verification

- Real 1-GPU box: `np=4` emits the warning, `np=1` stays quiet.
- `anuga.shallow_water` under the unified default (isolated runner, GPU-offload build, nvc/cc120): **435 pass / 2 skip**.
- Fast CPU suite: **2610 pass / 218 skip**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)