### PR TITLE
Propagate OpenMP thread count to all domains; document mesh-size guidance

### DIFF
--- a/anuga/__init__.py
+++ b/anuga/__init__.py
@@ -55,7 +55,7 @@ def test(*args, **kwargs):
 from anuga.shallow_water.shallow_water_domain import Domain
 from anuga.shallow_water.shallow_water_domain import (
     set_gpu_offload, gpu_offload_enabled, gpu_offload_supported,
-    set_omp_num_threads)
+    set_omp_num_threads, get_omp_num_threads)
 from anuga.abstract_2d_finite_volumes.quantity import Quantity
 from anuga.abstract_2d_finite_volumes.region import Region
 from anuga.geospatial_data.geospatial_data import Geospatial_data
@@ -376,6 +376,7 @@ __all__ = [
     'gpu_offload_enabled',
     'gpu_offload_supported',
     'set_omp_num_threads',
+    'get_omp_num_threads',
     'Geo_reference',
     'Geospatial_data',
     'Mesh',

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -379,13 +379,32 @@ def set_gpu_offload(enable: bool = True, verbose: bool = True) -> bool:
     return state
 
 
+# Process-wide OpenMP thread count for ANUGA kernels. This is the single source
+# of truth read back by ``Domain.omp_num_threads`` (a property), so that setting
+# it once via ``anuga.set_omp_num_threads(n)`` is reflected by every domain in
+# the session — including ones already constructed (important in notebooks).
+# Initialised from OMP_NUM_THREADS so introspection is sane before the first
+# call / domain construction.
+try:
+    _omp_num_threads = int(os.environ.get('OMP_NUM_THREADS', 1))
+except (ValueError, TypeError):
+    _omp_num_threads = 1
+
+
+def get_omp_num_threads() -> int:
+    """Return the current process-wide OpenMP thread count for ANUGA kernels."""
+    return _omp_num_threads
+
+
 def set_omp_num_threads(omp_num_threads: int | None = None, verbose: bool = True) -> int:
     """Set the OpenMP thread count for ANUGA kernels (process-wide).
 
     ``OMP_NUM_THREADS`` / ``omp_set_num_threads`` controls the whole process, so
     this is a module-level setting, not per-domain — it affects every domain's
     OpenMP regions (both the legacy ``sw_domain_openmp_ext`` solver and the
-    unified ``gpu_ext`` kernels). ``Domain.set_omp_num_threads`` delegates here.
+    unified ``gpu_ext`` kernels), and is reflected by the ``omp_num_threads``
+    property of every existing domain. ``Domain.set_omp_num_threads`` delegates
+    here.
 
     Parameters
     ----------
@@ -421,6 +440,10 @@ def set_omp_num_threads(omp_num_threads: int | None = None, verbose: bool = True
     # Keep the env var consistent so banners / introspection / any subprocess
     # report the same count (the runtime ICV is already set above).
     os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
+    # Record the process-wide count so every domain's omp_num_threads property
+    # reflects this call (including domains constructed before it).
+    global _omp_num_threads
+    _omp_num_threads = omp_num_threads
 
     if verbose:
         print(f'Setting omp_num_threads to {omp_num_threads}')
@@ -5950,15 +5973,31 @@ class Domain(Generic_Domain):
         """
         return self.multiprocessor_mode
 
+    @property
+    def omp_num_threads(self) -> int:
+        """The process-wide OpenMP thread count (read-only view).
+
+        OpenMP thread count is a process-level setting, not per-domain, so this
+        reflects the live value set by :func:`anuga.set_omp_num_threads` for
+        *every* domain in the session — including domains constructed before the
+        call. Assigning to it (``domain.omp_num_threads = n``) is kept for
+        backward compatibility and sets the count process-wide.
+        """
+        return get_omp_num_threads()
+
+    @omp_num_threads.setter
+    def omp_num_threads(self, value: int) -> None:
+        set_omp_num_threads(value, verbose=False)
+
     def set_omp_num_threads(self, omp_num_threads: int | None = None, verbose: bool = True) -> None:
         """Set the OpenMP thread count (process-wide).
 
         OpenMP thread count is a process-level setting, not per-domain. This is a
         thin wrapper that delegates to the module-level
         :func:`anuga.set_omp_num_threads`; prefer that in new code. Kept for
-        backward compatibility, and records ``self.omp_num_threads``.
+        backward compatibility.
         """
-        self.omp_num_threads = set_omp_num_threads(omp_num_threads, verbose=verbose)
+        set_omp_num_threads(omp_num_threads, verbose=verbose)
 
 
     @property

--- a/anuga/shallow_water/tests/test_shallow_water_domain.py
+++ b/anuga/shallow_water/tests/test_shallow_water_domain.py
@@ -3879,6 +3879,62 @@ friction  \n \
         domain.get_extent()
 
 
+class Test_OMP_Num_Threads(unittest.TestCase):
+    """OpenMP thread count is process-wide, so anuga.set_omp_num_threads(n)
+    must be reflected by every domain in the session, including ones already
+    constructed (the notebook use-case)."""
+
+    def setUp(self):
+        from anuga.shallow_water.shallow_water_domain import get_omp_num_threads
+        self._saved = get_omp_num_threads()
+        self._saved_env = os.environ.get('OMP_NUM_THREADS')
+
+    def tearDown(self):
+        from anuga.shallow_water.shallow_water_domain import set_omp_num_threads
+        set_omp_num_threads(self._saved, verbose=False)
+        if self._saved_env is None:
+            os.environ.pop('OMP_NUM_THREADS', None)
+        else:
+            os.environ['OMP_NUM_THREADS'] = self._saved_env
+
+    def _make_domain(self):
+        points, vertices, boundary = rectangular_cross(4, 4)
+        return Domain(points, vertices, boundary)
+
+    def test_module_level_propagates_to_existing_and_new_domains(self):
+        from anuga.shallow_water.shallow_water_domain import (
+            set_omp_num_threads, get_omp_num_threads)
+
+        set_omp_num_threads(1, verbose=False)
+        d1 = self._make_domain()
+        self.assertEqual(d1.omp_num_threads, 1)
+
+        # Bump the session count AFTER d1 already exists.
+        set_omp_num_threads(3, verbose=False)
+        self.assertEqual(get_omp_num_threads(), 3)
+        self.assertEqual(d1.omp_num_threads, 3)          # existing domain updates
+        self.assertEqual(os.environ['OMP_NUM_THREADS'], '3')
+
+        d2 = self._make_domain()
+        self.assertEqual(d2.omp_num_threads, 3)          # new domain inherits it
+
+    def test_backward_compatible_setters_are_process_wide(self):
+        from anuga.shallow_water.shallow_water_domain import set_omp_num_threads
+
+        set_omp_num_threads(1, verbose=False)
+        d1 = self._make_domain()
+        d2 = self._make_domain()
+
+        # Legacy attribute assignment still works and is process-wide.
+        d1.omp_num_threads = 2
+        self.assertEqual(d1.omp_num_threads, 2)
+        self.assertEqual(d2.omp_num_threads, 2)
+
+        # Legacy Domain.set_omp_num_threads() method still works and is process-wide.
+        d2.set_omp_num_threads(4, verbose=False)
+        self.assertEqual(d1.omp_num_threads, 4)
+        self.assertEqual(d2.omp_num_threads, 4)
+
 
 #################################################################################
 

--- a/docs/source/appendices/compute_modes.rst
+++ b/docs/source/appendices/compute_modes.rst
@@ -67,6 +67,96 @@ degrade gracefully to the CPU path — ``set_gpu_offload(True)`` warns and retur
 :ref:`use_gpu_offloading` for hardware/compiler requirements and build steps).
 
 
