### PR TITLE
Fix non-portable PyPI wheels: drop -march=native from meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,9 +75,12 @@ if openmp.found()
  
   #if host_machine.system() == 'windows'
   
-  openmp_c_args = ['-O3', '-march=native', '-fopenmp', '-g']
-  # openmp_c_args = ['-O3', '-march=native','-funroll-loops', '-fvectorize', '-Rpass=loop-vectorize', '-Rpass=loop-unroll', '-g'],
-  # openmp_c_args = ['-O3', '-march=native', openmp_flag, '-g'],
+  # Do NOT use -march=native here: it bakes the build host's ISA into the
+  # compiled extensions, so a wheel built on e.g. a Sapphire Rapids CI runner
+  # gets AVX-512 and dies with an illegal instruction at `import anuga` on any
+  # CPU without it (this broke the 3.3.8 PyPI wheels, e.g. on Colab). Leave the
+  # toolchain's portable default in place (conda-forge sets -march=nocona).
+  openmp_c_args = ['-O3', '-fopenmp', '-g']
 
   openmp_deps = dependencies + [openmp]
 


### PR DESCRIPTION
## Problem

The 3.3.8 PyPI **Linux wheels crash at `import anuga`** with an illegal instruction on CPUs without AVX-512 (e.g. Google Colab).

## Root cause

`meson.build` compiled the OpenMP extension modules with **`-march=native`**:

```meson
openmp_c_args = ['-O3', '-march=native', '-fopenmp', '-g']
```

As a meson *project* c_arg this takes precedence over the environment `CFLAGS` (conda-forge sets the portable `-march=nocona`), so GCC expands `native` to the CI runner's exact microarchitecture and bakes that ISA into the `.so` files — including the Cython module-init function, which is why it dies at *import*:

```
# 3.3.8 wheel, built on a Sapphire Rapids runner:
$ readelf -n sw_domain_openmp_ext...so | grep 'x86 ISA'
  x86 ISA used: x86-64-baseline, x86-64-v3, x86-64-v4      # v4 = AVX-512
```

It's intermittent across releases because it tracks whichever runner built the wheel (Intel Sapphire Rapids → AVX-512; AMD Zen 3 → AVX2; etc.).

## Fix

Drop `-march=native` from `openmp_c_args` so the toolchain's portable default stands (conda-forge's `-march=nocona`). This matches `develop`, whose wheels already build as baseline/v2 with **no AVX/AVX-512** — verified on a develop CI wheel:

```
$ readelf -n sw_domain_openmp_ext...so | grep 'x86 ISA'   # develop
  x86 ISA used: x86-64-baseline, x86-64-v2                 # producer: -march=nocona
```

Peak-performance builds should come from source or conda (`--march=native` locally).

> Supersedes the earlier workflow-`CFLAGS` approach on this branch: an env `CFLAGS` override can't win against a meson project c_arg, so it didn't actually change the baked ISA. The fix has to be in `meson.build`.

## Verify after CI
Download a Linux wheel artifact and confirm no AVX-512:
```
readelf -n .../sw_domain_openmp_ext.*.so | grep 'x86 ISA'   # expect no x86-64-v4
```

Targets `main` for a 3.3.x patch release. `develop` already dropped `-march=native`, so it needs no change (PR #205 closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)