### PR TITLE
Unify Boyd/weir culvert kernel (mode-1 == mode-2); add CI mode-2 coverage

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -137,3 +137,18 @@ jobs:
           export OMP_NUM_THREADS=1
           pytest --pyargs anuga --cov=anuga --cov-report=xml --cov-report=term-missing --cov-config=../.coveragerc
 
+      # Exercise the unified (mode-2) compute path — the v4.0 gpu_ext C kernels
+      # running on the CPU (gpu_offload=false). ANUGA_DEFAULT_COMPUTE_MODE=unified
+      # makes every default domain use mode 2, so this validates that whole path.
+      # Safe to run the full suite in one process on a CPU build (the NVHPC
+      # target-runtime abort is GPU-build-only). Linux / Python 3.14 only.
+      - name: Test package (unified compute mode, full — Linux / Python 3.14)
+        if: runner.os == 'Linux' && matrix.python-version == '3.14'
+        shell: bash -el {0}
+        run: |
+          conda activate anuga_env
+          cd sandpit
+          export OMP_NUM_THREADS=1
+          export ANUGA_DEFAULT_COMPUTE_MODE=unified
+          pytest -rs --pyargs anuga
+

--- a/anuga/parallel/parallel_structure_operator.py
+++ b/anuga/parallel/parallel_structure_operator.py
@@ -260,6 +260,12 @@ class Parallel_Structure_operator(anuga.Operator):
 
     def __call__(self):
 
+        from anuga.structures.structure_operator import (
+            _can_use_c_culvert, _call_c_culvert)
+        if _can_use_c_culvert(self):
+            _call_c_culvert(self)
+            return
+
         timestep = self.domain.get_timestep()
 
         Q, barrel_speed, outlet_depth = self.discharge_routine()

--- a/anuga/shallow_water/gpu/gpu_culvert_operator.c
+++ b/anuga/shallow_water/gpu/gpu_culvert_operator.c
@@ -1248,101 +1248,51 @@ static void scatter_single_inlet(struct gpu_domain *GD,
 // Cross-boundary culverts use MPI between gather and scatter phases.
 // ============================================================================
 
-void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
-    NVTX_PUSH("gpu_culverts_apply_all");
-    struct culvert_operators *CO = &GD->culvert_ops;
-    int nc = CO->num_culverts;
+// ============================================================================
+// Pure per-culvert compute: discharge determination + semi-implicit water
+// transfer.  This is THE single implementation of the Boyd/weir update, shared
+// by the mode-2 batch (gpu_culverts_apply_all, below) and the mode-1 host path
+// (via the Cython wrapper), so the two compute modes agree bit-for-bit.
+//
+// Assumes a local/master, in-bounds culvert; the caller handles non-master
+// parallel skips.  Reads gathered inlet data (data0/data1), reads+updates the
+// smoothing state (st), and writes the result (r) and the water transfer (t).
+// ============================================================================
+void culvert_compute_one(const struct inlet_data *data0,
+                         const struct inlet_data *data1,
+                         const struct culvert_params *p,
+                         struct culvert_state *st,
+                         double timestep,
+                         struct culvert_result *r,
+                         struct culvert_transfer *t) {
+    // Reset per-step reporting stats; filled in below where a discharge runs.
+    st->report_gain = 0.0;
+    st->report_discharge = 0.0;
+    st->report_velocity = 0.0;
+    st->report_driving_energy = 0.0;
+    st->report_delta_total_energy = 0.0;
 
-    if (nc == 0 || !CO->initialized) {
-        NVTX_POP();
-        return;
-    }
+    double dim = (p->type == CULVERT_TYPE_BOX || p->type == CULVERT_TYPE_WEIR_TRAPEZOID)
+                 ? p->height : p->diameter;
 
-    omp_set_default_device(gpu_compute_device(GD));
-    int myrank = GD->rank;
-
-    // Check if any parallel culverts exist
-    int has_parallel = 0;
-    for (int c = 0; c < nc; c++) {
-        if (!CO->indices[c].is_local) { has_parallel = 1; break; }
-    }
-
-    // Stack-allocate per-culvert working data
-    struct inlet_data data0[MAX_CULVERTS];
-    struct inlet_data data1[MAX_CULVERTS];
-    struct culvert_result results[MAX_CULVERTS];
-    struct culvert_transfer transfers[MAX_CULVERTS];
-
-    // ----------------------------------------------------------------
-    // PHASE 1: Batched GPU gather (2 target update from's)
-    // Gathers LOCAL data for ALL culverts (local + parallel).
-    // Remote enquiry points get placeholder values (overwritten by MPI).
-    // ----------------------------------------------------------------
-    gpu_culvert_gather_enquiry(GD, data0, data1);
-    gpu_culvert_gather_inlets(GD, data0, data1);
-
-    // ----------------------------------------------------------------
-    // PHASE 1b: MPI exchange for cross-boundary culverts
-    // ----------------------------------------------------------------
-    // Static allocation of MPI buffers (MAX_CULVERTS * ~200 bytes = ~12KB)
-    static struct culvert_mpi_bufs mpi_bufs;
-
-    if (has_parallel) {
-        mpi_exchange_enquiry(GD, data0, data1, &mpi_bufs);
-        mpi_exchange_inlet_averages(GD, data0, data1, &mpi_bufs);
-    }
-
-    // ----------------------------------------------------------------
-    // PHASE 2: CPU computation loop (all culverts, ~200 FLOPs each)
-    // Only master_proc computes for cross-boundary culverts.
-    // ----------------------------------------------------------------
-    for (int c = 0; c < nc; c++) {
-        struct culvert_indices *ci = &CO->indices[c];
-        struct culvert_params *p = &CO->params[c];
-        struct culvert_state *st = &CO->state[c];
-        struct culvert_result *r = &results[c];
-
-        // Reset per-step reporting stats; they stay zero on ranks / states that
-        // don't compute a discharge (non-master, closed, dry). Filled in below
-        // and in Phase 3, then read back by the Python logger.
-        st->report_gain = 0.0;
-        st->report_discharge = 0.0;
-        st->report_velocity = 0.0;
-        st->report_driving_energy = 0.0;
-        st->report_delta_total_energy = 0.0;
-
-        // Non-master ranks skip computation for cross-boundary culverts
-        if (!ci->is_local && myrank != ci->master_proc) {
-            r->Q = 0.0;
-            r->barrel_velocity = 0.0;
-            r->outlet_culvert_depth = 0.0;
-            r->flow_area = 0.00001;
-            r->inflow_idx = 0;
-            continue;
-        }
-
-        // Check culvert is open
-        double dim = (p->type == CULVERT_TYPE_BOX || p->type == CULVERT_TYPE_WEIR_TRAPEZOID)
-                     ? p->height : p->diameter;
-        if (dim <= 0.0) {
-            r->Q = 0.0;
-            r->barrel_velocity = 0.0;
-            r->outlet_culvert_depth = 0.0;
-            r->flow_area = 0.00001;
-            r->inflow_idx = 0;
-            continue;
-        }
-
+    if (dim <= 0.0) {
+        // Closed culvert: no discharge. Transfer below still runs (Q=0 => no-op).
+        r->Q = 0.0;
+        r->barrel_velocity = 0.0;
+        r->outlet_culvert_depth = 0.0;
+        r->flow_area = 0.00001;
+        r->inflow_idx = 0;
+    } else {
         // Compute delta_total_energy to determine flow direction
         double delta_total_energy;
         if (p->use_velocity_head) {
             double depth0, vh0, te0, se0;
             double depth1, vh1, te1, se1;
-            compute_enquiry_values(&data0[c], p, 0, &depth0, &vh0, &te0, &se0);
-            compute_enquiry_values(&data1[c], p, 1, &depth1, &vh1, &te1, &se1);
+            compute_enquiry_values(data0, p, 0, &depth0, &vh0, &te0, &se0);
+            compute_enquiry_values(data1, p, 1, &depth1, &vh1, &te1, &se1);
             delta_total_energy = te0 - te1;
         } else {
-            delta_total_energy = data0[c].enquiry_stage - data1[c].enquiry_stage;
+            delta_total_energy = data0->enquiry_stage - data1->enquiry_stage;
         }
 
         // Smooth delta_total_energy
@@ -1352,24 +1302,21 @@ void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
                               p->smoothing_timescale, &ts);
 
         // Determine inflow/outflow
-        struct inlet_data *inflow_data, *outflow_data;
+        const struct inlet_data *inflow_data, *outflow_data;
         if (st->smooth_delta_total_energy >= 0.0) {
             r->inflow_idx = 0;
-            inflow_data = &data0[c];
-            outflow_data = &data1[c];
+            inflow_data = data0;
+            outflow_data = data1;
             delta_total_energy = st->smooth_delta_total_energy;
         } else {
             r->inflow_idx = 1;
-            inflow_data = &data1[c];
-            outflow_data = &data0[c];
+            inflow_data = data1;
+            outflow_data = data0;
             delta_total_energy = -st->smooth_delta_total_energy;
         }
 
-        // Report the (absolute) smoothed delta total energy, matching mode-1's
-        // self.delta_total_energy.
         st->report_delta_total_energy = delta_total_energy;
 
-        // Only calculate if there's water at inflow
         double inflow_depth, inflow_vh, inflow_te, inflow_se;
         compute_enquiry_values(inflow_data, p, r->inflow_idx,
                                &inflow_depth, &inflow_vh, &inflow_te, &inflow_se);
@@ -1416,8 +1363,6 @@ void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
                 r->Q = r->flow_area * r->barrel_velocity;
             }
 
-            // Report instantaneous driving energy and barrel velocity
-            // (matching mode-1's self.driving_energy / self.velocity).
             st->report_driving_energy = driving_energy;
             st->report_velocity = r->barrel_velocity;
         } else {
@@ -1428,104 +1373,273 @@ void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
         }
     }
 
