### PR TITLE
environments: add contextily to visualisation deps (fixes greyed-out SWW GUI basemap)

### DIFF
--- a/environments/environment_3.10.yml
+++ b/environments/environment_3.10.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.10_intel.yml
+++ b/environments/environment_3.10_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.11.yml
+++ b/environments/environment_3.11.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.11_intel.yml
+++ b/environments/environment_3.11_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.12.yml
+++ b/environments/environment_3.12.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.12_intel.yml
+++ b/environments/environment_3.12_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.13.yml
+++ b/environments/environment_3.13.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.13_intel.yml
+++ b/environments/environment_3.13_intel.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.14.yml
+++ b/environments/environment_3.14.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.14_intel.yml
+++ b/environments/environment_3.14_intel.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.10.yml
+++ b/environments/environment_win_3.10.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.11.yml
+++ b/environments/environment_win_3.11.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.12.yml
+++ b/environments/environment_win_3.12.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.13.yml
+++ b/environments/environment_win_3.13.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio


### PR DESCRIPTION
## Summary

The `anuga_sww_gui` basemap overlay (OpenStreetMap / Esri, via **contextily**)
is disabled whenever `import contextily` fails — even when the SWW file carries a
valid EPSG. `contextily>=1.3` was declared in the pyproject `gui`
optional-dependencies extra, but it was **missing from every conda environment
YAML**, which is the documented setup path
(`conda env create --file environments/...`). So a standard conda checkout got an
env without contextily and the Basemap checkbox silently stayed greyed out.

## Change

Add `- contextily` (after `- cartopy`) to the **14 supported** environment YAMLs:

- `environment_3.10` … `3.14` (+ each `_intel` variant)
- `environment_win_3.10` … `win_3.13`

The deprecated `3.8`/`3.9` YAMLs are left untouched (below the
`requires-python >=3.10` floor). `Pillow` (the other `gui` extra) is already
pulled in transitively by conda-forge `matplotlib`, so it's not added explicitly.

All 14 files parse cleanly as YAML.

## Not changed

`pyproject.toml` already lists `contextily>=1.3` under `[project.optional-dependencies].gui`, so `pip install anuga[gui]` was already correct — this only closes the conda-env gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)