### PR TITLE
Fix Sanddune_erosion_operator: scalar base + whole-domain (indices=None) crashes

### DIFF
--- a/anuga/operators/sanddune_erosion_operator.py
+++ b/anuga/operators/sanddune_erosion_operator.py
@@ -139,7 +139,20 @@ class Sanddune_erosion_operator(Operator, Region)  :
         #------------------------------------------
         # Local variables
         #------------------------------------------
-        self.base = base
+        # self.base must be indexable the same way self.elev_c / self.stage_c
+        # are (i.e. a full-domain array), since __call__ does self.base[ind].
+        # Allow the caller to pass either a single uniform base level (int/float)
+        # or a pre-built per-triangle array.
+        if num.isscalar(base):
+            self.base = num.full(domain.number_of_elements, float(base))
+        else:
+            self.base = num.asarray(base, dtype=float)
+            if self.base.shape[0] != domain.number_of_elements:
+                raise ValueError(
+                    "sanddune_erosion_operator: 'base' array length (%d) does not "
+                    "match number of domain elements (%d)"
+                    % (self.base.shape[0], domain.number_of_elements)
+                )
 
         if self.indices != []:
 

--- a/anuga/operators/sanddune_erosion_operator.py
+++ b/anuga/operators/sanddune_erosion_operator.py
@@ -154,27 +154,10 @@ class Sanddune_erosion_operator(Operator, Region)  :
                     % (self.base.shape[0], domain.number_of_elements)
                 )
 
-        if self.indices != []:
-
-            ind = self.indices
-            if ind is None:
-                # None means "apply to the entire domain" - see note in __call__.
-                ind = num.arange(domain.number_of_elements)
-
-            neighbours = self.domain.surrogate_neighbours
-
-            self.neighbourindices = neighbours[ind]           # get the neighbour Indices for each triangle in the erosion zone(s)
-
-            self.n0 = self.neighbourindices[:,0]              # separate into three lists
-            self.n1 = self.neighbourindices[:,1]
-            self.n2 = self.neighbourindices[:,2]
-
-            k = self.n0.shape[0]                              # Erosion poly lEN - num of triangles in poly
-
-            self.e = num.zeros((k,3))                         # create elev array k triangles, 3 neighbour elev
-
-            self.ident  = num.arange(k)                       # ident is array 0.. k-1, step 1
-
+        # Note: neighbour-index arrays are NOT cached here. Erosion-zone
+        # membership (self.indices) can change size between calls, so the
+        # neighbour arrays are rebuilt against the current indices every call
+        # in __call__ rather than once at construction.
 
 
     def __call__(self):

--- a/anuga/operators/sanddune_erosion_operator.py
+++ b/anuga/operators/sanddune_erosion_operator.py
@@ -171,7 +171,11 @@ class Sanddune_erosion_operator(Operator, Region)  :
 
         updated = True             # flag called OK
 
-        if self.indices != []:     # empty list no polygon - return
+        # self.indices is None (whole domain), [] (nothing to do), or a non-empty
+        # ndarray of triangle ids. Test with len()/is None rather than
+        # `self.indices != []`, which raises under NumPy 2.x when self.indices is
+        # an array (array-vs-empty-list broadcast error).
+        if self.indices is None or len(self.indices) > 0:
 
 
             Wd       = self.Wd

--- a/anuga/operators/sanddune_erosion_operator.py
+++ b/anuga/operators/sanddune_erosion_operator.py
@@ -157,6 +157,9 @@ class Sanddune_erosion_operator(Operator, Region)  :
         if self.indices != []:
 
             ind = self.indices
+            if ind is None:
+                # None means "apply to the entire domain" - see note in __call__.
+                ind = num.arange(domain.number_of_elements)
 
             neighbours = self.domain.surrogate_neighbours
 
@@ -212,6 +215,12 @@ class Sanddune_erosion_operator(Operator, Region)  :
 
 
             ind = self.indices             # indices of triangles in polygon
+            if ind is None:
+                # None means "apply to the entire domain" (Region/Operator convention).
+                # Left unresolved, NumPy silently treats None as np.newaxis when used
+                # as a fancy index, producing corrupted-shape intermediate arrays
+                # instead of an error - so it must be turned into a real index array.
+                ind = num.arange(self.domain.number_of_elements)
 
             stage_c_ind = self.stage_c[ind]
             elev_c_ind  = self.elev_c[ind]
@@ -241,23 +250,24 @@ class Sanddune_erosion_operator(Operator, Region)  :
             # that the final face slope lies at or about the angle of repose. This only approximates the
     		# collapse process as slopes are CG to CG and not specifically oriented to the dip angle.
             #--------------------------------------------------------------------------------------------
-            #neighbours = self.domain.surrogate_neighbours
+            # NOTE: self.indices can change size from one call to the next (e.g. threshold-based
+            # region membership shrinking/growing as water rises or recedes). The neighbour-index
+            # arrays therefore CANNOT be safely cached once in __init__ (as a fixed-size self.n0/
+            # self.e/self.ident) - they must be rebuilt against the current ind every call.
 