+    // ---- Semi-implicit water transfer (was PHASE 3) ----
+    t->inflow_idx = r->inflow_idx;
+
+    const struct inlet_data *inflow_data = (r->inflow_idx == 0) ? data0 : data1;
+    const struct inlet_data *outflow_data = (r->inflow_idx == 0) ? data1 : data0;
+    double inflow_area = inflow_data->total_area;
+    double outflow_area = outflow_data->total_area;
+
+    double old_inflow_depth = inflow_data->avg_depth;
+    double old_inflow_xmom = inflow_data->avg_xmom;
+    double old_inflow_ymom = inflow_data->avg_ymom;
+
+    // Semi-implicit factor
+    double dt_Q_on_d;
+    if (old_inflow_depth > 0.0)
+        dt_Q_on_d = timestep * r->Q / old_inflow_depth;
+    else
+        dt_Q_on_d = 0.0;
+
+    double factor = 1.0 / (1.0 + dt_Q_on_d / inflow_area);
+
+    double new_inflow_depth, timestep_star;
+    if (p->always_use_Q_wetdry_adjustment) {
+        new_inflow_depth = old_inflow_depth * factor;
+        if (old_inflow_depth > 0.0)
+            timestep_star = timestep * new_inflow_depth / old_inflow_depth;
+        else
+            timestep_star = 0.0;
+    } else {
+        new_inflow_depth = old_inflow_depth - timestep * r->Q / inflow_area;
+        timestep_star = timestep;
+    }
+
+    st->report_gain = r->Q * timestep_star;
+    st->report_discharge = (timestep > 0.0) ? (r->Q * timestep_star / timestep) : 0.0;
+
+    double new_inflow_xmom, new_inflow_ymom;
+    if (p->use_old_momentum_method) {
+        new_inflow_xmom = old_inflow_xmom * factor;
+        new_inflow_ymom = old_inflow_ymom * factor;
+    } else {
+        double factor2;
+        if (old_inflow_depth > 0.0) {
+            if (p->always_use_Q_wetdry_adjustment)
+                factor2 = 1.0 / (1.0 + dt_Q_on_d * new_inflow_depth / (old_inflow_depth * inflow_area));
+            else
+                factor2 = 1.0 / (1.0 + timestep * r->Q / (old_inflow_depth * inflow_area));
+        } else {
+            factor2 = 0.0;
+        }
+        new_inflow_xmom = old_inflow_xmom * factor2;
+        new_inflow_ymom = old_inflow_ymom * factor2;
+    }
+
+    t->new_inflow_depth = new_inflow_depth;
+    t->new_inflow_xmom = new_inflow_xmom;
+    t->new_inflow_ymom = new_inflow_ymom;
+
+    // Outflow
+    double outflow_extra_depth = r->Q * timestep_star / outflow_area;
+    double new_outflow_depth = outflow_data->avg_depth + outflow_extra_depth;
+
+    const double *outflow_vec = (r->inflow_idx == 0) ? p->outward_vector_1 : p->outward_vector_0;
+    double dir0 = -outflow_vec[0];
+    double dir1 = -outflow_vec[1];
+
+    double new_outflow_xmom, new_outflow_ymom;
+    if (p->use_momentum_jet) {
+        new_outflow_xmom = r->barrel_velocity * new_outflow_depth * dir0;
+        new_outflow_ymom = r->barrel_velocity * new_outflow_depth * dir1;
+    } else {
+        new_outflow_xmom = 0.0;
+        new_outflow_ymom = 0.0;
+    }
+
+    t->new_outflow_depth = new_outflow_depth;
+    t->new_outflow_xmom = new_outflow_xmom;
+    t->new_outflow_ymom = new_outflow_ymom;
+}
+
+// ============================================================================
+// Flat host entry point for the mode-1 (Python) path. Marshals scalars into the
+// culvert_params / culvert_state / inlet_data structs, calls the shared
+// culvert_compute_one(), and returns the transfer + reporting via out-params.
+// No gpu_domain, no device memory — operates purely on values gathered by the
+// Python operator, so mode-1 and mode-2 run identical culvert arithmetic.
+// ============================================================================
+void culvert_apply_one_host(
+        int type, double g, double width, double height, double diameter,
+        double z1, double z2, double length, double manning, double sum_loss,
+        double blockage, double barrels,
+        int use_velocity_head, int use_momentum_jet, int use_old_momentum_method,
+        int always_use_Q_wetdry_adjustment, double max_velocity,
+        double smoothing_timescale,
+        double ov0x, double ov0y, double ov1x, double ov1y,
+        double invert0, double invert1, int has_invert0, int has_invert1,
+        double *smooth_delta_total_energy, double *smooth_Q,
+        double timestep,
+        double e0_stage, double e0_xmom, double e0_ymom, double e0_elev,
+        double a0_stage, double a0_depth, double a0_xmom, double a0_ymom, double a0_area,
+        double e1_stage, double e1_xmom, double e1_ymom, double e1_elev,
+        double a1_stage, double a1_depth, double a1_xmom, double a1_ymom, double a1_area,
+        int *inflow_idx,
+        double *new_inflow_depth, double *new_inflow_xmom, double *new_inflow_ymom,
+        double *new_outflow_depth, double *new_outflow_xmom, double *new_outflow_ymom,
+        double *report_gain, double *report_discharge, double *report_velocity,
+        double *report_driving_energy, double *report_delta_total_energy,
+        double *outlet_culvert_depth) {
+
+    struct culvert_params p;
+    memset(&p, 0, sizeof(p));
+    p.type = type; p.g = g; p.width = width; p.height = height; p.diameter = diameter;
+    p.z1 = z1; p.z2 = z2; p.length = length; p.manning = manning; p.sum_loss = sum_loss;
+    p.blockage = blockage; p.barrels = barrels;
+    p.use_velocity_head = use_velocity_head;
+    p.use_momentum_jet = use_momentum_jet;
+    p.use_old_momentum_method = use_old_momentum_method;
+    p.always_use_Q_wetdry_adjustment = always_use_Q_wetdry_adjustment;
+    p.max_velocity = max_velocity; p.smoothing_timescale = smoothing_timescale;
+    p.outward_vector_0[0] = ov0x; p.outward_vector_0[1] = ov0y;
+    p.outward_vector_1[0] = ov1x; p.outward_vector_1[1] = ov1y;
+    p.invert_elevation_0 = invert0; p.invert_elevation_1 = invert1;
+    p.has_invert_elevation_0 = has_invert0; p.has_invert_elevation_1 = has_invert1;
+
+    struct culvert_state st;
+    memset(&st, 0, sizeof(st));
+    st.smooth_delta_total_energy = *smooth_delta_total_energy;
+    st.smooth_Q = *smooth_Q;
+
+    struct inlet_data d0, d1;
+    d0.enquiry_stage = e0_stage; d0.enquiry_xmom = e0_xmom;
+    d0.enquiry_ymom = e0_ymom; d0.enquiry_elevation = e0_elev;
+    d0.avg_stage = a0_stage; d0.avg_depth = a0_depth;
+    d0.avg_xmom = a0_xmom; d0.avg_ymom = a0_ymom; d0.total_area = a0_area;
+    d1.enquiry_stage = e1_stage; d1.enquiry_xmom = e1_xmom;
+    d1.enquiry_ymom = e1_ymom; d1.enquiry_elevation = e1_elev;
+    d1.avg_stage = a1_stage; d1.avg_depth = a1_depth;
+    d1.avg_xmom = a1_xmom; d1.avg_ymom = a1_ymom; d1.total_area = a1_area;
+
+    struct culvert_result r;
+    struct culvert_transfer t;
+    memset(&r, 0, sizeof(r));
+    memset(&t, 0, sizeof(t));
+
+    culvert_compute_one(&d0, &d1, &p, &st, timestep, &r, &t);
+
+    *smooth_delta_total_energy = st.smooth_delta_total_energy;
+    *smooth_Q = st.smooth_Q;
+    *inflow_idx = t.inflow_idx;
+    *new_inflow_depth = t.new_inflow_depth;
+    *new_inflow_xmom = t.new_inflow_xmom;
+    *new_inflow_ymom = t.new_inflow_ymom;
+    *new_outflow_depth = t.new_outflow_depth;
+    *new_outflow_xmom = t.new_outflow_xmom;
+    *new_outflow_ymom = t.new_outflow_ymom;
+    *report_gain = st.report_gain;
+    *report_discharge = st.report_discharge;
+    *report_velocity = st.report_velocity;
+    *report_driving_energy = st.report_driving_energy;
+    *report_delta_total_energy = st.report_delta_total_energy;
+    *outlet_culvert_depth = r.outlet_culvert_depth;
+}
+
+// Host inlet gather for the mode-1 path. Mirrors the inner reduction of
+// gpu_culvert_gather_inlets() exactly (same accumulation order, same depth
+// clamp, same divisor) so mode-1's inlet averages match mode-2's bit-for-bit.
+void culvert_gather_inlet_host(int n, const int *indices, const double *areas,
+                               const double *stage_c, const double *xmom_c,
+                               const double *ymom_c, const double *bed_c,
+                               double total_area,
+                               double *avg_stage, double *avg_depth,
+                               double *avg_xmom, double *avg_ymom) {
+    double sum_stage = 0.0, sum_depth = 0.0, sum_xmom = 0.0, sum_ymom = 0.0;
+    for (int j = 0; j < n; j++) {
+        int i = indices[j];
+        double area = areas[j];
+        double depth = stage_c[i] - bed_c[i];
+        if (depth < 0.0) depth = 0.0;
+        sum_stage += stage_c[i] * area;
+        sum_depth += depth * area;
+        sum_xmom += xmom_c[i] * area;
+        sum_ymom += ymom_c[i] * area;
+    }
+    if (total_area > 0.0) {
+        *avg_stage = sum_stage / total_area;
+        *avg_depth = sum_depth / total_area;
+        *avg_xmom = sum_xmom / total_area;
+        *avg_ymom = sum_ymom / total_area;
+    } else {
+        *avg_stage = 0.0; *avg_depth = 0.0; *avg_xmom = 0.0; *avg_ymom = 0.0;
+    }
+}
+
+void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
+    NVTX_PUSH("gpu_culverts_apply_all");
+    struct culvert_operators *CO = &GD->culvert_ops;
+    int nc = CO->num_culverts;
+
+    if (nc == 0 || !CO->initialized) {
+        NVTX_POP();
+        return;
+    }
+
+    omp_set_default_device(gpu_compute_device(GD));
+    int myrank = GD->rank;
+
+    // Check if any parallel culverts exist
+    int has_parallel = 0;
+    for (int c = 0; c < nc; c++) {
+        if (!CO->indices[c].is_local) { has_parallel = 1; break; }
+    }
+
+    // Stack-allocate per-culvert working data
+    struct inlet_data data0[MAX_CULVERTS];
+    struct inlet_data data1[MAX_CULVERTS];
+    struct culvert_result results[MAX_CULVERTS];
+    struct culvert_transfer transfers[MAX_CULVERTS];
+
     // ----------------------------------------------------------------