+When is parallelism worth it? (mesh-size guidance)
+--------------------------------------------------
+
+Neither OpenMP threads nor GPU offload speed up a *small* mesh. The shallow
+water solver is memory-bandwidth-bound, and each timestep is a sequence of short
+parallel regions. On a small domain the fixed per-region costs — OpenMP
+fork/join, and for the GPU the kernel-launch latency — dominate the actual
+arithmetic, so extra threads give little and the GPU can be *slower than a single
+CPU core*. Parallelism only pays off once the mesh is large enough to amortise
+that overhead.
+
+The numbers below are illustrative measurements on **one machine** (32-core CPU
+vs an RTX 5070 Laptop GPU, single rank, ``unified`` mode, steady-state timing
+with one-time setup excluded). **Treat the crossover sizes, not the exact
+ratios, as the takeaway** — both shift with CPU core count, memory bandwidth,
+GPU class, and problem.
+
+**OpenMP thread scaling** (speedup over a single core):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20
+
+   * - Triangles
+     - 8-thread speedup
+     - Notes
+   * - ~400
+     - 0.4×
+     - *slower* — fork/join overhead wins
+   * - ~1,600
+     - 1.4×
+     - barely worthwhile
+   * - ~6,400
+     - 2.6×
+     -
+   * - ~25,600
+     - 4.4×
+     -
+   * - ~100,000+
+     - ~5–6×
+     - near-peak (bandwidth-bound plateau, below the ideal 8×)
+
+**GPU offload crossover** (speedup, same meshes):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20
+
+   * - Triangles
+     - vs 1 core
+     - vs 8 threads
+   * - ~100–400
+     - 0.5× (slower)
+     - 0.6× (slower)
+   * - ~1,600
+     - 1.1×
+     - 0.7× (slower)
+   * - ~6,400
+     - 3.4×
+     - ~1.0× (tie)
+   * - ~25,600
+     - 7.9×
+     - 1.5×
+   * - ~100,000
+     - 12×
+     - 1.8×
+   * - ~400,000
+     - 15×
+     - 2.9× (still climbing)
+
+**Rule of thumb:**
+
+- Small exploratory meshes (a few hundred to a few thousand triangles, e.g. a
+  quick Jupyter notebook) — stay on **legacy, single-threaded**. Threads give
+  almost nothing and the GPU is counterproductive.
+- From **~10k triangles**, raise ``anuga.set_omp_num_threads()`` for a useful CPU
+  speedup.
+- Reach for the **GPU above ~25k triangles** versus a multicore CPU (or above
+  ~1.5k versus a single core); its lead keeps growing into the hundreds of
+  thousands of triangles, which is where these solvers are meant to run.
+
+.. note::
+
+   OpenMP thread count is **process-wide**, so ``anuga.set_omp_num_threads(n)``
+   applies to every domain in the session — including ones already constructed
+   (each domain's ``omp_num_threads`` reflects the live process-wide value).
+   Setting it once at the top of a notebook is enough;
+   ``anuga.get_omp_num_threads()`` reports the current value.
+
+
 Command-line flags
 ------------------
 


### PR DESCRIPTION
## Summary

`anuga.set_omp_num_threads(n)` already set the process-wide OpenMP count and the
compute kernels honoured it — but each `Domain` cached `omp_num_threads` as a
plain instance value fixed at construction. So in a notebook, setting the thread
count in a later cell left an already-built domain **reporting** the stale count
(even though its kernels ran with `n`), which reads as "it didn't propagate".

Since OpenMP thread count is genuinely **process-wide**, this makes it a single
source of truth instead of per-domain cached state:

- Module-level `_omp_num_threads`, updated by `set_omp_num_threads()`, plus a new
  `get_omp_num_threads()` (exported as `anuga.get_omp_num_threads`).
- `Domain.omp_num_threads` is now a **property** returning the live process-wide
  value, so every domain — existing or newly constructed — reports the same
  count.
- Backward compatible: `domain.omp_num_threads = n` (setter) and
  `Domain.set_omp_num_threads(n)` still work and set the count process-wide.

No C rebuild required — pure-Python change (kernels already read the global
OpenMP ICV that `set_omp_num_threads` sets).

## Docs

Adds a **"When is parallelism worth it? (mesh-size guidance)"** section to the
compute-modes appendix, with measured OpenMP-scaling and GPU-crossover tables and
a mesh-size rule of thumb:

- Small notebook meshes (hundreds–low thousands of triangles) gain ~nothing from
  threads and are *slower* on the GPU (launch/transfer overhead dominates a
  bandwidth-bound solver).
- OpenMP threads help from ~10k triangles; GPU wins above ~25k vs a multicore CPU
  (above ~1.5k vs a single core), with the lead growing into the hundreds of
  thousands.
- Caveat: the numbers are from one machine (32-core CPU vs RTX 5070 Laptop) — the
  *crossover sizes*, not the exact ratios, are the takeaway.

## Tests

`Test_OMP_Num_Threads` — notebook-order propagation (set threads after a domain
exists → existing and new domains both report the new count) and the
backward-compatible attribute/method setters. Full `test_shallow_water_domain.py`
(48) + new (2) pass; pickle/deepcopy unaffected; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)