### PR TITLE
Merge main into develop: base develop version on 3.3.10

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -44,8 +44,15 @@ jobs:
       - name: Create conda environment with build deps
         shell: bash -el {0}
         run: |
+          # Pin the standard (GIL) CPython ABI. On Linux `python=3.14` otherwise
+          # resolves to the free-threaded build (cp314t) and yields a cp314t
+          # wheel instead of a standard cp314 one (anuga's OpenMP extensions are
+          # not free-thread-safe anyway). Constrain python_abi to the *_cp<tag>
+          # (GIL) build: python_abi uses the cp3XX tag consistently across
+          # versions, so this excludes cp3XXt and is a no-op for 3.10-3.13.
+          pytag=$(echo "${{ matrix.python-version }}" | tr -d .)
           conda create -n anuga_env -c conda-forge \
-            python=${{ matrix.python-version }} pip \
+            python=${{ matrix.python-version }} "python_abi=${{ matrix.python-version }}=*_cp${pytag}" pip \
             meson-python meson ninja cython pybind11 numpy pkg-config
 
       - name: Install compilers (Windows)
@@ -129,8 +136,10 @@ jobs:
       - name: Create osx-64 conda env (x86_64 packages, run under Rosetta)
         shell: bash -el {0}
         run: |
+          # Pin the standard (GIL) CPython ABI (see build-wheels above).
+          pytag=$(echo "${{ matrix.python-version }}" | tr -d .)
           CONDA_SUBDIR=osx-64 conda create -n anuga_env -c conda-forge \
-            python=${{ matrix.python-version }} pip \
+            python=${{ matrix.python-version }} "python_abi=${{ matrix.python-version }}=*_cp${pytag}" pip \
             meson-python meson ninja cython pybind11 numpy pkg-config compilers
           conda activate anuga_env
           conda config --env --set subdir osx-64

--- a/meson.build
+++ b/meson.build
@@ -75,9 +75,12 @@ if openmp.found()
  
   #if host_machine.system() == 'windows'
   
-  openmp_c_args = ['-O3', '-march=native', '-fopenmp', '-g']
-  # openmp_c_args = ['-O3', '-march=native','-funroll-loops', '-fvectorize', '-Rpass=loop-vectorize', '-Rpass=loop-unroll', '-g'],
-  # openmp_c_args = ['-O3', '-march=native', openmp_flag, '-g'],
+  # Do NOT use -march=native here: it bakes the build host's ISA into the
+  # compiled extensions, so a wheel built on e.g. a Sapphire Rapids CI runner
+  # gets AVX-512 and dies with an illegal instruction at `import anuga` on any
+  # CPU without it (this broke the 3.3.8 PyPI wheels, e.g. on Colab). Leave the
+  # toolchain's portable default in place (conda-forge sets -march=nocona).
+  openmp_c_args = ['-O3', '-fopenmp', '-g']
 
   openmp_deps = dependencies + [openmp]
 


### PR DESCRIPTION
## Summary

Brings the `3.3.10` release tag into `develop`'s history so `git describe`
bases the develop version on **3.3.10** instead of the stale **3.3.8**:

```
git describe --tags  →  3.3.10-861-ga3c32260   (was 3.3.8-860-...)
```

`develop` already carried both underlying release fixes by content — this
merge only reconciles history so the tag is an ancestor:

- **Portable wheels** — `-march=native` dropped from `openmp_c_args` (the fix that broke the 3.3.8 PyPI wheels with AVX-512; #204-equivalent already on develop).
- **cp314 wheels** — CI builds standard GIL `cp314-cp314` wheels, not `cp314t` (#207, already on develop).

## Conflict resolution

One conflict, in `meson.build`'s OpenMP flag block. Resolved by keeping
develop's per-compiler `openmp_c_args` dispatch (none of which use
`-march=native`) and preserving main's explanatory comment on why
`-march=native` must not be reintroduced. No functional change to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)