-    // PHASE 3: CPU water transfer (semi-implicit update per culvert)
-    // Only master computes for cross-boundary culverts.
+    // PHASE 1: Batched GPU gather (2 target update from's)
+    // Gathers LOCAL data for ALL culverts (local + parallel).
+    // Remote enquiry points get placeholder values (overwritten by MPI).
+    // ----------------------------------------------------------------
+    gpu_culvert_gather_enquiry(GD, data0, data1);
+    gpu_culvert_gather_inlets(GD, data0, data1);
+
+    // ----------------------------------------------------------------
+    // PHASE 1b: MPI exchange for cross-boundary culverts
+    // ----------------------------------------------------------------
+    // Static allocation of MPI buffers (MAX_CULVERTS * ~200 bytes = ~12KB)
+    static struct culvert_mpi_bufs mpi_bufs;
+
+    if (has_parallel) {
+        mpi_exchange_enquiry(GD, data0, data1, &mpi_bufs);
+        mpi_exchange_inlet_averages(GD, data0, data1, &mpi_bufs);
+    }
+
+    // ----------------------------------------------------------------
+    // PHASE 2+3: per-culvert discharge + semi-implicit water transfer.
+    // The actual physics lives in culvert_compute_one() (above), which mode-1
+    // also calls via Cython so both compute modes are bit-for-bit identical.
+    // Only master_proc computes for cross-boundary culverts.
     // ----------------------------------------------------------------
     for (int c = 0; c < nc; c++) {
         struct culvert_indices *ci = &CO->indices[c];
         struct culvert_params *p = &CO->params[c];
-        struct culvert_result *r = &results[c];
         struct culvert_state *st = &CO->state[c];
+        struct culvert_result *r = &results[c];
         struct culvert_transfer *t = &transfers[c];
 
-        // Non-master ranks: will receive transfer data via MPI
+        // Non-master ranks skip: results/transfer arrive via MPI below.
         if (!ci->is_local && myrank != ci->master_proc) {
+            st->report_gain = 0.0;
+            st->report_discharge = 0.0;
+            st->report_velocity = 0.0;
+            st->report_driving_energy = 0.0;
+            st->report_delta_total_energy = 0.0;
+            r->Q = 0.0;
+            r->barrel_velocity = 0.0;
+            r->outlet_culvert_depth = 0.0;
+            r->flow_area = 0.00001;
+            r->inflow_idx = 0;
             memset(t, 0, sizeof(*t));
             continue;
         }
 
-        t->inflow_idx = r->inflow_idx;
-
-        struct inlet_data *inflow_data = (r->inflow_idx == 0) ? &data0[c] : &data1[c];
-        struct inlet_data *outflow_data = (r->inflow_idx == 0) ? &data1[c] : &data0[c];
-        double inflow_area = inflow_data->total_area;
-        double outflow_area = outflow_data->total_area;
-
-        double old_inflow_depth = inflow_data->avg_depth;
-        double old_inflow_xmom = inflow_data->avg_xmom;
-        double old_inflow_ymom = inflow_data->avg_ymom;
-
-        // Semi-implicit factor
-        double dt_Q_on_d;
-        if (old_inflow_depth > 0.0)
-            dt_Q_on_d = timestep * r->Q / old_inflow_depth;
-        else
-            dt_Q_on_d = 0.0;
-
-        double factor = 1.0 / (1.0 + dt_Q_on_d / inflow_area);
-
-        // New inflow values (with wet-dry adjustment if always_use_Q_wetdry_adjustment)
-        double new_inflow_depth, timestep_star;
-        if (p->always_use_Q_wetdry_adjustment) {
-            new_inflow_depth = old_inflow_depth * factor;
-            if (old_inflow_depth > 0.0)
-                timestep_star = timestep * new_inflow_depth / old_inflow_depth;
-            else
-                timestep_star = 0.0;
-        } else {
-            new_inflow_depth = old_inflow_depth - timestep * r->Q / inflow_area;
-            timestep_star = timestep;
-        }
-
-        // Report instantaneous discharge and the volume gained this step,
-        // matching mode-1: gain = Q*timestep_star, discharge = gain/timestep.
-        st->report_gain = r->Q * timestep_star;
-        st->report_discharge = (timestep > 0.0) ? (r->Q * timestep_star / timestep) : 0.0;
-
-        double new_inflow_xmom, new_inflow_ymom;
-        if (p->use_old_momentum_method) {
-            new_inflow_xmom = old_inflow_xmom * factor;
-            new_inflow_ymom = old_inflow_ymom * factor;
-        } else {
-            double factor2;
-            if (old_inflow_depth > 0.0) {
-                if (p->always_use_Q_wetdry_adjustment)
-                    factor2 = 1.0 / (1.0 + dt_Q_on_d * new_inflow_depth / (old_inflow_depth * inflow_area));
-                else
-                    factor2 = 1.0 / (1.0 + timestep * r->Q / (old_inflow_depth * inflow_area));
-            } else {
-                factor2 = 0.0;
-            }
-            new_inflow_xmom = old_inflow_xmom * factor2;
-            new_inflow_ymom = old_inflow_ymom * factor2;
-        }
-
-        t->new_inflow_depth = new_inflow_depth;
-        t->new_inflow_xmom = new_inflow_xmom;
-        t->new_inflow_ymom = new_inflow_ymom;
-
-        // Outflow
-        double outflow_extra_depth = r->Q * timestep_star / outflow_area;
-        double new_outflow_depth = outflow_data->avg_depth + outflow_extra_depth;
-
-        // Outflow direction vector
-        double *outflow_vec = (r->inflow_idx == 0) ? p->outward_vector_1 : p->outward_vector_0;
-        double dir0 = -outflow_vec[0];
-        double dir1 = -outflow_vec[1];
-
-        double new_outflow_xmom, new_outflow_ymom;
-        if (p->use_momentum_jet) {
-            new_outflow_xmom = r->barrel_velocity * new_outflow_depth * dir0;
-            new_outflow_ymom = r->barrel_velocity * new_outflow_depth * dir1;
-        } else {
-            new_outflow_xmom = 0.0;
-            new_outflow_ymom = 0.0;
-        }
-
-        t->new_outflow_depth = new_outflow_depth;
-        t->new_outflow_xmom = new_outflow_xmom;
-        t->new_outflow_ymom = new_outflow_ymom;
+        culvert_compute_one(&data0[c], &data1[c], p, st, timestep, r, t);
     }
 
     // ----------------------------------------------------------------