-            #neighbourindices = neighbours[ind]           # get the neighbour Indices for each triangle in the erosion zone(s)
+            neighbours = self.domain.surrogate_neighbours
 
-            #n0 = neighbourindices[:,0]                   # separate into three lists
-            #n1 = neighbourindices[:,1]
-            #n2 = neighbourindices[:,2]
+            neighbourindices = neighbours[ind]           # get the neighbour Indices for each triangle in the erosion zone(s)
 
-            #k = n0.shape[0]                              # Erosion poly lEN - num of triangles in poly
+            n0 = neighbourindices[:,0]                   # separate into three lists
+            n1 = neighbourindices[:,1]
+            n2 = neighbourindices[:,2]
 
-            #e = num.zeros((k,3))                         # create elev array k triangles, 3 neighbour elev
+            k = n0.shape[0]                              # Erosion poly lEN - num of triangles in poly
 
-            n0 = self.n0
-            n1 = self.n1
-            n2 = self.n2
+            e = num.zeros((k,3))                         # create elev array k triangles, 3 neighbour elev
 
-            e = self.e
+            ident = num.arange(k)                        # ident is array 0.. k-1, step 1
 
             e[:,0] = self.elev_c[n0]                     # get the elev of each neighbours CG
             e[:,1] = self.elev_c[n1]
@@ -265,7 +275,7 @@ class Sanddune_erosion_operator(Operator, Region)  :
 
             minid0 = num.argmin(e, axis=1)               # get indices of min elev for each triangles neighbours
 
-            n0ind = self.neighbourindices[self.ident,minid0]       # store the neighbour indices in order lowest elev first (n0)
+            n0ind = neighbourindices[ident,minid0]       # store the neighbour indices in order lowest elev first (n0)
 
 
             # compute the plan distance lxy from each triangles CG to the lowest neighbours CG

--- a/anuga/operators/tests/meson.build
+++ b/anuga/operators/tests/meson.build
@@ -9,6 +9,7 @@ python_sources = [
 'test_mannings_operator.py',
 'test_kinematic_viscosity_operator.py',
 'test_rate_operators.py',
+'test_sanddune_erosion_operator.py',
 'test_set_elevation_operator.py',
 'test_set_quantity.py',
 'test_set_stage_operator.py',

--- a/anuga/operators/tests/test_sanddune_erosion_operator.py
+++ b/anuga/operators/tests/test_sanddune_erosion_operator.py
@@ -104,6 +104,43 @@ class Test_sanddune_erosion_operator(unittest.TestCase):
             num.all(self.domain.quantities['elevation'].centroid_values
                     >= base_level - 1.0e-10))
 
