### PR TITLE
CI: build standard (GIL) cp314 wheels, not cp314t (develop)

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -43,8 +43,15 @@ jobs:
       - name: Create conda environment with build deps
         shell: bash -el {0}
         run: |
+          # Pin the standard (GIL) CPython ABI. On Linux `python=3.14` otherwise
+          # resolves to the free-threaded build (cp314t) and yields a cp314t
+          # wheel instead of a standard cp314 one (anuga's OpenMP extensions are
+          # not free-thread-safe anyway). Constrain python_abi to the *_cp<tag>
+          # (GIL) build: python_abi uses the cp3XX tag consistently across
+          # versions, so this excludes cp3XXt and is a no-op for 3.10-3.13.
+          pytag=$(echo "${{ matrix.python-version }}" | tr -d .)
           conda create -n anuga_env -c conda-forge \
-            python=${{ matrix.python-version }} pip \
+            python=${{ matrix.python-version }} "python_abi=${{ matrix.python-version }}=*_cp${pytag}" pip \
             meson-python meson ninja cython pybind11 numpy pkg-config
 
       - name: Install compilers (Windows)
@@ -128,8 +135,10 @@ jobs:
       - name: Create osx-64 conda env (x86_64 packages, run under Rosetta)
         shell: bash -el {0}
         run: |
+          # Pin the standard (GIL) CPython ABI (see build-wheels above).
+          pytag=$(echo "${{ matrix.python-version }}" | tr -d .)
           CONDA_SUBDIR=osx-64 conda create -n anuga_env -c conda-forge \
-            python=${{ matrix.python-version }} pip \
+            python=${{ matrix.python-version }} "python_abi=${{ matrix.python-version }}=*_cp${pytag}" pip \
             meson-python meson ninja cython pybind11 numpy pkg-config compilers
           conda activate anuga_env
           conda config --env --set subdir osx-64


### PR DESCRIPTION
Cherry-pick of #206 onto develop.

`conda create ... python=3.14` on linux-64 resolves to the free-threaded build (cp314t), so the Linux 3.14 wheel was tagged `cp314-cp314t` and a standard GIL CPython 3.14 on Linux gets no matching wheel (falls back to sdist). anuga's OpenMP extensions aren't free-thread-safe, so the standard cp314 wheel is the correct artifact.

Fix: pin the conda python to the GIL build via `"python=${{ matrix.python-version }}=*cp${pytag}"` in both env-create steps (build-wheels and build-wheels-osx64). No-op for 3.10–3.13 and on platforms already resolving to GIL.

Same commit as #206. Verify after CI: the py3.14 ubuntu wheel artifact is `cp314-cp314` (not `cp314t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)