--- a/anuga/shallow_water/gpu/gpu_culvert_operator.h
+++ b/anuga/shallow_water/gpu/gpu_culvert_operator.h
@@ -96,4 +96,47 @@ void culvert_smooth_discharge(double smooth_delta_total_energy,
                               double ts,
                               double *Q_out, double *velocity_out);
 
+// Single implementation of the per-culvert Boyd/weir update (discharge +
+// semi-implicit water transfer), shared by the mode-2 batch and the mode-1
+// host path so both compute modes agree bit-for-bit. Assumes a local/master,
+// in-bounds culvert; the caller handles non-master parallel skips.
+void culvert_compute_one(const struct inlet_data *data0,
+                         const struct inlet_data *data1,
+                         const struct culvert_params *p,
+                         struct culvert_state *st,
+                         double timestep,
+                         struct culvert_result *r,
+                         struct culvert_transfer *t);
+
+// Flat host entry point (scalars in/out) for the mode-1 Python path.
+void culvert_apply_one_host(
+        int type, double g, double width, double height, double diameter,
+        double z1, double z2, double length, double manning, double sum_loss,
+        double blockage, double barrels,
+        int use_velocity_head, int use_momentum_jet, int use_old_momentum_method,
+        int always_use_Q_wetdry_adjustment, double max_velocity,
+        double smoothing_timescale,
+        double ov0x, double ov0y, double ov1x, double ov1y,
+        double invert0, double invert1, int has_invert0, int has_invert1,
+        double *smooth_delta_total_energy, double *smooth_Q,
+        double timestep,
+        double e0_stage, double e0_xmom, double e0_ymom, double e0_elev,
+        double a0_stage, double a0_depth, double a0_xmom, double a0_ymom, double a0_area,
+        double e1_stage, double e1_xmom, double e1_ymom, double e1_elev,
+        double a1_stage, double a1_depth, double a1_xmom, double a1_ymom, double a1_area,
+        int *inflow_idx,
+        double *new_inflow_depth, double *new_inflow_xmom, double *new_inflow_ymom,
+        double *new_outflow_depth, double *new_outflow_xmom, double *new_outflow_ymom,
+        double *report_gain, double *report_discharge, double *report_velocity,
+        double *report_driving_energy, double *report_delta_total_energy,
+        double *outlet_culvert_depth);
+
+// Host inlet gather (mode-1), bit-identical to the mode-2 device gather.
+void culvert_gather_inlet_host(int n, const int *indices, const double *areas,
+                               const double *stage_c, const double *xmom_c,
+                               const double *ymom_c, const double *bed_c,
+                               double total_area,
+                               double *avg_stage, double *avg_depth,
+                               double *avg_xmom, double *avg_ymom);
+
 #endif // GPU_CULVERT_OPERATOR_H

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -400,6 +400,103 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_flop_counters_print_global(gpu_domain *GD)
 
 
+cdef extern from "gpu_culvert_operator.h" nogil:
+    void culvert_apply_one_host(
+        int type, double g, double width, double height, double diameter,
+        double z1, double z2, double length, double manning, double sum_loss,
+        double blockage, double barrels,
+        int use_velocity_head, int use_momentum_jet, int use_old_momentum_method,
+        int always_use_Q_wetdry_adjustment, double max_velocity,
+        double smoothing_timescale,
+        double ov0x, double ov0y, double ov1x, double ov1y,
+        double invert0, double invert1, int has_invert0, int has_invert1,
+        double *smooth_delta_total_energy, double *smooth_Q,
+        double timestep,
+        double e0_stage, double e0_xmom, double e0_ymom, double e0_elev,
+        double a0_stage, double a0_depth, double a0_xmom, double a0_ymom, double a0_area,
+        double e1_stage, double e1_xmom, double e1_ymom, double e1_elev,
+        double a1_stage, double a1_depth, double a1_xmom, double a1_ymom, double a1_area,
+        int *inflow_idx,
+        double *new_inflow_depth, double *new_inflow_xmom, double *new_inflow_ymom,
+        double *new_outflow_depth, double *new_outflow_xmom, double *new_outflow_ymom,
+        double *report_gain, double *report_discharge, double *report_velocity,
+        double *report_driving_energy, double *report_delta_total_energy,
+        double *outlet_culvert_depth)
+
+    void culvert_gather_inlet_host(
+        int n, const int *indices, const double *areas,
+        const double *stage_c, const double *xmom_c,
+        const double *ymom_c, const double *bed_c,
+        double total_area,
+        double *avg_stage, double *avg_depth,
+        double *avg_xmom, double *avg_ymom)
+
+
+def culvert_gather_inlet_host_py(
+        int[::1] indices, double[::1] areas,
+        double[::1] stage_c, double[::1] xmom_c,
+        double[::1] ymom_c, double[::1] bed_c,
+        double total_area):
+    """Inlet gather matching the mode-2 device gather bit-for-bit.
+
+    Returns (avg_stage, avg_depth, avg_xmom, avg_ymom).
+    """
+    cdef int n = indices.shape[0]
+    cdef double avg_stage = 0.0, avg_depth = 0.0, avg_xmom = 0.0, avg_ymom = 0.0
+    culvert_gather_inlet_host(
+        n, &indices[0], &areas[0],
+        &stage_c[0], &xmom_c[0], &ymom_c[0], &bed_c[0],
+        total_area, &avg_stage, &avg_depth, &avg_xmom, &avg_ymom)
+    return (avg_stage, avg_depth, avg_xmom, avg_ymom)
+
+
+def culvert_apply_one_host_py(
+        int type, double g, double width, double height, double diameter,
+        double z1, double z2, double length, double manning, double sum_loss,
+        double blockage, double barrels,
+        int use_velocity_head, int use_momentum_jet, int use_old_momentum_method,
+        int always_use_Q_wetdry_adjustment, double max_velocity,
+        double smoothing_timescale,
+        double ov0x, double ov0y, double ov1x, double ov1y,
+        double invert0, double invert1, int has_invert0, int has_invert1,
+        double smooth_dte, double smooth_Q, double timestep,
+        double e0_stage, double e0_xmom, double e0_ymom, double e0_elev,
+        double a0_stage, double a0_depth, double a0_xmom, double a0_ymom, double a0_area,
+        double e1_stage, double e1_xmom, double e1_ymom, double e1_elev,
+        double a1_stage, double a1_depth, double a1_xmom, double a1_ymom, double a1_area):
+    """Bit-identical single-culvert update shared with the mode-2 batch.
+
+    Returns (smooth_dte, smooth_Q, inflow_idx,
+             new_inflow_depth, new_inflow_xmom, new_inflow_ymom,
+             new_outflow_depth, new_outflow_xmom, new_outflow_ymom,
+             report_gain, report_discharge, report_velocity,
+             report_driving_energy, report_delta_total_energy,
+             outlet_culvert_depth).
+    """
+    cdef double sdte = smooth_dte
+    cdef double sQ = smooth_Q
+    cdef int inflow_idx = 0
+    cdef double nid = 0.0, nix = 0.0, niy = 0.0
+    cdef double nod = 0.0, nox = 0.0, noy = 0.0
+    cdef double rg = 0.0, rd = 0.0, rv = 0.0, rde = 0.0, rdte = 0.0
+    cdef double ocd = 0.0
+    culvert_apply_one_host(
+        type, g, width, height, diameter, z1, z2, length, manning, sum_loss,
+        blockage, barrels, use_velocity_head, use_momentum_jet,
+        use_old_momentum_method, always_use_Q_wetdry_adjustment, max_velocity,
+        smoothing_timescale, ov0x, ov0y, ov1x, ov1y,
+        invert0, invert1, has_invert0, has_invert1,
+        &sdte, &sQ, timestep,
+        e0_stage, e0_xmom, e0_ymom, e0_elev,
+        a0_stage, a0_depth, a0_xmom, a0_ymom, a0_area,
+        e1_stage, e1_xmom, e1_ymom, e1_elev,
+        a1_stage, a1_depth, a1_xmom, a1_ymom, a1_area,
+        &inflow_idx, &nid, &nix, &niy, &nod, &nox, &noy,
+        &rg, &rd, &rv, &rde, &rdte, &ocd)
+    return (sdte, sQ, inflow_idx, nid, nix, niy, nod, nox, noy,
+            rg, rd, rv, rde, rdte, ocd)
+
+
 # ============================================================================
 # GPU Domain Wrapper Class
 # ============================================================================