+    def test_subset_indices_with_full_domain_base_array(self):
+        """Primary usage (see anuga-clinic notebook3): a full-domain base array
+        applied to a subset of triangles selected by indices.
+
+        Also a regression for the ``self.indices != []`` guard, which raised a
+        broadcast ValueError under NumPy 2.x once Region turned a non-empty
+        indices list into an ndarray.
+        """
+        # Notebook pattern: base is the initial (full-domain) elevation array.
+        base = self.domain.get_quantity('elevation').get_values(
+            location='centroids').copy()
+        indices = [0, 1]
+        operator = Sanddune_erosion_operator(
+            self.domain, base=base, indices=indices, Ra=45)
+
+        elev_before = self.domain.quantities['elevation'].centroid_values.copy()
+        self.domain.timestep = 1.0
+        operator()   # must not raise
+        elev_after = self.domain.quantities['elevation'].centroid_values
+
+        # Triangles outside the erosion indices are left untouched.
+        outside = [i for i in range(self.domain.number_of_elements)
+                   if i not in indices]
+        self.assertTrue(num.allclose(elev_before[outside], elev_after[outside]))
+
+    def test_empty_indices_is_a_noop(self):
+        """indices=[] means "apply nowhere": nothing changes and nothing raises."""
+        operator = Sanddune_erosion_operator(self.domain, indices=[])
+        elev_before = self.domain.quantities['elevation'].centroid_values.copy()
+        stage_before = self.domain.quantities['stage'].centroid_values.copy()
+        self.domain.timestep = 1.0
+        operator()
+        self.assertTrue(num.allclose(
+            elev_before, self.domain.quantities['elevation'].centroid_values))
+        self.assertTrue(num.allclose(
+            stage_before, self.domain.quantities['stage'].centroid_values))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/anuga/operators/tests/test_sanddune_erosion_operator.py
+++ b/anuga/operators/tests/test_sanddune_erosion_operator.py
@@ -1,0 +1,109 @@
+"""Tests for Sanddune_erosion_operator.
+
+Regression coverage for the two crashes fixed on branch
+``fix/sanddune-erosion-base-scalar``:
+
+1. A default scalar ``base`` was indexed as an array (``self.base[ind]``),
+   raising ``TypeError: 'float' object is not subscriptable``.
+2. Whole-domain application (``indices=None``) passed ``None`` straight into
+   NumPy fancy indexing (``neighbours[None]``), which inserts a new axis
+   instead of selecting everything and corrupted the neighbour arrays,
+   eventually surfacing as a broadcasting ``ValueError``.
+
+Both are exercised together by applying the operator to the whole domain with
+the default scalar ``base`` and running it through a timestep.
+"""
+
+import unittest
+
+import numpy as num
+
+import anuga
+from anuga import Reflective_boundary
+from anuga.operators.sanddune_erosion_operator import Sanddune_erosion_operator
+
+
+def make_domain():
+    """4-triangle domain with moving water over a 0.5 m bed."""
+    a = [0.0, 0.0]; b = [0.0, 2.0]; c = [2.0, 0.0]
+    d = [0.0, 4.0]; e = [2.0, 2.0]; f = [4.0, 0.0]
+    points = [a, b, c, d, e, f]
+    vertices = [[1, 0, 2], [1, 2, 4], [4, 2, 5], [3, 1, 4]]
+    domain = anuga.Domain(points, vertices)
+    domain.set_quantity('elevation', 0.5)
+    domain.set_quantity('stage', 1.0)
+    domain.set_quantity('friction', 0.0)
+    domain.set_quantity('xmomentum', 2.0)
+    domain.set_quantity('ymomentum', 3.0)
+    domain.set_boundary({'exterior': Reflective_boundary(domain)})
+    return domain
+
+
+class Test_sanddune_erosion_operator(unittest.TestCase):
+
+    def setUp(self):
+        self.domain = make_domain()
+
+    def test_whole_domain_scalar_base_runs(self):
+        """indices=None + default scalar base: previously crashed, now runs.
+
+        Covers both fixed bugs at once (scalar-base indexing and the
+        None-as-newaxis fancy-index corruption).
+        """
+        n = self.domain.number_of_elements
+        stage_c = self.domain.quantities['stage'].centroid_values
+        elev_c = self.domain.quantities['elevation'].centroid_values
+        height_before = num.sum(stage_c - elev_c)
+
+        operator = Sanddune_erosion_operator(self.domain)   # indices=None, base=0.0
+
+        self.domain.timestep = 1.0
+        operator()   # must not raise
+
+        # Water column (height) is preserved: stage is rebuilt as elev + depth.
+        height_after = num.sum(
+            self.domain.quantities['stage'].centroid_values
+            - self.domain.quantities['elevation'].centroid_values)
+        self.assertTrue(num.allclose(height_before, height_after))
+
+        # Erosion never cuts below the base level (0.0 here) anywhere.
+        self.assertTrue(
+            num.all(self.domain.quantities['elevation'].centroid_values
+                    >= 0.0 - 1.0e-10))
+        # Shapes untouched.
+        self.assertEqual(
+            self.domain.quantities['elevation'].centroid_values.shape, (n,))
+
+    def test_scalar_base_expanded_to_full_array(self):
+        """A scalar base is broadcast to a per-element array of the right length."""
+        n = self.domain.number_of_elements
+        operator = Sanddune_erosion_operator(self.domain, base=0.25)
+        self.assertEqual(num.shape(operator.base), (n,))
+        self.assertTrue(num.allclose(operator.base, 0.25))
+
+    def test_per_element_base_array_accepted(self):
+        """A correctly sized per-element base array is accepted as-is."""
+        n = self.domain.number_of_elements
+        base = num.linspace(0.0, 0.2, n)
+        operator = Sanddune_erosion_operator(self.domain, base=base)
+        self.assertTrue(num.allclose(operator.base, base))
+
+    def test_wrong_length_base_array_raises(self):
+        """A base array whose length != number_of_elements is rejected."""
+        n = self.domain.number_of_elements
+        with self.assertRaises(ValueError):
+            Sanddune_erosion_operator(self.domain, base=num.zeros(n + 1))
+
+    def test_base_level_is_respected(self):
+        """Erosion cannot lower elevation below a raised base level."""
+        base_level = 0.5   # equal to the bed, so no erosion is permitted
+        operator = Sanddune_erosion_operator(self.domain, base=base_level)
+        self.domain.timestep = 5.0
+        operator()
+        self.assertTrue(
+            num.all(self.domain.quantities['elevation'].centroid_values
+                    >= base_level - 1.0e-10))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes two crashes in `Sanddune_erosion_operator` when applied to the whole Model_Domain (`indices=None`) with a default scalar `base`:

1. `self.base` defaulted to a scalar but `__call__` indexed it as an array (`self.base[ind]`) — `TypeError: 'float' object is not subscriptable`.
2. `self.indices is None` (whole-domain case) was passed directly into NumPy fancy indexing (`neighbours[ind]`), which silently inserts a new axis instead of selecting everything — corrupting `self.n0`/`self.e` from construction, eventually surfacing as `ValueError: could not broadcast input array from shape (3,) into shape (1,)`.

This branch also fixes a third issue found in the process: neighbour-index arrays were cached once in `__init__`, but erosion-zone membership can shrink/grow between timesteps (e.g. threshold-based regions as water rises/recedes), so they need to be rebuilt every call rather than cached.

Confirmed working end-to-end on a real simulation using a Sand Dune erosion operator applied to the whole Model_Domain with default `base` — previously crashed immediately on the first evolve step; runs to completion on this branch.