--- a/anuga/shallow_water/tests/test_DE_gpu_omp.py
+++ b/anuga/shallow_water/tests/test_DE_gpu_omp.py
@@ -626,9 +626,11 @@ class Test_GPU_InletOperator(unittest.TestCase):
         self.assertAlmostEqual(cpu_volume, gpu_volume, delta=1e-6,
                                msg=f"Water volumes differ: CPU={cpu_volume}, GPU={gpu_volume}")
 
-        # Compare stage values
+        # Compare stage values. mode=1 and mode=2 apply the inlet with the same
+        # level-fill, so they agree to machine precision (~7e-17 on a GPU build,
+        # bit-identical on CPU); the bound catches any mode-1/mode-2 regression.
         stage_diff = np.abs(cpu_stage - gpu_stage)
-        self.assertLess(stage_diff.max(), 1e-8,
+        self.assertLess(stage_diff.max(), 1e-10,
                         f"Stage difference too large: max={stage_diff.max():.2e}")
 
     def test_inlet_operator_time_varying_Q(self):
@@ -694,9 +696,10 @@ class Test_GPU_InletOperator(unittest.TestCase):
         sync_from_device(gpu_dom)
         gpu_xmom = gpu_domain.quantities['xmomentum'].centroid_values.copy()
 
-        # Compare momentum
+        # Compare momentum. Inlet applied identically in mode=1 and mode=2, so
+        # agreement is to machine precision (~5e-16 on a GPU build).
         xmom_diff = np.abs(cpu_xmom - gpu_xmom)
-        self.assertLess(xmom_diff.max(), 1e-8,
+        self.assertLess(xmom_diff.max(), 1e-10,
                         f"Xmomentum difference too large: max={xmom_diff.max():.2e}")
 
 
@@ -1240,19 +1243,20 @@ class Test_GPU_Culvert(unittest.TestCase):
         gpu_stage = gpu_domain.quantities['stage'].centroid_values.copy()
         gpu_xmom = gpu_domain.quantities['xmomentum'].centroid_values.copy()
 
-        # mode=1 calls Python boyd_box_function (boyd_box_operator.py); mode=2
-        # calls the C boyd_box_discharge translation.  Tiny FP-order differences
-        # in pow()/sqrt() at step 1 (~1e-7) get amplified by the depth↔Q feedback
-        # to ~3% by t=5.  Volume is conserved (test_culvert_volume_conservation
-        # is the rigorous physical check); these atol bounds catch catastrophic
-        # failures (wrong flow direction, culvert not firing) without flagging
-        # normal amplified-FP drift.  Momentum is more sensitive than stage
-        # because momentum = depth * velocity compounds the depth error.
+        # mode=1 and mode=2 now share the single C culvert kernel
+        # (culvert_compute_one + culvert_gather_inlet_host), so they agree to
+        # machine precision: measured ~3e-16 (stage) / ~2e-15 (xmom) at t=5 on a
+        # GPU-offload build, and bit-identical on a CPU build.  (Previously mode=1
+        # called Python boyd_box_function and mode=2 the C translation, whose
+        # pow()/sqrt() FP-order differences amplified to ~3% by t=5 — hence the
+        # old atol=0.02/0.05.)  The tight bounds below catch any regression that
+        # reintroduces a mode-1/mode-2 divergence, with generous headroom over the
+        # measured ~1e-15.
         np.testing.assert_allclose(
-            gpu_stage, cpu_stage, rtol=0, atol=0.02,
+            gpu_stage, cpu_stage, rtol=0, atol=1e-10,
             err_msg='Culvert 5s: stage mismatch between mode=1 and mode=2')
         np.testing.assert_allclose(
-            gpu_xmom, cpu_xmom, rtol=0, atol=0.05,
+            gpu_xmom, cpu_xmom, rtol=0, atol=1e-9,
             err_msg='Culvert 5s: xmomentum mismatch between mode=1 and mode=2')
 
     def test_culvert_volume_conservation(self):
@@ -1418,10 +1422,12 @@ class Test_GPU_WeirTrapezoid(unittest.TestCase):
         sync_from_device(gpu_domain.gpu_interface.gpu_dom)
         gpu_stage = gpu_domain.quantities['stage'].centroid_values.copy()
 
-        # atol=0.02: physically reasonable tolerance for real GPU vs CPU FP divergence
-        # after 5 s.  Tight enough to catch wrong-direction or zero-flow failures.
+        # mode=1 and mode=2 share the single C weir/culvert kernel, so they agree
+        # to machine precision: ~4e-16 at t=5 on a GPU-offload build, bit-identical
+        # on a CPU build.  (Old atol=0.02 predated the shared kernel.)  Tight enough
+        # to catch any regression that reintroduces a mode-1/mode-2 divergence.
         np.testing.assert_allclose(
-            gpu_stage, cpu_stage, rtol=0, atol=0.02,
+            gpu_stage, cpu_stage, rtol=0, atol=1e-10,
             err_msg='Weir trapezoid 5s: stage mismatch between mode=1 and mode=2')
 
     def test_weir_trapezoid_cpu_gpu_velocity_match(self):
@@ -2931,7 +2937,11 @@ class Test_GPU_ForcingOperators(unittest.TestCase):
     def _assert_modes_agree(self, add_operator, label):
         d1 = self._run(1, add_operator, f'{label}_m1')
         d2 = self._run(2, add_operator, f'{label}_m2')
-        atol = 1e-8 if anuga.gpu_offload_enabled() else 1e-12
+        # These operators apply the same per-cell forcing in mode 1 and mode 2, so
+        # they agree to machine precision on still water: measured <=1.2e-15 at t=5
+        # for wind/pressure and bit-identical for rain on a GPU-offload build. The
+        # bound below catches any mode-1/mode-2 regression with wide headroom.
+        atol = 1e-10 if anuga.gpu_offload_enabled() else 1e-12
         for q in ['stage', 'xmomentum', 'ymomentum']:
             np.testing.assert_allclose(
                 d2.quantities[q].centroid_values,

--- a/anuga/structures/structure_operator.py
+++ b/anuga/structures/structure_operator.py
@@ -9,6 +9,148 @@ from anuga.utilities.system_tools import log_to_file
 from anuga.utilities.numerical_tools import ensure_numeric
 
 
+_c_culvert_funcs = None
+
+
+def _get_c_culvert_funcs():
+    """Lazily import the shared C culvert kernels (apply + inlet gather).
+
+    Returns (apply_fn, gather_fn), or (None, None) if the extension is
+    unavailable. These are the single source of truth for the Boyd/weir
+    discharge + water-transfer physics: mode-1 (here) and mode-2 (the GPU
+    culvert batch) call the same C code, so the two compute modes agree.
+    """
+    global _c_culvert_funcs
+    if _c_culvert_funcs is None:
+        try:
+            from anuga.shallow_water.sw_domain_gpu_ext import (
+                culvert_apply_one_host_py, culvert_gather_inlet_host_py)
+            _c_culvert_funcs = (culvert_apply_one_host_py,
+                                culvert_gather_inlet_host_py)
+        except Exception:
+            _c_culvert_funcs = (None, None)
+    return _c_culvert_funcs
+
+
+def _c_culvert_type_of(op):
+    """CULVERT_TYPE_* code (box=0, pipe=1, weir_trapezoid=2) for the shared C
+    kernel, or None if the operator has no C implementation. Handles both the
+    serial and parallel variants (same predicates the GPU culvert manager uses)."""
+    try:
+        from anuga.structures.gpu_culvert_manager import GPUCulvertManager
+    except Exception:
+        return None
+    if GPUCulvertManager._is_boyd_box(op):
+        return 0
+    if GPUCulvertManager._is_boyd_pipe(op):
+        return 1
+    if GPUCulvertManager._is_weir_trapezoid(op):
+        return 2
+    return None
+
+
+def _can_use_c_culvert(op):
+    """True if this operator's per-step update can run through the shared C
+    kernel: a supported Boyd/weir culvert that is fully local to this rank (so no
+    MPI is needed) with a C-covered outflow model. Cross-boundary parallel
+    culverts keep the Python + MPI path."""
+    if _c_culvert_type_of(op) is None:
+        return False
+    if op.inlets[0] is None or op.inlets[1] is None:
+        return False
+    # The C kernel models jet OR zero outflow momentum; Boyd/weir always satisfy
+    # this (zero_outflow_momentum == not use_momentum_jet).
+    if not (op.use_momentum_jet or op.zero_outflow_momentum):
+        return False
+    # Parallel operator: only take the C path when this rank fully owns the
+    # culvert (master, both enquiry points, both inlets). Otherwise MPI is needed.
+    if hasattr(op, 'myid'):
+        myid = op.myid
+        if myid != op.master_proc:
+            return False
+        if op.enquiry_proc[0] != myid or op.enquiry_proc[1] != myid:
+            return False
+        if op.inlet_master_proc[0] != myid or op.inlet_master_proc[1] != myid:
+            return False
+    return _get_c_culvert_funcs()[0] is not None
+
+
+def _call_c_culvert(op):
+    """Per-step culvert update via the shared C kernel — bit-identical to the
+    Python discharge_routine + transfer, and to the mode-2 GPU culvert batch.
+    This is the single source of truth for the Boyd/weir physics on the mode-1
+    (host) path; only reached for fully-local culverts (see _can_use_c_culvert)."""
+    apply_fn, gather_fn = _get_c_culvert_funcs()
+    ctype = _c_culvert_type_of(op)
+    d = op.domain
+    stage_c = d.quantities['stage'].centroid_values
+    xmom_c = d.quantities['xmomentum'].centroid_values
+    ymom_c = d.quantities['ymomentum'].centroid_values
+    bed_c = d.quantities['elevation'].centroid_values
+    i0, i1 = op.inlets[0], op.inlets[1]
+    ov0 = i0.outward_culvert_vector
+    ov1 = i1.outward_culvert_vector
+    inv0, inv1 = i0.invert_elevation, i1.invert_elevation
+    h0 = 1 if inv0 is not None else 0
+    h1 = 1 if inv1 is not None else 0
+
+    def gather(inl):
+        idx = num.ascontiguousarray(inl.triangle_indices, dtype=num.intc)
+        areas = num.ascontiguousarray(d.areas[inl.triangle_indices], dtype=float)
+        a_stage, a_depth, a_xmom, a_ymom = gather_fn(
+            idx, areas, stage_c, xmom_c, ymom_c, bed_c, inl.get_area())
+        return (inl.get_enquiry_stage(), inl.get_enquiry_xmom(),
+                inl.get_enquiry_ymom(), inl.get_enquiry_elevation(),
+                a_stage, a_depth, a_xmom, a_ymom, inl.get_area())
+
+    g0 = gather(i0)
+    g1 = gather(i1)
+    res = apply_fn(
+        ctype, d.g,
+        float(getattr(op, 'culvert_width', 0.0)),
+        float(getattr(op, 'culvert_height', 0.0)),
+        float(getattr(op, 'culvert_diameter', 0.0)),
+        float(getattr(op, 'culvert_z1', 0.0)),
+        float(getattr(op, 'culvert_z2', 0.0)),
+        op.culvert_length, op.manning, op.sum_loss,
+        float(getattr(op, 'culvert_blockage', getattr(op, 'blockage', 0.0))),
+        float(getattr(op, 'culvert_barrels', getattr(op, 'barrels', 1.0))),
+        1 if op.use_velocity_head else 0,
+        1 if op.use_momentum_jet else 0,
+        1 if getattr(op, 'use_old_momentum_method', True) else 0,
+        1 if getattr(op, 'always_use_Q_wetdry_adjustment', True) else 0,
+        op.max_velocity, op.smoothing_timescale,
+        ov0[0], ov0[1], ov1[0], ov1[1],
+        float(inv0) if h0 else 0.0, float(inv1) if h1 else 0.0, h0, h1,
+        op.smooth_delta_total_energy, op.smooth_Q, d.get_timestep(),
+        *g0, *g1)
+    (sdte, sQ, inflow_idx, nid, nix, niy, nod, nox, noy,
+     rg, rd, rv, rde, rdte, ocd) = res
+
+    op.smooth_delta_total_energy = sdte
+    op.smooth_Q = sQ
+    inflow = op.inlets[inflow_idx]
+    outflow = op.inlets[1 - inflow_idx]
+    op.inflow = inflow
+    op.outflow = outflow
+
+    inflow.set_depths(nid)
+    inflow.set_xmoms(nix)
+    inflow.set_ymoms(niy)
+    outflow.set_depths(nod)
+    outflow.set_xmoms(nox)
+    outflow.set_ymoms(noy)
+
+    # Reporting (matches the Python discharge routine and the mode-2 readback)
+    op.accumulated_flow += rg
+    if d.yieldstep:
+        op.discharge_abs_timemean += rg / d.yieldstep
+    op.discharge = rd
+    op.velocity = rv
+    op.driving_energy = rde
+    op.delta_total_energy = rdte
+    op.outlet_depth = ocd
+
 
 class Structure_operator(anuga.Operator):
     """Structure Operator - transfer water from one rectangular box to another.
@@ -214,6 +356,10 @@ class Structure_operator(anuga.Operator):
 
 
     def __call__(self):
+
+        if _can_use_c_culvert(self):
+            _call_c_culvert(self)
+            return
 
         timestep = self.domain.get_timestep()
 

--- a/claude/FUTURE_WORK.md
+++ b/claude/FUTURE_WORK.md
@@ -45,6 +45,63 @@ the `acc_free` teardown in `gpu_halo.c`; add tests; and rebase onto `develop` (i
 #200). The kernel win does **not** reach wall-clock (the async queue issues 2.5× more
 `cuStreamSynchronize` than OpenMP-target) — headroom, not a blocker, but worth noting.
 
+**~~P2 — Unify the culvert implementation so mode-1 and mode-2 are bit-identical.~~ DONE
+(session 51, uncommitted in working tree as of write-up).**
+
+**What was done.** There is now **one** implementation of the Boyd/weir per-culvert update —
+`culvert_compute_one()` in `shallow_water/gpu/gpu_culvert_operator.c` — plus a shared host inlet
+gather `culvert_gather_inlet_host()`. Mode-2's batch was refactored to call it (behaviour
+preserving); mode-1's Python operators (both `Structure_operator` and the *default*
+`Parallel_Structure_operator`) now route their per-step update through it via a Cython bridge
+(`culvert_apply_one_host` / `culvert_gather_inlet_host_py` in `sw_domain_gpu_ext.pyx`), gated to
+fully-local culverts (cross-boundary MPI culverts keep the Python+MPI path). Files touched:
+`gpu_culvert_operator.c/.h`, `sw_domain_gpu_ext.pyx`, `structures/structure_operator.py`,
+`parallel/parallel_structure_operator.py`. Result: **mode-1 == mode-2 bit-for-bit** for every
+culvert config (box/pipe, velocity head, blockage), at 1 and 16 threads. Full suite green in
+legacy (2698) and unified (2697); 230 structure/GPU tests pass. De-dups the Python/C physics on
+the runtime path (single source of truth).
+
+**Correction to the earlier diagnosis (don't repeat the wrong turns):** the seed was **not**
+momentum, ordering, or FMA. It was the **inlet-average gather** — mode-1 summed with numpy
+(`num.sum(v*a)/area`), mode-2 with a C loop; for a multi-cell inlet these round 1 ULP apart in a
+value-dependent way (plus a dry-cell depth clamp the C gather does and the Python global-average
+path didn't). Two earlier "proofs" were invalid because a monkeypatch hit the **unused serial
+`Structure_operator`** while the default operator is `Parallel_Structure_operator` (a *separate*
+class hierarchy). Lesson: `anuga.Boyd_box_operator` is a **factory** returning the parallel
+class even in serial — instrument the class that actually runs.
+
+---
+
+**Towradgi still diverges — and it is NOT culverts (diagnosed, recommend ACCEPT).**
+After the culvert fix, towradgi mode-1 vs mode-2 is unchanged (7.6e-6 → 2.5e-3). An in-process
+double-precision localization harness (two domains from the same setup, restartable lockstep
+evolve, double diff — reconstructable, see session 51) pinned the real seed:
+
+- The seed is **rainfall (`Rate_operator`) falling on DRY cells.** Remove the rate operators from
+  both domains → **zero divergence** (bit-identical); rain on a **fully wet** domain →
+  bit-identical; rain on **dry** cells → 1 ULP.
+- It is **not** the rate operator's arithmetic (numpy `arr+scalar` == a C loop; wet cells prove
+  it, and the rate inputs `local_rate/timestep/rate/factor` are bit-identical between modes) and
+  **not** the sync (a plain `omp target update` memcpy of stage). Both modes are in fact
+  **stage-primary** (`height == stage - bed` exactly in each) — there is no `stage = bed + height`
+  reconstruction to flip. The residual is a **1-ULP difference in the core's near-dry stage
+  itself**: mode-2's stage going *into* the rate op is already ~1 ULP off from mode-1, produced by
+  the unified C RK loop's dry-cell handling and **masked by the bed-clamp** (`protect` sets
+  `stage = bed` exactly in both) right up until rain lifts the cell off the bed and exposes it.
+  That's why bare runs are bit-identical and only *rain-on-dry* diverges. Same family as the
+  **#200** dry-cell issue (a wet/dry-margin roundoff gap between the legacy and unified paths).
+  The exact operation was not isolated — it needs instrumenting the C RK loop's device state
+  mid-step.
+- A red herring ruled out along the way: mode-2 also clamps dry cells to bed at
+  `set_multiprocessor_mode(2)` (#200) while mode-1 defers to first protect — but forcing mode-1
+  to clamp too left the divergence unchanged, so the *initial* state is not the cause.
+
+**Recommendation: accept it.** One ULP in the stage of dry ground under a hair of rain —
+physically meaningless, chaos-amplified to mm over hours, both modes equally valid. A real fix
+means reconciling stage-primary vs height-primary at the wet/dry margin (core-level, #200
+family, large blast radius, no physical payoff). Unifying the `Rate_operator` would **not** help
+(it's already identical on wet cells). If ever pursued, the localization harness is the tool.
+
 **P3 — process, not code:**
 - **`develop` is ~833 commits ahead of `main`.** *Every* session-50 fix (including the #200
   startup mass-loss and #193 parallel-inlet mass-balance correctness fixes) is unreleased,

--- a/claude/KNOWN_ISSUES.md
+++ b/claude/KNOWN_ISSUES.md
@@ -324,6 +324,25 @@ writing new flux/operator code.
 
 Cells below this height are treated as dry. Negative depths are clipped.
 
+### mode-1 vs mode-2 differ by ~1 ULP at the wet/dry margin (2026-07-20)
+
+Both modes are **stage-primary** (`height == stage - bed` exactly in each) — there
+is *no* stage-vs-height representation flip. The residual is a **1-ULP difference
+in the core's near-dry stage value itself**: for a cell sitting essentially *at*
+the bed that gets lifted a hair off it (e.g. rain on dry ground, terrain ~343 m +
+~1e-5 m of rainfall), mode-2's stage going into the fractional step is already ~1
+ULP off from mode-1, and it is **masked by the dry-cell bed-clamp** (`protect` sets
+`stage = bed` exactly in both) until the lift exposes it. Only in the just-wetted
+cells, zero in momentum; chaos-amplifies to mm over hours. Ruled out along the way:
+the rate operator's arithmetic (rate inputs are bit-identical; rain on a *fully
+wet* domain is bit-identical) and the device sync (a plain memcpy). This is why
+**towradgi's mode-1/mode-2 divergence is rain-on-dry-cells** — remove rain and the
+whole run is bit-identical. Same family as the #200 dry-cell gap; benign (both
+modes valid). The exact operation was not isolated (it needs instrumenting the C
+RK loop's device state mid-step). The session-51 in-process double-precision
+localization harness (build two domains from the same setup, restartable lockstep
+evolve, diff `centroid_values` in double precision) is the tool if it's ever chased.
+
 ---
 
 ## API

--- a/claude/SESSION_GUIDE.md
+++ b/claude/SESSION_GUIDE.md
@@ -449,7 +449,54 @@ Findings:
 
 ---
 
-## Recent session summaries (sessions 21–50)
+## Recent session summaries (sessions 21–51)
+
+**Session 51 (2026-07-19/20):** **Unify the culvert kernel (mode-1 == mode-2), diagnose
+Towradgi's residual as rain-on-dry, tighten comparison tolerances.** Rebuilt CPU-only
+(gcc, `-Dgpu_offload=false`), confirmed the full suite green in both modes (legacy 2698 /
+unified 2697), then closed out the mode-1-vs-mode-2 culvert difference and chased what's left.
+- **Culvert unification (commit `b7a010ae`).** Extracted the per-culvert discharge +
+  semi-implicit transfer into one C routine `culvert_compute_one()` plus a shared host inlet
+  gather `culvert_gather_inlet_host()` (`gpu_culvert_operator.c`). Mode-2's batch calls it
+  (behaviour-preserving); **mode-1's Python operators now route their per-step update through it
+  via a Cython bridge** (`culvert_apply_one_host` / `culvert_gather_inlet_host_py`), gated to
+  fully-local culverts (cross-boundary MPI keeps the Python path). Wired into **both**
+  `Structure_operator` and — the one that matters — `Parallel_Structure_operator`. Result:
+  **mode-1 == mode-2 bit-for-bit** for every culvert config (box/pipe, velocity head, blockage),
+  1 and 16 threads. De-dups the Python/C physics on the runtime path.
+  - **The seed was the inlet-average gather**, not momentum/ordering/FMA: mode-1 summed with
+    numpy, mode-2 with a C loop, 1 ULP apart for multi-cell inlets.
+  - **Two wrong-turn traps worth remembering:** (1) `anuga.Boyd_box_operator` is a **factory**
+    returning `Parallel_Boyd_box_operator` — a *separate* class hierarchy from `Structure_operator`
+    — even in serial, so a monkeypatch of `Structure_operator.__call__` silently hit an unused
+    class and produced two invalid "proofs". Instrument the class that actually runs. (2) An FMA
+    hypothesis was moot: the CPU build is generic x86-64 (no `-march`/`-mfma`).
+- **Towradgi still diverges → it's rain-on-dry, NOT culverts.** Built an **in-process
+  double-precision localization harness** (two domains from the same setup, restartable lockstep
+  evolve, diff `centroid_values` in double). It pinned the seed to `Rate_operator` on **dry**
+  cells: remove rain → bit-identical; rain on a **fully-wet** domain → bit-identical; rain on
+  **dry** → 1 ULP. **Corrected framing:** both modes are *stage-primary* (`height == stage - bed`
+  in each); the residual is a 1-ULP difference in the core's near-dry **stage itself**, masked by
+  the dry-cell bed-clamp (`protect` sets `stage=bed`) until rain lifts the cell off the bed. Rate
+  inputs and the device sync (a plain memcpy) are ruled out; exact operation not isolated (needs
+  C-RK-loop device-state instrumentation). Same family as #200; **benign, accepted**. Red
+  herring: the #200 init dry-cell clamp asymmetry — forcing mode-1 to clamp too left the
+  divergence unchanged, so the initial state is not the cause. Documented in FUTURE_WORK /
+  KNOWN_ISSUES (commit `aadbd8e7`).
+- **GPU build validated.** Rebuilt nvc (`gpu_offload=true`, cc120, RTX 5070). Towradgi
+  mode-1(CPU) vs mode-2(GPU): same-order divergence dominated by rain-on-dry (**wet-only ΔStage
+  ≈ 0 at t=120** — only dry cells differ; wet cells diverge later via chaos). Isolated GPU test
+  runner: **all classes pass** on the device, including the culvert/weir/dry-cell/fractional-step
+  tests that touch the changed code.
+- **Tightened mode-1/mode-2 comparison tolerances (commit `7a42bb2d`).** The culvert/weir
+  CPU-vs-GPU tests used **atol=0.02/0.05** with comments blaming Python-vs-C ~3% drift — obsolete
+  now that both run the same C kernel. Re-measured and tightened: culvert 0.02/0.05→1e-10/1e-9,
+  weir 0.02→1e-10, inlet 1e-8→1e-10, forcing helper (wind/pressure/**rate**) 1e-8→1e-10 on GPU.
+  Measured ≤1.2e-15 everywhere (rain bit-identical); kept 5–6 orders of headroom. These now catch
+  a mode-1/mode-2 regression instead of silently passing multi-percent drift. All 17 pass under
+  the isolated GPU runner. **Lesson:** when a comparison test's loose tolerance is justified by a
+  "Python vs C FP drift" note, re-measure after any unification — the rationale may be stale by
+  orders of magnitude. All commits on `develop`, pushed to `stoiver`.
 
 **Session 50 (2026-07-16/19):** **mode-1 vs mode-2 difference notebook → two real GPU bugs.**
 Built `validation_tests/case_studies/towradgi/compare_mode1_mode2.ipynb` (uses


### PR DESCRIPTION
## Summary

Unify the Boyd/weir culvert update into a **single C kernel** shared by mode-1
(legacy CPU) and mode-2 (unified / GPU-ext), removing the duplicated Python/C
physics on the runtime path and making the two compute modes **bit-for-bit
identical** for culverts. Also tightens the now-obsolete mode-1/mode-2 comparison
test tolerances, and adds a CI job that exercises the unified (mode-2) build.

## Changes

- **Culvert unification** (`b7a010ae`) — extract `culvert_compute_one()` + a shared
  host inlet gather `culvert_gather_inlet_host()` in `gpu_culvert_operator.c`.
  Mode-2's batch calls it (behaviour-preserving); mode-1's Python operators (both
  `Structure_operator` and the default `Parallel_Structure_operator`) route their
  per-step update through it via a thin Cython bridge, gated to fully-local
  culverts (cross-boundary MPI keeps the Python path). The prior 1-ULP
  mode-1/mode-2 seed was the inlet-average gather (numpy sum vs a C loop); both now
  use the same code.
- **Tighten mode comparison tolerances** (`7a42bb2d`) — the culvert/weir CPU-vs-GPU
  tests used `atol=0.02/0.05`, justified by a now-obsolete "Python `boyd_box_function`
  vs C ~3% drift" note. Measured actual diffs (<=1e-15) and tightened: culvert
  0.02/0.05 -> 1e-10/1e-9; weir 0.02 -> 1e-10; inlet 1e-8 -> 1e-10; forcing helper
  1e-8 -> 1e-10 on GPU. These now catch a real mode-1/mode-2 regression.
- **CI: unified (mode-2) full-suite job** (`2e163d1b`) — run the full suite with
  `ANUGA_DEFAULT_COMPUTE_MODE=unified` on Linux / Python 3.14. First CI validation
  of the mode-2 gcc build.
- **Docs** (`aadbd8e7`, `02774f4e`) — session notes, and the diagnosis that
  Towradgi's residual mode-1/mode-2 divergence is **rain-on-dry-cells** (a 1-ULP
  near-dry stage roundoff, #200 family) — *not* a culvert or rate-operator bug
  (rain on a fully-wet domain is bit-identical; removing rain makes the whole run
  bit-identical). Recorded as benign in `KNOWN_ISSUES.md`.

## Validation

- Full suite green in **both** compute modes on the CPU (gcc) build:
  legacy 2698 / unified 2697 (fast); 2917 / 2916 (full).
- mode-1 == mode-2 **bit-identical** for every culvert config (box/pipe, velocity
  head, blockage), at 1 and 16 threads.
- nvc GPU build (RTX 5070): isolated GPU test runner — **all classes pass**;
  Towradgi mode-1(CPU) vs mode-2(GPU) sensible and benign.
- CI on `stoiver/develop`: **all 15 matrix cells green**, including the new
  unified/mode-2 job (ran, not skipped, on Ubuntu / Python 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
