### PR TITLE
Add Docker images (CPU + GPU/nvc) with S3 batch entrypoint for AWS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Keep the Docker build context small and reproducible.
+# (Applies to builds whose context is the repo root, e.g. docker/Dockerfile.gpu.)
+#
+# NOTE: the meson build only descends into anuga/ (plus scripts/ and
+# _git_version.py), and installs package data such as anuga/**/data/*.tsh|*.msh.
+# So do NOT exclude those by extension — instead drop the large directories that
+# are not part of the wheel build (validation data, examples, docs, sandpit).
+
+.git
+.github
+build
+dist
+*.egg-info
+**/__pycache__
+**/*.pyc
+**/*.so
+**/*.o
+
+# Large directories not needed to build/install the wheel
+validation_tests
+examples
+docs
+sandpit
+claude
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+
+# Docker's own runtime mount (not build input)
+docker/data

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,6 +78,12 @@ jobs:
           df -h /
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history + tags so _git_version.py can describe
+
+      - name: Compute ANUGA version (PEP 440, from git)
+        id: ver
+        run: echo "v=$(python _git_version.py)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -92,10 +98,15 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           flavor: |
-            suffix=-gpu,onlatest=true
+            suffix=-gpu,onlatest=false
           tags: |
+            # branch name (e.g. develop-gpu) — the pre-release channel
+            type=ref,event=branch
+            # immutable commit tag (e.g. sha-abc1234-gpu)
+            type=sha
+            # release version (e.g. 4.0.0-gpu) and latest-gpu, only on a Release
             type=ref,event=tag
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build & push GPU image
         uses: docker/build-push-action@v6
@@ -106,5 +117,6 @@ jobs:
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}
             GPU_ARCH=${{ inputs.gpu_arch }}
+            ANUGA_VERSION=${{ steps.ver.outputs.v }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ on:
         default: '25.9-devel-cuda_multi-ubuntu24.04'
       gpu_arch:
         description: 'nvc -gpu arch list for the GPU image'
-        default: 'cc70,cc75,cc80,cc86,cc89,cc90,cc120'
+        default: 'cc75,cc80,cc86,cc89,cc90,cc120'
 
 permissions:
   contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,110 @@
+# Build and publish ANUGA container images to GitHub Container Registry (GHCR).
+#
+# - CPU image: built + pushed automatically on a GitHub Release (and on demand).
+# - GPU image: opt-in only (workflow_dispatch with build_gpu=true), because the
+#   NVHPC base is ~15 GB and the multi-arch build is heavy for free runners —
+#   it may need disk cleanup and/or a larger runner. It is never in the release
+#   critical path.
+#
+# Images: ghcr.io/<owner>/anuga:<tag>-cpu  and  ...:<tag>-gpu
+name: Build and Publish Docker images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      build_gpu:
+        description: 'Also build & push the (large) GPU image'
+        type: boolean
+        default: false
+      nvhpc_tag:
+        description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
+        default: '25.9-devel-cuda_multi-ubuntu24.04'
+      gpu_arch:
+        description: 'nvc -gpu arch list for the GPU image'
+        default: 'cc70,cc75,cc80,cc86,cc90,cc120'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/anuga
+
+jobs:
+  cpu:
+    name: CPU image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tags for CPU image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: |
+            suffix=-cpu,onlatest=true
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+      - name: Build & push CPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.cpu
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  gpu:
+    name: GPU image (opt-in)
+    if: github.event_name == 'workflow_dispatch' && inputs.build_gpu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free up disk space (NVHPC base is large)
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h /
+
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tags for GPU image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: |
+            suffix=-gpu,onlatest=true
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build & push GPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.gpu
+          push: true
+          build-args: |
+            NVHPC_TAG=${{ inputs.nvhpc_tag }}
+            GPU_ARCH=${{ inputs.gpu_arch }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ on:
         default: '25.9-devel-cuda_multi-ubuntu24.04'
       gpu_arch:
         description: 'nvc -gpu arch list for the GPU image'
-        default: 'cc70,cc75,cc80,cc86,cc90,cc120'
+        default: 'cc70,cc75,cc80,cc86,cc89,cc90,cc120'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ claude/CDAC_EXECUTIVE_SUMMARY.md
 
 # Profiling artifacts
 *.prof
+docker/data/output/

--- a/_git_version.py
+++ b/_git_version.py
@@ -11,12 +11,20 @@ PEP 440 mapping:
   abcdef  (no tag reachable)     -> 0.0.0+gabcdef
 """
 
+import os
 import re
 import subprocess
 import sys
 
 
 def git_version():
+    # Allow an explicit override (PEP 440 string) for builds where git metadata
+    # is unavailable — e.g. an sdist, or a Docker build whose context excludes
+    # .git. Set ANUGA_VERSION to what `git describe` would have produced.
+    override = os.environ.get('ANUGA_VERSION', '').strip()
+    if override:
+        return override
+
     result = subprocess.run(
         ['git', 'describe', '--tags', '--dirty', '--always'],
         capture_output=True, text=True

--- a/docker/AWS_SETUP.md
+++ b/docker/AWS_SETUP.md
@@ -1,0 +1,94 @@
+# Setting up AWS to run ANUGA GPU jobs
+
+A practical, ordered walkthrough from "no account" to running `aws_run_gpu.sh`.
+Two GPU-specific gotchas are called out — **a service-quota increase** and
+**billing guardrails** — do those early.
+
+> **Cost note:** GPU instances are **not** free-tier. You pay from the first run
+> (~US$1.2/hr for a `g5.2xlarge` on-demand, ~$0.4 spot). Set up the budget in
+> step 5 before running anything. Each user runs in **their own AWS account and
+> pays for their own usage** — there is no shared/central bill.
+
+## 1. Create the account
+- aws.amazon.com → **Create an AWS Account**. Needs an email, a **credit card**,
+  and phone verification.
+- The signup email/password is the **root user** (all-powerful). Use it only for
+  account/billing setup, then stop using it day-to-day.
+
+## 2. Lock down the root user
+- Sign in as root → **IAM → enable MFA** on the root user (authenticator app).
+  This is the single most important security step.
+- Do **not** create access keys for the root user.
+
+## 3. Create your everyday identity
+- **Simplest (solo account):** IAM → **Users → Create user** → attach
+  **AdministratorAccess** (fine in your own account) → create an **access key**
+  (type: CLI). Save the Key ID + Secret. Enable MFA on this user too.
+- **More secure/modern:** IAM **Identity Center** → user + admin permission set,
+  then sign in with `aws configure sso`. Either works with the launch script.
+
+## 4. Install and configure the AWS CLI
+```bash
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip awscliv2.zip && sudo ./aws/install
+aws configure                 # paste Key ID + Secret, set region + output=json
+aws sts get-caller-identity   # confirms creds work
+```
+
+## 5. Set a budget + billing alert — **before running jobs**
+- Root → **Account → "IAM user and role access to billing"** = Activate.
+- **Billing → Budgets → Create budget** → monthly cost budget (e.g. $50) with an
+  email alert at 80% / 100%. The first two budgets are free. This is your safety
+  net against a forgotten/runaway instance.
+
+## 6. Request the GPU quota increase — **do this early (can take hours–days)**
+New accounts have a **0-vCPU quota** for GPU instances, so the first GPU launch
+*fails* until this is approved.
+- **Service Quotas → Amazon EC2 →** search **"Running On-Demand G and P
+  instances"** → request an increase to at least **8 vCPUs** (a `g5.2xlarge` =
+  8 vCPU; ask for 16–32 for headroom).
+- Using Spot too? Also raise **"All G and P Spot Instance Requests"**.
+
+## 7. Pick a region + make an S3 bucket
+- Choose a region near you with GPU availability. In Australia:
+  **`ap-southeast-2` (Sydney)** — has the `g5`/`g6` families. Set it as your
+  default in `aws configure`.
+- Create a bucket (globally-unique name), same region:
+  ```bash
+  aws s3 mb s3://my-anuga-bucket --region ap-southeast-2
+  ```
+
+## 8. Dry-run, then run a GPU job
+Check everything (creds, GPU quota, AMI, the launch plan) **without spending**:
+```bash
+docker/aws_run_gpu.sh --region ap-southeast-2 \
+  --output s3://my-anuga-bucket/anuga/out \
+  --command "python run.py" --dry-run
+```
+Then launch for real:
+```bash
+docker/aws_run_gpu.sh --region ap-southeast-2 \
+  --upload  ./my_project \
+  --input   s3://my-anuga-bucket/anuga/in \
+  --output  s3://my-anuga-bucket/anuga/out \
+  --command "python run_Tohoku.py -alg DE0"
+```
+It launches one `g5.2xlarge` (A10G / cc86, 8 vCPU, 32 GB), runs the container,
+uploads results (+ `anuga-run.log`) to `--output`, and **self-terminates**.
+A ~1M-triangle single-GPU run fits comfortably (a few GB of GPU memory).
+
+## 9. Cost hygiene
+- The instance self-terminates, but verify occasionally:
+  ```bash
+  aws ec2 describe-instances --region ap-southeast-2 \
+    --filters Name=tag:Name,Values=anuga-gpu-run \
+              Name=instance-state-name,Values=running \
+    --query 'Reservations[].Instances[].InstanceId' --output text
+  ```
+- Delete outputs you don't need (`aws s3 rm --recursive s3://.../out`) or set an
+  S3 lifecycle rule. Your Budget alert (step 5) is the backstop.
+
+---
+
+**Do first / in parallel:** step 5 (budget) and step 6 (quota) — the quota
+approval is the long pole, and the budget protects you from surprises.

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -21,13 +21,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgomp1 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# anuga[data] pulls the optional geodata stack (rasterio/fiona/shapely/xarray/
+# pandas/openpyxl) that case-study scripts need — e.g. spatialInputUtil's
+# readListOfRiverWalls, shapefile/raster/polygon-CSV I/O — which otherwise
+# import in a degraded mode and raise AttributeError/ImportError.
 RUN pip install --no-cache-dir -U pip && \
-    pip install --no-cache-dir "anuga${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
-    python -c "import anuga; print('ANUGA', anuga.__version__, 'imported OK')"
+    pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
+    python -c "import anuga, fiona, rasterio, shapely; print('ANUGA', anuga.__version__, '+ geodata imported OK')"
 
 COPY docker/anuga-entrypoint.sh /usr/local/bin/anuga-entrypoint
 RUN chmod +x /usr/local/bin/anuga-entrypoint
 
 ENV ANUGA_WORKDIR=/work
+# Writable HOME/config so `docker run --user $(id -u):$(id -g)` works (host-owned
+# output, no root-owned files) without a home dir for the arbitrary uid.
+ENV HOME=/tmp MPLCONFIGDIR=/tmp
 WORKDIR /work
 ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,0 +1,33 @@
+# ANUGA — CPU image (slim, PyPI wheel).
+#
+# Runs ANUGA on the CPU, including the unified (mode-2) kernels as multicore
+# OpenMP. Ideal for CPU AWS Batch jobs and cheap instances. Tracks the
+# published release, not the working tree.
+#
+# Build (context = repo root, so the entrypoint script is available):
+#   docker build -f docker/Dockerfile.cpu -t anuga:cpu .
+#   docker build -f docker/Dockerfile.cpu --build-arg ANUGA_VERSION=3.3.10 -t anuga:cpu-3.3.10 .
+#
+# Run a script (mount a host dir with your input + collect the .sww output):
+#   docker run --rm -v "$PWD/data:/work" anuga:cpu python /work/my_run.py -alg DE0
+FROM python:3.12-slim
+
+# Empty = latest release; pin with e.g. --build-arg ANUGA_VERSION=3.3.10
+ARG ANUGA_VERSION=
+
+# libgomp1: OpenMP runtime the manylinux extension links against.
+# ca-certificates: TLS for pip/aws.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgomp1 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir "anuga${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
+    python -c "import anuga; print('ANUGA', anuga.__version__, 'imported OK')"
+
+COPY docker/anuga-entrypoint.sh /usr/local/bin/anuga-entrypoint
+RUN chmod +x /usr/local/bin/anuga-entrypoint
+
+ENV ANUGA_WORKDIR=/work
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -28,6 +28,15 @@ ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG}
 
 ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
+# PEP 440 version to stamp into the build (.git is excluded from the context, so
+# `git describe` can't run inside the image). Pass what it would have produced:
+#   --build-arg ANUGA_VERSION="$(python _git_version.py)"
+# Left empty => anuga.__version__ is 0.0.0+unknown (cosmetic).
+ARG ANUGA_VERSION=
+
+LABEL org.opencontainers.image.title="ANUGA (GPU, nvc)" \
+      org.opencontainers.image.source="https://github.com/anuga-community/anuga_core" \
+      org.opencontainers.image.version="${ANUGA_VERSION}"
 
 SHELL ["/bin/bash", "-lc"]
 
@@ -52,7 +61,8 @@ RUN set -euo pipefail && \
     echo "Using nvc: $NVC ($($NVC --version | head -1))" && \
     pip install --no-cache-dir -U pip && \
     pip install --no-cache-dir "numpy>=2.0" cython "meson>=1.4" meson-python ninja pybind11 && \
-    CC="$NVC" pip install --no-cache-dir --no-build-isolation -v \
+    ANUGA_VERSION="${ANUGA_VERSION}" CC="$NVC" \
+      pip install --no-cache-dir --no-build-isolation -v \
         -Csetup-args=-Dgpu_offload=true \
         -Csetup-args=-Dgpu_arch="${GPU_ARCH}" \
         ".[data]" && \

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -5,9 +5,13 @@
 # against nvc with gpu_offload=true for a multi-arch fat binary that runs on
 # both AWS datacenter GPUs and a local Blackwell laptop.
 #
-#   GPU_ARCH default cc70,cc75,cc80,cc86,cc89,cc90,cc120 covers:
-#     cc70 V100 (p3)   cc75 T4 (g4dn)   cc80 A100 (p4d)
-#     cc86 A10G (g5)   cc89 L4 (g6)     cc90 H100 (p5)   cc120 RTX 50-series (laptop)
+#   GPU_ARCH default cc75,cc80,cc86,cc89,cc90,cc120 covers:
+#     cc75 T4 (g4dn)   cc80 A100 (p4d)  cc86 A10G (g5)
+#     cc89 L4 (g6)     cc90 H100 (p5)   cc120 RTX 50-series (laptop)
+#   cc70 (V100 / p3) is intentionally excluded: NVHPC 25.9 defaults to CUDA 13,
+#   which dropped Volta (sm_70), so it can't share a fat binary with Blackwell
+#   (cc120). For V100 build a separate image with an older CUDA/NVHPC and
+#   --build-arg GPU_ARCH=cc70.
 #
 # NVHPC_TAG must be an nvcr.io/nvidia/nvhpc *devel* tag that exists AND whose
 # nvc supports every arch in GPU_ARCH (Blackwell/cc120 needs NVHPC >= 25.1).
@@ -27,7 +31,7 @@
 ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG}
 
-ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
+ARG GPU_ARCH=cc75,cc80,cc86,cc89,cc90,cc120
 # PEP 440 version to stamp into the build (.git is excluded from the context, so
 # `git describe` can't run inside the image). Pass what it would have produced:
 #   --build-arg ANUGA_VERSION="$(python _git_version.py)"

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,0 +1,73 @@
+# ANUGA — GPU image (built from source with the NVIDIA HPC SDK / nvc).
+#
+# There are no GPU wheels on PyPI: the GPU offload extension is OpenMP-target
+# code that must be compiled by nvc. This builds ANUGA from the repo checkout
+# against nvc with gpu_offload=true for a multi-arch fat binary that runs on
+# both AWS datacenter GPUs and a local Blackwell laptop.
+#
+#   GPU_ARCH default cc70,cc75,cc80,cc86,cc90,cc120 covers:
+#     cc70 V100 (p3)   cc75 T4 (g4dn)   cc80 A100 (p4d)
+#     cc86 A10G (g5)   cc90 H100 (p5)   cc120 RTX 50-series (local laptop)
+#
+# NVHPC_TAG must be an nvcr.io/nvidia/nvhpc *devel* tag that exists AND whose
+# nvc supports every arch in GPU_ARCH (Blackwell/cc120 needs NVHPC >= 25.1).
+# Verify a tag before the (long) build:
+#   docker pull nvcr.io/nvidia/nvhpc:25.9-devel-cuda_multi-ubuntu24.04
+# Tag list: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc/tags
+#
+# Build (context = repo root):
+#   docker build -f docker/Dockerfile.gpu -t anuga:gpu .
+#   docker build -f docker/Dockerfile.gpu \
+#     --build-arg NVHPC_TAG=26.3-devel-cuda_multi-ubuntu24.04 \
+#     --build-arg GPU_ARCH=cc120 -t anuga:gpu-local .        # laptop-only, smaller
+#
+# Run (GPU visible via the NVIDIA Container Toolkit; opt into offload per run):
+#   docker run --rm --gpus all -e ANUGA_DEFAULT_COMPUTE_MODE=unified \
+#     -v "$PWD/data:/work" anuga:gpu python /work/my_run.py -alg DE0
+ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
+FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG}
+
+ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc90,cc120
+
+SHELL ["/bin/bash", "-lc"]
+
+# Python + build tooling. (The NVHPC image ships nvc/CUDA but not a build-ready
+# Python.) A venv avoids Debian/Ubuntu PEP 668 "externally managed" errors.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-dev python3-pip git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /opt/anuga
+COPY . .
+
+# Build every extension with nvc (CC=nvc), GPU offload on, multi-arch.
+# --no-build-isolation so the pinned build deps + CC=nvc are the ones meson uses.
+RUN set -euo pipefail && \
+    NVC="$(command -v nvc || true)"; \
+    if [ -z "$NVC" ]; then echo "ERROR: nvc not found on PATH in this NVHPC image" >&2; exit 1; fi && \
+    echo "Using nvc: $NVC ($($NVC --version | head -1))" && \
+    pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir "numpy>=2.0" cython "meson>=1.4" meson-python ninja pybind11 && \
+    CC="$NVC" pip install --no-cache-dir --no-build-isolation -v \
+        -Csetup-args=-Dgpu_offload=true \
+        -Csetup-args=-Dgpu_arch="${GPU_ARCH}" \
+        . && \
+    pip install --no-cache-dir awscli && \
+    install -m 0755 docker/anuga-entrypoint.sh /usr/local/bin/anuga-entrypoint && \
+    cd / && \
+    python -c "import anuga; print('ANUGA', anuga.__version__, 'built + imported OK')" && \
+    rm -rf /opt/anuga
+# The import test runs from / (not /opt/anuga) so it imports the installed
+# package, not the source tree (which lacks the generated _version.py / .so).
+# The source tree is then removed: it is not needed at runtime and its presence
+# would shadow the installed package for anyone who cd'd into it.
+# Note: gpu_offload_supported() is False here (build has no GPU); verify offload
+# at runtime with `--gpus all` (see docker/README.md).
+
+ENV ANUGA_WORKDIR=/work
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -55,7 +55,7 @@ RUN set -euo pipefail && \
     CC="$NVC" pip install --no-cache-dir --no-build-isolation -v \
         -Csetup-args=-Dgpu_offload=true \
         -Csetup-args=-Dgpu_arch="${GPU_ARCH}" \
-        . && \
+        ".[data]" && \
     pip install --no-cache-dir awscli && \
     install -m 0755 docker/anuga-entrypoint.sh /usr/local/bin/anuga-entrypoint && \
     cd / && \
@@ -69,5 +69,8 @@ RUN set -euo pipefail && \
 # at runtime with `--gpus all` (see docker/README.md).
 
 ENV ANUGA_WORKDIR=/work
+# Writable HOME/config so `docker run --user $(id -u):$(id -g)` works (host-owned
+# output, no root-owned files) without a home dir for the arbitrary uid.
+ENV HOME=/tmp MPLCONFIGDIR=/tmp
 WORKDIR /work
 ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -5,9 +5,9 @@
 # against nvc with gpu_offload=true for a multi-arch fat binary that runs on
 # both AWS datacenter GPUs and a local Blackwell laptop.
 #
-#   GPU_ARCH default cc70,cc75,cc80,cc86,cc90,cc120 covers:
+#   GPU_ARCH default cc70,cc75,cc80,cc86,cc89,cc90,cc120 covers:
 #     cc70 V100 (p3)   cc75 T4 (g4dn)   cc80 A100 (p4d)
-#     cc86 A10G (g5)   cc90 H100 (p5)   cc120 RTX 50-series (local laptop)
+#     cc86 A10G (g5)   cc89 L4 (g6)     cc90 H100 (p5)   cc120 RTX 50-series (laptop)
 #
 # NVHPC_TAG must be an nvcr.io/nvidia/nvhpc *devel* tag that exists AND whose
 # nvc supports every arch in GPU_ARCH (Blackwell/cc120 needs NVHPC >= 25.1).
@@ -27,7 +27,7 @@
 ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG}
 
-ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc90,cc120
+ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
 
 SHELL ["/bin/bash", "-lc"]
 

--- a/docker/Dockerfile.gpu.slim
+++ b/docker/Dockerfile.gpu.slim
@@ -1,0 +1,63 @@
+# ANUGA — GPU image, SLIM multi-stage build.  *** EXPERIMENTAL / DRAFT ***
+#
+# Goal: cut the ~15 GB single-stage image (Dockerfile.gpu, whole NVHPC devel SDK)
+# down to a few GB by shipping only:
+#   * a CUDA *runtime* base,
+#   * the NVHPC *redistributable* runtime libs the nvc-compiled .so need, and
+#   * the built venv (anuga + deps).
+# Smaller image => cheaper storage and much faster AWS cold-start pulls.
+#
+# NOT YET VALIDATED. The fragile part is getting the exact set of NVHPC runtime
+# libraries right — `import anuga` and a GPU run must both work in the runtime
+# stage. Build locally and iterate (add any missing *.so to the REDIST copy)
+# the same way the single-stage image was brought up:
+#   docker build -f docker/Dockerfile.gpu.slim --build-arg GPU_ARCH=cc120 -t anuga:gpu-slim .
+#   docker run --rm --gpus all -e ANUGA_DEFAULT_COMPUTE_MODE=unified \
+#     -v "$PWD/data:/work" anuga:gpu-slim python /work/example_run.py
+# If import fails with a missing .so, widen the REDIST copy glob below.
+
+ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
+ARG CUDA_RUNTIME_TAG=12.6.2-runtime-ubuntu24.04
+
+# ---- builder: compile anuga with nvc (as in Dockerfile.gpu) -----------------
+FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG} AS builder
+ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
+SHELL ["/bin/bash", "-lc"]
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-dev python3-pip git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+WORKDIR /opt/anuga
+COPY . .
+RUN set -euo pipefail && \
+    NVC="$(command -v nvc)" && \
+    pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir "numpy>=2.0" cython "meson>=1.4" meson-python ninja pybind11 && \
+    CC="$NVC" pip install --no-cache-dir --no-build-isolation \
+        -Csetup-args=-Dgpu_offload=true -Csetup-args=-Dgpu_arch="${GPU_ARCH}" ".[data]" && \
+    pip install --no-cache-dir awscli && \
+    install -m 0755 docker/anuga-entrypoint.sh /opt/anuga-entrypoint
+# Collect the NVHPC redistributable runtime libs (libnvomp / libnvc / libacc* /
+# libnvhpcatm / libnvcpumath ...) the compiled extensions link against. REDIST
+# holds exactly the redistributable subset. Widen this glob if a lib is missing.
+RUN mkdir -p /opt/nvhpc-redist && \
+    cp -aL /opt/nvidia/hpc_sdk/Linux_x86_64/*/REDIST/compilers/lib/*.so* /opt/nvhpc-redist/ 2>/dev/null || true && \
+    ls -1 /opt/nvhpc-redist | sed 's/^/  redist: /'
+
+# ---- runtime: small CUDA-runtime base + venv + NVHPC redist libs ------------
+FROM nvidia/cuda:${CUDA_RUNTIME_TAG}
+# python3 must match the builder's minor (both ubuntu24.04 => 3.12). libgomp1
+# for the mode-1 CPU kernels; ca-certificates for aws/TLS.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 libgomp1 ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /opt/venv          /opt/venv
+COPY --from=builder /opt/nvhpc-redist  /opt/nvhpc-redist
+COPY --from=builder /opt/anuga-entrypoint /usr/local/bin/anuga-entrypoint
+ENV PATH="/opt/venv/bin:$PATH" \
+    LD_LIBRARY_PATH="/opt/nvhpc-redist:${LD_LIBRARY_PATH}" \
+    ANUGA_WORKDIR=/work HOME=/tmp MPLCONFIGDIR=/tmp
+RUN python -c "import anuga; print('slim ANUGA', anuga.__version__, 'imports OK')"
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/Dockerfile.gpu.slim
+++ b/docker/Dockerfile.gpu.slim
@@ -22,6 +22,7 @@ ARG CUDA_RUNTIME_TAG=12.6.2-runtime-ubuntu24.04
 # ---- builder: compile anuga with nvc (as in Dockerfile.gpu) -----------------
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG} AS builder
 ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
+ARG ANUGA_VERSION=
 SHELL ["/bin/bash", "-lc"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-venv python3-dev python3-pip git ca-certificates && \
@@ -35,7 +36,7 @@ RUN set -euo pipefail && \
     NVC="$(command -v nvc)" && \
     pip install --no-cache-dir -U pip && \
     pip install --no-cache-dir "numpy>=2.0" cython "meson>=1.4" meson-python ninja pybind11 && \
-    CC="$NVC" pip install --no-cache-dir --no-build-isolation \
+    ANUGA_VERSION="${ANUGA_VERSION}" CC="$NVC" pip install --no-cache-dir --no-build-isolation \
         -Csetup-args=-Dgpu_offload=true -Csetup-args=-Dgpu_arch="${GPU_ARCH}" ".[data]" && \
     pip install --no-cache-dir awscli && \
     install -m 0755 docker/anuga-entrypoint.sh /opt/anuga-entrypoint

--- a/docker/Dockerfile.gpu.slim
+++ b/docker/Dockerfile.gpu.slim
@@ -21,7 +21,7 @@ ARG CUDA_RUNTIME_TAG=12.6.2-runtime-ubuntu24.04
 
 # ---- builder: compile anuga with nvc (as in Dockerfile.gpu) -----------------
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG} AS builder
-ARG GPU_ARCH=cc70,cc75,cc80,cc86,cc89,cc90,cc120
+ARG GPU_ARCH=cc75,cc80,cc86,cc89,cc90,cc120
 ARG ANUGA_VERSION=
 SHELL ["/bin/bash", "-lc"]
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,6 +49,37 @@ docker build -f docker/Dockerfile.gpu -t anuga:gpu .
 # ...or a faster laptop-only build (RTX 50-series = cc120):
 docker build -f docker/Dockerfile.gpu \
   --build-arg GPU_ARCH=cc120 -t anuga:gpu-local .
+
+# Stamp a real version (else anuga.__version__ is 0.0.0+unknown, since .git is
+# excluded from the build context):
+docker build -f docker/Dockerfile.gpu \
+  --build-arg ANUGA_VERSION="$(python _git_version.py)" -t anuga:gpu .
+```
+
+### Published (pre-release) image
+
+The GPU image is built from the **develop** branch (v4.0 line), which isn't
+released yet — so it's published to GHCR under a **pre-release** tag, not
+`latest`:
+
+```bash
+docker pull ghcr.io/anuga-community/anuga:develop-gpu     # branch channel
+# or an immutable commit:  ghcr.io/anuga-community/anuga:sha-<short>-gpu
+```
+
+Publishing a container from develop is fine — it's an artifact, not a source
+release. The `docker-publish.yml` workflow (manual `workflow_dispatch`,
+`build_gpu=true`) tags `develop-gpu` + `sha-<short>-gpu`; version tags + `latest`
+only appear on a GitHub Release. Until CI has a big enough runner for the ~15 GB
+NVHPC base, the reliable path is to **build locally and push**:
+
+```bash
+docker build -f docker/Dockerfile.gpu \
+  --build-arg ANUGA_VERSION="$(python _git_version.py)" \
+  -t ghcr.io/anuga-community/anuga:develop-gpu .
+echo "$GHCR_PAT" | docker login ghcr.io -u <user> --password-stdin
+docker push ghcr.io/anuga-community/anuga:develop-gpu
+# then make the package public (org package settings) so AWS pulls without creds
 ```
 
 Verify offload actually reaches the GPU (needs `--gpus all`):

--- a/docker/README.md
+++ b/docker/README.md
@@ -117,12 +117,21 @@ docker/aws_run_gpu.sh \
 # results (+ anuga-run.log) appear under --output; the instance is gone.
 ```
 
+Validate first (checks creds, GPU quota, AMI; prints the plan; launches nothing):
+```bash
+docker/aws_run_gpu.sh --region ap-southeast-2 \
+  --output s3://my-bucket/anuga/out --command "python run.py" --dry-run
+```
+
 Defaults to `g5.2xlarge` (1× A10G / cc86, 8 vCPU, 32 GB — a good balance since
-mesh-gen + DEM fitting are CPU-bound). Flags: `--instance`, `--spot`, `--keep`
-(don't self-terminate, for debugging), `--ami`, `--instance-profile`, `--region`,
-`--disk`. Prereqs: `awscli` configured, an S3 bucket, and a one-time **GPU vCPU
-service-quota increase** (new accounts start at 0 for G/P families). Each user
-runs this in **their own AWS account and pays for their own usage**.
+mesh-gen + DEM fitting are CPU-bound). Flags: `--dry-run`, `--instance`, `--spot`,
+`--keep` (don't self-terminate, for debugging), `--ami`, `--instance-profile`,
+`--region`, `--disk`. Prereqs: `awscli` configured, an S3 bucket, and a one-time
+**GPU vCPU service-quota increase** (new accounts start at 0 for G/P families).
+Each user runs this in **their own AWS account and pays for their own usage**.
+
+**New to AWS?** Follow [`AWS_SETUP.md`](AWS_SETUP.md) — account, budget alerts,
+the quota increase, region + bucket, then dry-run and launch.
 
 A ~1M-triangle single-GPU run fits comfortably (only a few GB of GPU memory).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,159 @@
+# ANUGA in Docker (local + AWS)
+
+Two images:
+
+| Image | Base | ANUGA source | Use |
+|-------|------|--------------|-----|
+| `anuga:cpu` | `python:3.12-slim` | PyPI wheel | CPU runs; small, fast; CPU AWS Batch |
+| `anuga:gpu` | `nvcr.io/nvidia/nvhpc:*-devel` | built from this checkout with `nvc` | GPU offload; local Blackwell laptop **and** AWS GPU instances |
+
+Both share `anuga-entrypoint.sh`: a headless entrypoint that optionally syncs
+input from S3, runs the command you pass, and syncs `output/` back to S3 —
+ideal for AWS Batch, and a no-op locally when `INPUT_S3`/`OUTPUT_S3` are unset.
+
+There are **no GPU wheels** (the offload extension is OpenMP-target code only
+`nvc` compiles), so the GPU image must build from source.
+
+---
+
+## Prerequisites
+
+- **Docker** (`docker --version`).
+- **GPU image only:** NVIDIA driver on the host + the **NVIDIA Container
+  Toolkit**, then `docker run --gpus all ... nvidia-smi` should list your GPU.
+
+---
+
+## Build & test locally
+
+Put data in `docker/data/` (mounted at `/work` by compose).
+
+### CPU
+
+```bash
+docker build -f docker/Dockerfile.cpu -t anuga:cpu .
+docker run --rm anuga:cpu python -c "import anuga; print(anuga.__version__)"
+```
+
+### GPU
+
+First confirm the NVHPC base tag exists (and supports your arch — Blackwell
+`cc120` needs NVHPC ≥ 25.1). Tags: <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc/tags>
+
+```bash
+docker pull nvcr.io/nvidia/nvhpc:25.9-devel-cuda_multi-ubuntu24.04   # adjust if 404
+
+# Multi-arch (AWS + laptop). Large base + fat binary => slow, one-time.
+docker build -f docker/Dockerfile.gpu -t anuga:gpu .
+
+# ...or a faster laptop-only build (RTX 50-series = cc120):
+docker build -f docker/Dockerfile.gpu \
+  --build-arg GPU_ARCH=cc120 -t anuga:gpu-local .
+```
+
+Verify offload actually reaches the GPU (needs `--gpus all`):
+
+```bash
+docker run --rm --gpus all anuga:gpu python - <<'PY'
+import anuga
+print("supported:", anuga.gpu_offload_supported(), "enabled:", anuga.gpu_offload_enabled())
+PY
+```
+
+`supported: True` means the GPU is visible and the offload build works. A small
+unified run should print the "GPU Domain" startup banner:
+
+```bash
+docker run --rm --gpus all -e ANUGA_DEFAULT_COMPUTE_MODE=unified \
+  -v "$PWD/docker/data:/work" anuga:gpu python /work/my_run.py -alg DE0
+```
+
+### Via compose
+
+```bash
+docker compose -f docker/docker-compose.yml build anuga-gpu
+docker compose -f docker/docker-compose.yml run --rm anuga-gpu python /work/my_run.py
+```
+
+---
+
+## S3 entrypoint (the AWS batch pattern)
+
+The entrypoint runs whatever command you give it from `$ANUGA_WORKDIR` (`/work`)
+and, driven by env vars:
+
+| Env var | Effect |
+|---------|--------|
+| `INPUT_S3` | `aws s3 cp $INPUT_S3 /work/input --recursive` before the run |
+| `OUTPUT_S3` | `aws s3 cp /work/output $OUTPUT_S3 --recursive` after a successful run |
+| `STAGE_OUT_ON_FAILURE=1` | also upload output when the run fails |
+| `AWS_BATCH_JOB_ARRAY_INDEX` | appended to `OUTPUT_S3` (array jobs land in `.../0/`, `.../1/`, …) |
+
+Write results to `/work/output`. Credentials come from the environment / instance
+role — none are baked in. Test the flow locally with a mounted dir and no S3:
+
+```bash
+docker run --rm -v "$PWD/docker/data:/work" anuga:cpu python /work/my_run.py
+# results appear in docker/data/output/
+```
+
+---
+
+## Running on AWS
+
+Push to a registry AWS can pull (GHCR public, or your account's ECR):
+
+```bash
+# ECR example
+aws ecr create-repository --repository-name anuga || true
+aws ecr get-login-password | docker login --username AWS --password-stdin \
+  "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
+docker tag anuga:gpu "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu"
+docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu"
+```
+
+### AWS Batch (GPU)
+
+1. **Compute environment** — EC2 with GPU instance types (`p3`/`g4dn`/`g5`/`p4d`/`p5`)
+   using the **ECS GPU-optimized AMI** (driver + `nvidia-container-runtime`
+   preinstalled). Spot is fine for interruptible runs.
+2. **Job definition** — key fields:
+   ```json
+   {
+     "image": "<registry>/anuga:gpu",
+     "resourceRequirements": [
+       {"type": "GPU",    "value": "1"},
+       {"type": "VCPU",   "value": "8"},
+       {"type": "MEMORY", "value": "32768"}
+     ],
+     "environment": [
+       {"name": "INPUT_S3",  "value": "s3://my-bucket/tohoku/input/"},
+       {"name": "OUTPUT_S3", "value": "s3://my-bucket/tohoku/results/"},
+       {"name": "ANUGA_DEFAULT_COMPUTE_MODE", "value": "unified"}
+     ],
+     "command": ["python", "/work/input/my_run.py", "-alg", "DE0"],
+     "jobRoleArn": "arn:aws:iam::<acct>:role/anuga-batch-s3"
+   }
+   ```
+   Requesting `GPU: 1` makes ECS use the NVIDIA runtime and set
+   `NVIDIA_VISIBLE_DEVICES` — **do not** pass `--gpus`. The `jobRoleArn` grants
+   the S3 access the entrypoint uses.
+3. **Submit** — a single job, or an **array job** (`arraySize: N`) for a sweep;
+   each index gets its own `OUTPUT_S3/<index>/` prefix automatically.
+
+> Multi-GPU MPI (e.g. 8×A100 on a `p4d`) needs #ranks == #visible GPUs — see the
+> project note on MPI mode-2. Use a multi-node-parallel Batch job for cross-node MPI.
+
+---
+
+## Notes & caveats
+
+- **Image size:** the GPU image's NVHPC base is ~10–15 GB. A slimmer multi-stage
+  runtime (CUDA-runtime base + copied NVHPC redistributable libs + the venv) is a
+  worthwhile follow-up once the single-stage image is confirmed working.
+- **Version string:** `.git` is excluded from the build context, so a
+  source-built GPU image reports `0.0.0+unknown` for `anuga.__version__`
+  (cosmetic; the code is the checkout's).
+- **`ANUGA_DEFAULT_COMPUTE_MODE=unified`** turns on the mode-2 path. On the GPU
+  image with a visible GPU it offloads; without `--gpus` it falls back to the
+  (slow) host path. Leave it unset for legacy CPU runs.

--- a/docker/README.md
+++ b/docker/README.md
@@ -148,6 +148,17 @@ docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu"
 
 ## Notes & caveats
 
+- **File ownership / run as your host user.** By default the container runs as
+  **root**, so anything it writes to the bind-mounted dir (e.g. `MODEL_OUTPUTS/*.sww`)
+  is owned by `root` on the host. A later non-root run then can't overwrite those
+  files, and ANUGA silently reopens+appends to the stale `.sww` (garbled time
+  axis) instead of truncating. Avoid it by running as yourself:
+  ```bash
+  docker run --rm --gpus all --user "$(id -u):$(id -g)" \
+    -v "$PWD:/work" anuga:gpu python run.py
+  ```
+  (The images set `HOME=/tmp` so `--user` runs have a writable config dir. With
+  compose, `export UID GID` first — see the header of docker-compose.yml.)
 - **Image size:** the GPU image's NVHPC base is ~10–15 GB. A slimmer multi-stage
   runtime (CUDA-runtime base + copied NVHPC redistributable libs + the venv) is a
   worthwhile follow-up once the single-stage image is confirmed working.

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,8 +79,18 @@ docker build -f docker/Dockerfile.gpu \
   -t ghcr.io/anuga-community/anuga:develop-gpu .
 echo "$GHCR_PAT" | docker login ghcr.io -u <user> --password-stdin
 docker push ghcr.io/anuga-community/anuga:develop-gpu
-# then make the package public (org package settings) so AWS pulls without creds
 ```
+
+**Make the package public** (so AWS pulls without credentials). Two steps, both
+require an org **owner**:
+1. Allow public packages org-wide: **Org Settings → "Code, planning, and
+   automation" → Packages** → enable public packages.
+2. On the package: **Package settings → Danger Zone → Change visibility → Public**
+   (also link it to `anuga_core` via *Manage Actions access* so the workflow can
+   update it).
+
+`ghcr.io/anuga-community/anuga:develop-gpu` is currently **published and public**
+(anonymous `docker pull` verified).
 
 Verify offload actually reaches the GPU (needs `--gpus all`):
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -84,13 +84,14 @@ and, driven by env vars:
 
 | Env var | Effect |
 |---------|--------|
-| `INPUT_S3` | `aws s3 cp $INPUT_S3 /work/input --recursive` before the run |
-| `OUTPUT_S3` | `aws s3 cp /work/output $OUTPUT_S3 --recursive` after a successful run |
-| `STAGE_OUT_ON_FAILURE=1` | also upload output when the run fails |
+| `INPUT_S3` | `aws s3 sync $INPUT_S3 /work` before the run — input lands **in place** (so `python run.py` finds `run.py` at `/work/run.py`) |
+| `OUTPUT_S3` | `aws s3 sync <ANUGA_OUTPUT_DIR> $OUTPUT_S3` after a successful run |
+| `ANUGA_OUTPUT_DIR` | what to upload (default `/work` — captures output wherever the script writes it, e.g. `MODEL_OUTPUTS/`; set to a subdir to skip re-sending large inputs) |
+| `STAGE_OUT_ON_FAILURE=1` | also upload when the run fails |
 | `AWS_BATCH_JOB_ARRAY_INDEX` | appended to `OUTPUT_S3` (array jobs land in `.../0/`, `.../1/`, …) |
 
-Write results to `/work/output`. Credentials come from the environment / instance
-role — none are baked in. Test the flow locally with a mounted dir and no S3:
+Credentials come from the environment / instance role — none are baked in. Test
+the flow locally with a mounted dir and no S3:
 
 ```bash
 docker run --rm -v "$PWD/docker/data:/work" anuga:cpu python /work/my_run.py
@@ -99,9 +100,38 @@ docker run --rm -v "$PWD/docker/data:/work" anuga:cpu python /work/my_run.py
 
 ---
 
-## Running on AWS
+## Simplest AWS path — one self-terminating GPU instance
 
-Push to a registry AWS can pull (GHCR public, or your account's ECR):
+For a **single** GPU run with **no standing infrastructure** (ideal if you have
+no local GPU), `aws_run_gpu.sh` launches one GPU EC2 instance that pulls the
+image, runs your command with S3 in/out, uploads results, and **terminates
+itself**. You pay only for the job's instance-hours.
+
+```bash
+# upload your project (run script + data), launch, walk away:
+docker/aws_run_gpu.sh \
+  --upload  ./my_tohoku_project \
+  --input   s3://my-bucket/anuga/in \
+  --output  s3://my-bucket/anuga/out \
+  --command "python run_Tohoku.py -alg DE0"
+# results (+ anuga-run.log) appear under --output; the instance is gone.
+```
+
+Defaults to `g5.2xlarge` (1× A10G / cc86, 8 vCPU, 32 GB — a good balance since
+mesh-gen + DEM fitting are CPU-bound). Flags: `--instance`, `--spot`, `--keep`
+(don't self-terminate, for debugging), `--ami`, `--instance-profile`, `--region`,
+`--disk`. Prereqs: `awscli` configured, an S3 bucket, and a one-time **GPU vCPU
+service-quota increase** (new accounts start at 0 for G/P families). Each user
+runs this in **their own AWS account and pays for their own usage**.
+
+A ~1M-triangle single-GPU run fits comfortably (only a few GB of GPU memory).
+
+---
+
+## Running many jobs on AWS Batch
+
+For sweeps/ensembles, push to a registry AWS can pull (GHCR public, or your
+account's ECR) and use Batch array jobs:
 
 ```bash
 # ECR example
@@ -160,8 +190,10 @@ docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu"
   (The images set `HOME=/tmp` so `--user` runs have a writable config dir. With
   compose, `export UID GID` first — see the header of docker-compose.yml.)
 - **Image size:** the GPU image's NVHPC base is ~10–15 GB. A slimmer multi-stage
-  runtime (CUDA-runtime base + copied NVHPC redistributable libs + the venv) is a
-  worthwhile follow-up once the single-stage image is confirmed working.
+  runtime (CUDA-runtime base + copied NVHPC redistributable libs + the venv) is
+  drafted in `Dockerfile.gpu.slim` (**experimental** — needs local build-testing
+  to confirm the runtime-lib set). It should drop the image to a few GB, cutting
+  storage and AWS cold-start pull time.
 - **Version string:** `.git` is excluded from the build context, so a
   source-built GPU image reports `0.0.0+unknown` for `anuga.__version__`
   (cosmetic; the code is the checkout's).

--- a/docker/README.md
+++ b/docker/README.md
@@ -184,7 +184,8 @@ docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu"
 
 ### AWS Batch (GPU)
 
-1. **Compute environment** — EC2 with GPU instance types (`p3`/`g4dn`/`g5`/`p4d`/`p5`)
+1. **Compute environment** — EC2 with GPU instance types (`g4dn`/`g5`/`g6`/`p4d`/`p5`;
+   `p3`/V100 is not covered by the default image — see GPU_ARCH note in Dockerfile.gpu)
    using the **ECS GPU-optimized AMI** (driver + `nvidia-container-runtime`
    preinstalled). Spot is fine for interruptible runs.
 2. **Job definition** — key fields:

--- a/docker/anuga-entrypoint.sh
+++ b/docker/anuga-entrypoint.sh
@@ -3,29 +3,33 @@
 # ANUGA container entrypoint — headless/batch friendly with optional S3 I/O.
 #
 # Behaviour:
-#   * If INPUT_S3 is set, its contents are synced into $ANUGA_WORKDIR/input.
+#   * If INPUT_S3 is set, its contents are synced INTO the workdir ($ANUGA_WORKDIR,
+#     default /work) in place — so your run script and its data land right where
+#     the command runs (e.g. `python run.py` finds run.py at /work/run.py).
 #   * The command passed to the container ("$@") is run from $ANUGA_WORKDIR.
-#     Write your results into $ANUGA_WORKDIR/output.
-#   * If OUTPUT_S3 is set, $ANUGA_WORKDIR/output is synced up to it when the
-#     command finishes (on success; also on failure if STAGE_OUT_ON_FAILURE=1).
+#   * If OUTPUT_S3 is set, results are synced up to it after the run:
+#       - by default the whole workdir (captures output wherever the script
+#         writes it, e.g. MODEL_OUTPUTS/), which also re-sends the inputs;
+#       - set ANUGA_OUTPUT_DIR to a subdir (e.g. /work/MODEL_OUTPUTS) to upload
+#         only that and avoid re-sending large inputs.
+#     Uses `aws s3 sync`, so re-runs only upload changed/new files.
 #   * For AWS Batch array jobs, AWS_BATCH_JOB_ARRAY_INDEX is appended to
 #     OUTPUT_S3 so each index lands in its own prefix (.../0/, .../1/, ...).
 #   * With no command, drops to an interactive bash shell (local debugging).
 #
-# Credentials for aws come from the environment / instance role (e.g. the
-# AWS Batch job IAM role) — none are baked into the image.
+# Credentials for aws come from the environment / instance role (e.g. the AWS
+# Batch job IAM role, or an EC2 instance profile). None are baked into the image.
 set -euo pipefail
 
 WORKDIR="${ANUGA_WORKDIR:-/work}"
-mkdir -p "$WORKDIR/output"
+mkdir -p "$WORKDIR"
 cd "$WORKDIR"
 
 log() { echo "[anuga-entrypoint] $*" >&2; }
 
 if [ -n "${INPUT_S3:-}" ]; then
-    log "Staging input: ${INPUT_S3} -> ${WORKDIR}/input"
-    mkdir -p input
-    aws s3 cp "${INPUT_S3}" input --recursive
+    log "Staging input: ${INPUT_S3} -> ${WORKDIR}"
+    aws s3 sync "${INPUT_S3}" "${WORKDIR}"
 fi
 
 OUT="${OUTPUT_S3:-}"
@@ -36,9 +40,10 @@ fi
 stage_out() {
     local rc=$1
     [ -z "$OUT" ] && return 0
+    local src="${ANUGA_OUTPUT_DIR:-$WORKDIR}"
     if [ "$rc" -eq 0 ] || [ "${STAGE_OUT_ON_FAILURE:-0}" = "1" ]; then
-        log "Uploading results: ${WORKDIR}/output -> ${OUT}"
-        aws s3 cp output "${OUT}" --recursive || log "WARNING: upload to ${OUT} failed"
+        log "Uploading results: ${src} -> ${OUT}"
+        aws s3 sync "${src}" "${OUT}" || log "WARNING: upload to ${OUT} failed"
     else
         log "Command failed (rc=$rc); skipping upload (set STAGE_OUT_ON_FAILURE=1 to override)"
     fi

--- a/docker/anuga-entrypoint.sh
+++ b/docker/anuga-entrypoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# ANUGA container entrypoint — headless/batch friendly with optional S3 I/O.
+#
+# Behaviour:
+#   * If INPUT_S3 is set, its contents are synced into $ANUGA_WORKDIR/input.
+#   * The command passed to the container ("$@") is run from $ANUGA_WORKDIR.
+#     Write your results into $ANUGA_WORKDIR/output.
+#   * If OUTPUT_S3 is set, $ANUGA_WORKDIR/output is synced up to it when the
+#     command finishes (on success; also on failure if STAGE_OUT_ON_FAILURE=1).
+#   * For AWS Batch array jobs, AWS_BATCH_JOB_ARRAY_INDEX is appended to
+#     OUTPUT_S3 so each index lands in its own prefix (.../0/, .../1/, ...).
+#   * With no command, drops to an interactive bash shell (local debugging).
+#
+# Credentials for aws come from the environment / instance role (e.g. the
+# AWS Batch job IAM role) — none are baked into the image.
+set -euo pipefail
+
+WORKDIR="${ANUGA_WORKDIR:-/work}"
+mkdir -p "$WORKDIR/output"
+cd "$WORKDIR"
+
+log() { echo "[anuga-entrypoint] $*" >&2; }
+
+if [ -n "${INPUT_S3:-}" ]; then
+    log "Staging input: ${INPUT_S3} -> ${WORKDIR}/input"
+    mkdir -p input
+    aws s3 cp "${INPUT_S3}" input --recursive
+fi
+
+OUT="${OUTPUT_S3:-}"
+if [ -n "$OUT" ] && [ -n "${AWS_BATCH_JOB_ARRAY_INDEX:-}" ]; then
+    OUT="${OUT%/}/${AWS_BATCH_JOB_ARRAY_INDEX}"
+fi
+
+stage_out() {
+    local rc=$1
+    [ -z "$OUT" ] && return 0
+    if [ "$rc" -eq 0 ] || [ "${STAGE_OUT_ON_FAILURE:-0}" = "1" ]; then
+        log "Uploading results: ${WORKDIR}/output -> ${OUT}"
+        aws s3 cp output "${OUT}" --recursive || log "WARNING: upload to ${OUT} failed"
+    else
+        log "Command failed (rc=$rc); skipping upload (set STAGE_OUT_ON_FAILURE=1 to override)"
+    fi
+}
+
+# No command -> interactive shell for debugging on a local/EC2 box.
+if [ "$#" -eq 0 ]; then
+    log "No command given; starting interactive shell in ${WORKDIR}"
+    exec /bin/bash
+fi
+
+log "Running: $*"
+set +e
+"$@"
+rc=$?
+set -e
+stage_out "$rc"
+exit "$rc"

--- a/docker/aws_run_gpu.sh
+++ b/docker/aws_run_gpu.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# aws_run_gpu.sh — run a single ANUGA GPU job on AWS with no standing infra.
+#
+# Launches ONE GPU EC2 instance that pulls the anuga:gpu container, runs your
+# command with S3 input/output, uploads results, and TERMINATES itself. You pay
+# only for the instance-hours the job uses (it self-destructs when done).
+#
+# Prereqs: awscli configured (`aws configure`); an S3 bucket you can read/write;
+# a one-time GPU vCPU service-quota increase for the instance family (new
+# accounts start at 0 for G/P instances).
+#
+# Typical use — upload your project (run script + data), then launch:
+#   ./aws_run_gpu.sh \
+#       --upload   ./my_tohoku_project \
+#       --input    s3://my-bucket/anuga/in \
+#       --output   s3://my-bucket/anuga/out \
+#       --command  "python run_Tohoku.py -alg DE0"
+#
+# Results (and anuga-run.log) appear under --output. The instance is gone.
+#
+# NOTE: authored but not yet exercised against a live account — test with your
+# own creds and a tiny run first.
+set -euo pipefail
+
+# ---- defaults ---------------------------------------------------------------
+IMAGE="ghcr.io/anuga-community/anuga:latest-gpu"
+INSTANCE_TYPE="g5.2xlarge"        # 1x A10G (24GB, cc86), 8 vCPU, 32GB RAM
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+DISK_GB=100                       # root volume; DEMs + SWW output can be large
+COMPUTE_MODE="unified"            # GPU offload for mode-2 domains
+INPUT_S3="" ; OUTPUT_S3="" ; COMMAND="" ; UPLOAD_DIR="" ; OUTPUT_DIR=""
+INSTANCE_PROFILE="" ; AMI="" ; SSH_KEY="" ; SPOT=0 ; KEEP=0
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# ---- args -------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image)            IMAGE="$2"; shift 2 ;;
+    --instance)         INSTANCE_TYPE="$2"; shift 2 ;;
+    --region)           REGION="$2"; shift 2 ;;
+    --disk)             DISK_GB="$2"; shift 2 ;;
+    --input)            INPUT_S3="$2"; shift 2 ;;
+    --output)           OUTPUT_S3="$2"; shift 2 ;;
+    --command)          COMMAND="$2"; shift 2 ;;
+    --upload)           UPLOAD_DIR="$2"; shift 2 ;;
+    --output-dir)       OUTPUT_DIR="$2"; shift 2 ;;   # ANUGA_OUTPUT_DIR in container
+    --compute-mode)     COMPUTE_MODE="$2"; shift 2 ;;
+    --instance-profile) INSTANCE_PROFILE="$2"; shift 2 ;;
+    --ami)              AMI="$2"; shift 2 ;;
+    --ssh-key)          SSH_KEY="$2"; shift 2 ;;
+    --spot)             SPOT=1; shift ;;
+    --keep)             KEEP=1; shift ;;              # don't self-terminate (debug)
+    -h|--help)          usage 0 ;;
+    *) echo "unknown arg: $1" >&2; usage 1 ;;
+  esac
+done
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+[ -n "$OUTPUT_S3" ] || die "--output s3://... is required"
+[ -n "$COMMAND" ]   || die "--command '...' is required"
+[ -n "$REGION" ]    || die "no region (pass --region or set AWS_REGION)"
+[ -n "$UPLOAD_DIR" ] && [ -z "$INPUT_S3" ] && die "--upload needs --input to upload to"
+AWS=(aws --region "$REGION")
+
+bucket_of() { echo "$1" | sed -E 's#^s3://([^/]+).*#\1#'; }
+
+# ---- optional: upload a local project dir to the input prefix ---------------
+if [ -n "$UPLOAD_DIR" ]; then
+  echo ">> uploading ${UPLOAD_DIR} -> ${INPUT_S3}"
+  aws s3 sync "$UPLOAD_DIR" "$INPUT_S3"
+fi
+
+# ---- resolve a GPU-ready AMI (Docker + NVIDIA toolkit + driver preinstalled) -
+if [ -z "$AMI" ]; then
+  echo ">> resolving Deep Learning Base GPU AMI via SSM"
+  AMI=$("${AWS[@]}" ssm get-parameter \
+    --name /aws/service/deeplearning/ami/x86_64/base-oss-nvidia-driver-gpu-ubuntu-22.04/latest/ami-id \
+    --query 'Parameter.Value' --output text 2>/dev/null) \
+    || die "could not resolve the DLAMI AMI id via SSM; pass --ami ami-xxxxx (a GPU AMI with Docker + the NVIDIA Container Toolkit)"
+fi
+echo ">> AMI: $AMI   instance: $INSTANCE_TYPE   region: $REGION"
+
+# ---- ensure an instance profile with S3 access ------------------------------
+if [ -z "$INSTANCE_PROFILE" ]; then
+  INSTANCE_PROFILE="anuga-gpu-runner"
+  ROLE="$INSTANCE_PROFILE"
+  if ! aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null 2>&1; then
+    echo ">> creating IAM instance profile '$INSTANCE_PROFILE' (S3 access)"
+    IN_B=$(bucket_of "${INPUT_S3:-$OUTPUT_S3}") ; OUT_B=$(bucket_of "$OUTPUT_S3")
+    aws iam create-role --role-name "$ROLE" \
+      --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}' >/dev/null
+    aws iam put-role-policy --role-name "$ROLE" --policy-name s3-access \
+      --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::${IN_B}\",\"arn:aws:s3:::${IN_B}/*\",\"arn:aws:s3:::${OUT_B}\",\"arn:aws:s3:::${OUT_B}/*\"]}]}" >/dev/null
+    aws iam create-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null
+    aws iam add-role-to-instance-profile --instance-profile-name "$INSTANCE_PROFILE" --role-name "$ROLE" >/dev/null
+    echo ">> waiting for IAM propagation..."; sleep 15
+  fi
+fi
+
+# ---- build user-data (runs at boot on the GPU instance) ---------------------
+TERMINATE="shutdown -h now"
+[ "$KEEP" = "1" ] && TERMINATE="echo '[--keep] leaving instance up; terminate it manually when done.'"
+USER_DATA=$(cat <<EOF
+#!/bin/bash
+set -x
+exec > /var/log/anuga-run.log 2>&1
+docker pull "${IMAGE}" || true
+docker run --rm --gpus all \
+  -e ANUGA_DEFAULT_COMPUTE_MODE='${COMPUTE_MODE}' \
+  ${INPUT_S3:+-e INPUT_S3='${INPUT_S3}'} \
+  -e OUTPUT_S3='${OUTPUT_S3}' \
+  ${OUTPUT_DIR:+-e ANUGA_OUTPUT_DIR='${OUTPUT_DIR}'} \
+  "${IMAGE}" sh -c '${COMMAND}'
+rc=\$?
+aws s3 cp /var/log/anuga-run.log "${OUTPUT_S3%/}/anuga-run.log" || true
+echo "anuga job exited rc=\$rc"
+${TERMINATE}
+EOF
+)
+
+# ---- launch -----------------------------------------------------------------
+RUN_ARGS=(
+  --image-id "$AMI"
+  --instance-type "$INSTANCE_TYPE"
+  --count 1
+  --iam-instance-profile "Name=$INSTANCE_PROFILE"
+  --instance-initiated-shutdown-behavior terminate
+  --metadata-options "HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=2"
+  --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=${DISK_GB},VolumeType=gp3}"
+  --user-data "$USER_DATA"
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=anuga-gpu-run}]"
+)
+[ -n "$SSH_KEY" ] && RUN_ARGS+=(--key-name "$SSH_KEY")
+[ "$SPOT" = "1" ] && RUN_ARGS+=(--instance-market-options "MarketType=spot")
+# The metadata hop limit of 2 is REQUIRED so the container can reach IMDSv2 for
+# the instance-profile credentials the entrypoint's aws sync uses.
+
+echo ">> launching..."
+IID=$("${AWS[@]}" ec2 run-instances "${RUN_ARGS[@]}" --query 'Instances[0].InstanceId' --output text)
+echo ">> instance $IID launched ($INSTANCE_TYPE${SPOT:+, spot})."
+echo ">> it will run: ${COMMAND}"
+echo ">> results ->   ${OUTPUT_S3}    (+ anuga-run.log)"
+if [ "$KEEP" = "1" ]; then
+  echo ">> --keep set: instance will NOT self-terminate. Terminate with:"
+  echo "     aws --region $REGION ec2 terminate-instances --instance-ids $IID"
+else
+  echo ">> instance self-terminates when the job finishes. Watch it:"
+  echo "     aws --region $REGION ec2 describe-instances --instance-ids $IID --query 'Reservations[0].Instances[0].State.Name' --output text"
+fi

--- a/docker/aws_run_gpu.sh
+++ b/docker/aws_run_gpu.sh
@@ -27,7 +27,7 @@
 set -euo pipefail
 
 # ---- defaults ---------------------------------------------------------------
-IMAGE="ghcr.io/anuga-community/anuga:latest-gpu"
+IMAGE="ghcr.io/anuga-community/anuga:develop-gpu"   # pre-release (built from develop)
 INSTANCE_TYPE="g5.2xlarge"        # 1x A10G (24GB, cc86), 8 vCPU, 32GB RAM
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 DISK_GB=100                       # root volume; DEMs + SWW output can be large

--- a/docker/aws_run_gpu.sh
+++ b/docker/aws_run_gpu.sh
@@ -19,6 +19,9 @@
 #
 # Results (and anuga-run.log) appear under --output. The instance is gone.
 #
+# Add --dry-run to validate creds / GPU quota / AMI and print the launch plan
+# without creating or charging anything.
+#
 # NOTE: authored but not yet exercised against a live account — test with your
 # own creds and a tiny run first.
 set -euo pipefail
@@ -30,7 +33,7 @@ REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 DISK_GB=100                       # root volume; DEMs + SWW output can be large
 COMPUTE_MODE="unified"            # GPU offload for mode-2 domains
 INPUT_S3="" ; OUTPUT_S3="" ; COMMAND="" ; UPLOAD_DIR="" ; OUTPUT_DIR=""
-INSTANCE_PROFILE="" ; AMI="" ; SSH_KEY="" ; SPOT=0 ; KEEP=0
+INSTANCE_PROFILE="" ; AMI="" ; SSH_KEY="" ; SPOT=0 ; KEEP=0 ; DRY=0
 
 usage() {
   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
@@ -55,6 +58,7 @@ while [ $# -gt 0 ]; do
     --ssh-key)          SSH_KEY="$2"; shift 2 ;;
     --spot)             SPOT=1; shift ;;
     --keep)             KEEP=1; shift ;;              # don't self-terminate (debug)
+    --dry-run)          DRY=1; shift ;;              # validate + print plan; launch nothing
     -h|--help)          usage 0 ;;
     *) echo "unknown arg: $1" >&2; usage 1 ;;
   esac
@@ -71,8 +75,12 @@ bucket_of() { echo "$1" | sed -E 's#^s3://([^/]+).*#\1#'; }
 
 # ---- optional: upload a local project dir to the input prefix ---------------
 if [ -n "$UPLOAD_DIR" ]; then
-  echo ">> uploading ${UPLOAD_DIR} -> ${INPUT_S3}"
-  aws s3 sync "$UPLOAD_DIR" "$INPUT_S3"
+  if [ "$DRY" = "1" ]; then
+    echo "[dry-run] would upload ${UPLOAD_DIR} -> ${INPUT_S3}"
+  else
+    echo ">> uploading ${UPLOAD_DIR} -> ${INPUT_S3}"
+    aws s3 sync "$UPLOAD_DIR" "$INPUT_S3"
+  fi
 fi
 
 # ---- resolve a GPU-ready AMI (Docker + NVIDIA toolkit + driver preinstalled) -
@@ -89,7 +97,11 @@ echo ">> AMI: $AMI   instance: $INSTANCE_TYPE   region: $REGION"
 if [ -z "$INSTANCE_PROFILE" ]; then
   INSTANCE_PROFILE="anuga-gpu-runner"
   ROLE="$INSTANCE_PROFILE"
-  if ! aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null 2>&1; then
+  if aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null 2>&1; then
+    : # already exists
+  elif [ "$DRY" = "1" ]; then
+    echo "[dry-run] would create IAM instance profile '$INSTANCE_PROFILE' (S3 access to the input/output buckets)"
+  else
     echo ">> creating IAM instance profile '$INSTANCE_PROFILE' (S3 access)"
     IN_B=$(bucket_of "${INPUT_S3:-$OUTPUT_S3}") ; OUT_B=$(bucket_of "$OUTPUT_S3")
     aws iam create-role --role-name "$ROLE" \
@@ -139,6 +151,31 @@ RUN_ARGS=(
 [ "$SPOT" = "1" ] && RUN_ARGS+=(--instance-market-options "MarketType=spot")
 # The metadata hop limit of 2 is REQUIRED so the container can reach IMDSv2 for
 # the instance-profile credentials the entrypoint's aws sync uses.
+
+if [ "$DRY" = "1" ]; then
+  echo
+  echo "================= DRY RUN — nothing launched, nothing charged ================="
+  echo "-- identity --"
+  aws sts get-caller-identity --output text 2>&1 | sed 's/^/  /' || echo "  (could not verify creds — is the CLI configured?)"
+  echo "-- GPU on-demand vCPU quota (needs >= this instance's vCPUs) --"
+  q=$("${AWS[@]}" service-quotas get-service-quota --service-code ec2 --quota-code L-DB2E81BA \
+        --query 'Quota.Value' --output text 2>/dev/null) \
+    && echo "  current 'Running On-Demand G and P instances' = ${q} vCPUs" \
+    || echo "  (could not read quota — check Service Quotas; new accounts start at 0, see AWS_SETUP.md step 6)"
+  echo "-- plan --"
+  printf '  %-16s %s\n' image "$IMAGE" instance "$INSTANCE_TYPE (spot=$SPOT, disk=${DISK_GB}GB)" \
+    region "$REGION" ami "$AMI" profile "$INSTANCE_PROFILE" \
+    input "${INPUT_S3:-<none>}" output "$OUTPUT_S3" command "$COMMAND" compute-mode "$COMPUTE_MODE"
+  echo "-- ec2 run-instances permission check --"
+  if aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null 2>&1; then
+    "${AWS[@]}" ec2 run-instances "${RUN_ARGS[@]}" --dry-run 2>&1 | sed 's/^/  /' | head -3
+  else
+    echo "  (skipped — instance profile not created yet; it would be created on a real run)"
+  fi
+  echo "==============================================================================="
+  echo "Re-run without --dry-run to launch."
+  exit 0
+fi
 
 echo ">> launching..."
 IID=$("${AWS[@]}" ec2 run-instances "${RUN_ARGS[@]}" --query 'Instances[0].InstanceId' --output text)

--- a/docker/aws_run_gpu.sh
+++ b/docker/aws_run_gpu.sh
@@ -22,18 +22,26 @@
 # Add --dry-run to validate creds / GPU quota / AMI and print the launch plan
 # without creating or charging anything.
 #
+# Robustness: creates a default VPC if the account has none (or pass --subnet-id);
+# on InsufficientInstanceCapacity it falls back across instance types and AZs
+# (--instance takes a single type or a comma list). The run log records timing
+# (image-pull vs container vs total).
+#
 # NOTE: authored but not yet exercised against a live account — test with your
 # own creds and a tiny run first.
 set -euo pipefail
 
 # ---- defaults ---------------------------------------------------------------
 IMAGE="ghcr.io/anuga-community/anuga:develop-gpu"   # pre-release (built from develop)
-INSTANCE_TYPE="g5.2xlarge"        # 1x A10G (24GB, cc86), 8 vCPU, 32GB RAM
+# Comma-separated capacity-fallback chain: the first type with capacity (in any
+# AZ) wins. g5.2xlarge (A10G/cc86, 8 vCPU) -> g5.xlarge -> g4dn.xlarge (T4/cc75,
+# cheap + widely available). Override with --instance (single or comma list).
+INSTANCE_TYPES="g5.2xlarge,g5.xlarge,g4dn.xlarge"
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 DISK_GB=100                       # root volume; DEMs + SWW output can be large
 COMPUTE_MODE="unified"            # GPU offload for mode-2 domains
 INPUT_S3="" ; OUTPUT_S3="" ; COMMAND="" ; UPLOAD_DIR="" ; OUTPUT_DIR=""
-INSTANCE_PROFILE="" ; AMI="" ; SSH_KEY="" ; SPOT=0 ; KEEP=0 ; DRY=0
+INSTANCE_PROFILE="" ; AMI="" ; SSH_KEY="" ; SPOT=0 ; KEEP=0 ; DRY=0 ; SUBNET_ID=""
 
 usage() {
   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
@@ -44,7 +52,8 @@ usage() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --image)            IMAGE="$2"; shift 2 ;;
-    --instance)         INSTANCE_TYPE="$2"; shift 2 ;;
+    --instance)         INSTANCE_TYPES="$2"; shift 2 ;;   # single or comma list
+    --subnet-id)        SUBNET_ID="$2"; shift 2 ;;        # else default-VPC subnets
     --region)           REGION="$2"; shift 2 ;;
     --disk)             DISK_GB="$2"; shift 2 ;;
     --input)            INPUT_S3="$2"; shift 2 ;;
@@ -91,7 +100,7 @@ if [ -z "$AMI" ]; then
     --query 'Parameter.Value' --output text 2>/dev/null) \
     || die "could not resolve the DLAMI AMI id via SSM; pass --ami ami-xxxxx (a GPU AMI with Docker + the NVIDIA Container Toolkit)"
 fi
-echo ">> AMI: $AMI   instance: $INSTANCE_TYPE   region: $REGION"
+echo ">> AMI: $AMI   instances: $INSTANCE_TYPES   region: $REGION"
 
 # ---- ensure an instance profile with S3 access ------------------------------
 if [ -z "$INSTANCE_PROFILE" ]; then
@@ -114,6 +123,36 @@ if [ -z "$INSTANCE_PROFILE" ]; then
   fi
 fi
 
+# ---- resolve subnet(s) to launch into ---------------------------------------
+# EC2 places the instance in the default VPC when no subnet is given; if the
+# account has no default VPC (a common surprise), run-instances fails with
+# VPCIdNotSpecified. Resolve one subnet per AZ so the capacity loop below can
+# also try alternate AZs. --subnet-id overrides all of this.
+SUBNETS=()
+if [ -n "$SUBNET_ID" ]; then
+  SUBNETS=("$SUBNET_ID")
+else
+  VPC=$("${AWS[@]}" ec2 describe-vpcs --filters Name=isDefault,Values=true \
+        --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo None)
+  if [ "$VPC" = "None" ] || [ -z "$VPC" ]; then
+    if [ "$DRY" = "1" ]; then
+      echo "[dry-run] no default VPC in $REGION — would run 'aws ec2 create-default-vpc'"
+    else
+      echo ">> no default VPC in $REGION — creating one"
+      "${AWS[@]}" ec2 create-default-vpc >/dev/null \
+        || die "no default VPC and create-default-vpc failed; pass --subnet-id of an existing subnet"
+      VPC=$("${AWS[@]}" ec2 describe-vpcs --filters Name=isDefault,Values=true \
+            --query 'Vpcs[0].VpcId' --output text)
+    fi
+  fi
+  if [ -n "${VPC:-}" ] && [ "$VPC" != "None" ]; then
+    mapfile -t SUBNETS < <("${AWS[@]}" ec2 describe-subnets \
+      --filters Name=vpc-id,Values="$VPC" Name=default-for-az,Values=true \
+      --query 'Subnets[].SubnetId' --output text | tr '\t' '\n' | grep -v '^$')
+  fi
+fi
+[ ${#SUBNETS[@]} -eq 0 ] && SUBNETS=("<none>")   # dry-run w/o default VPC
+
 # ---- build user-data (runs at boot on the GPU instance) ---------------------
 TERMINATE="shutdown -h now"
 [ "$KEEP" = "1" ] && TERMINATE="echo '[--keep] leaving instance up; terminate it manually when done.'"
@@ -121,7 +160,9 @@ USER_DATA=$(cat <<EOF
 #!/bin/bash
 set -x
 exec > /var/log/anuga-run.log 2>&1
+T0=\$(date +%s)
 docker pull "${IMAGE}" || true
+TR=\$(date +%s)
 docker run --rm --gpus all \
   -e ANUGA_DEFAULT_COMPUTE_MODE='${COMPUTE_MODE}' \
   ${INPUT_S3:+-e INPUT_S3='${INPUT_S3}'} \
@@ -129,16 +170,17 @@ docker run --rm --gpus all \
   ${OUTPUT_DIR:+-e ANUGA_OUTPUT_DIR='${OUTPUT_DIR}'} \
   "${IMAGE}" sh -c '${COMMAND}'
 rc=\$?
+TE=\$(date +%s)
+echo "anuga timing: image-pull \$((TR-T0))s | container \$((TE-TR))s | total(boot-script) \$((TE-T0))s | rc=\$rc"
 aws s3 cp /var/log/anuga-run.log "${OUTPUT_S3%/}/anuga-run.log" || true
-echo "anuga job exited rc=\$rc"
 ${TERMINATE}
 EOF
 )
 
-# ---- launch -----------------------------------------------------------------
+# ---- launch (capacity fallback across instance types x AZs) -----------------
+# Static args; --instance-type and --subnet-id are added per attempt below.
 RUN_ARGS=(
   --image-id "$AMI"
-  --instance-type "$INSTANCE_TYPE"
   --count 1
   --iam-instance-profile "Name=$INSTANCE_PROFILE"
   --instance-initiated-shutdown-behavior terminate
@@ -149,8 +191,8 @@ RUN_ARGS=(
 )
 [ -n "$SSH_KEY" ] && RUN_ARGS+=(--key-name "$SSH_KEY")
 [ "$SPOT" = "1" ] && RUN_ARGS+=(--instance-market-options "MarketType=spot")
-# The metadata hop limit of 2 is REQUIRED so the container can reach IMDSv2 for
-# the instance-profile credentials the entrypoint's aws sync uses.
+# hop limit 2 lets the container reach IMDSv2 for the instance-profile creds the
+# entrypoint's `aws s3 sync` uses.
 
 if [ "$DRY" = "1" ]; then
   echo
@@ -163,12 +205,15 @@ if [ "$DRY" = "1" ]; then
     && echo "  current 'Running On-Demand G and P instances' = ${q} vCPUs" \
     || echo "  (could not read quota — check Service Quotas; new accounts start at 0, see AWS_SETUP.md step 6)"
   echo "-- plan --"
-  printf '  %-16s %s\n' image "$IMAGE" instance "$INSTANCE_TYPE (spot=$SPOT, disk=${DISK_GB}GB)" \
-    region "$REGION" ami "$AMI" profile "$INSTANCE_PROFILE" \
+  printf '  %-16s %s\n' image "$IMAGE" instances "$INSTANCE_TYPES (spot=$SPOT, disk=${DISK_GB}GB)" \
+    region "$REGION" ami "$AMI" profile "$INSTANCE_PROFILE" subnets "${SUBNETS[*]}" \
     input "${INPUT_S3:-<none>}" output "$OUTPUT_S3" command "$COMMAND" compute-mode "$COMPUTE_MODE"
   echo "-- ec2 run-instances permission check --"
   if aws iam get-instance-profile --instance-profile-name "$INSTANCE_PROFILE" >/dev/null 2>&1; then
-    "${AWS[@]}" ec2 run-instances "${RUN_ARGS[@]}" --dry-run 2>&1 | sed 's/^/  /' | head -3
+    dt="${INSTANCE_TYPES%%,*}"; ds="${SUBNETS[0]}"
+    DA=( "${RUN_ARGS[@]}" --instance-type "$dt" )
+    [ "$ds" != "<none>" ] && DA+=( --subnet-id "$ds" )
+    "${AWS[@]}" ec2 run-instances "${DA[@]}" --dry-run 2>&1 | sed 's/^/  /' | head -3
   else
     echo "  (skipped — instance profile not created yet; it would be created on a real run)"
   fi
@@ -177,11 +222,28 @@ if [ "$DRY" = "1" ]; then
   exit 0
 fi
 
-echo ">> launching..."
-IID=$("${AWS[@]}" ec2 run-instances "${RUN_ARGS[@]}" --query 'Instances[0].InstanceId' --output text)
-echo ">> instance $IID launched ($INSTANCE_TYPE${SPOT:+, spot})."
+echo ">> launching (types: $INSTANCE_TYPES; ${#SUBNETS[@]} AZ subnet(s))..."
+IID="" ; USED_TYPE="" ; USED_SUBNET=""
+for itype in ${INSTANCE_TYPES//,/ }; do
+  for subnet in "${SUBNETS[@]}"; do
+    ATTEMPT=( "${RUN_ARGS[@]}" --instance-type "$itype" )
+    [ "$subnet" != "<none>" ] && ATTEMPT+=( --subnet-id "$subnet" )
+    if out=$("${AWS[@]}" ec2 run-instances "${ATTEMPT[@]}" \
+               --query 'Instances[0].InstanceId' --output text 2>&1); then
+      IID="$out" ; USED_TYPE="$itype" ; USED_SUBNET="$subnet" ; break 2
+    elif echo "$out" | grep -qE "InsufficientInstanceCapacity|Unsupported|InvalidParameterValue"; then
+      echo "   $itype${subnet:+ / $subnet}: unavailable — trying next"
+      continue
+    else
+      die "run-instances failed: $out"
+    fi
+  done
+done
+[ -z "$IID" ] && die "no capacity for any of [$INSTANCE_TYPES] across ${#SUBNETS[@]} AZ(s); try --spot, --instance <other type>, another --region, or retry later"
+
+echo ">> instance $IID launched ($USED_TYPE${SPOT:+, spot}${USED_SUBNET:+, $USED_SUBNET})."
 echo ">> it will run: ${COMMAND}"
-echo ">> results ->   ${OUTPUT_S3}    (+ anuga-run.log)"
+echo ">> results ->   ${OUTPUT_S3}    (+ anuga-run.log with timing)"
 if [ "$KEEP" = "1" ]; then
   echo ">> --keep set: instance will NOT self-terminate. Terminate with:"
   echo "     aws --region $REGION ec2 terminate-instances --instance-ids $IID"

--- a/docker/data/example_run.py
+++ b/docker/data/example_run.py
@@ -1,0 +1,42 @@
+"""Tiny ANUGA smoke-test run for the Docker images.
+
+Writes an SWW to /work/output so the S3 stage-out path has something to upload.
+Set ANUGA_DEFAULT_COMPUTE_MODE=unified (and run with --gpus all on the GPU
+image) to exercise the GPU offload path — you'll see the "GPU Domain" banner.
+
+    docker run --rm -v "$PWD/docker/data:/work" anuga:cpu python /work/example_run.py
+    docker run --rm --gpus all -e ANUGA_DEFAULT_COMPUTE_MODE=unified \
+        -v "$PWD/docker/data:/work" anuga:gpu python /work/example_run.py
+"""
+import os
+import anuga
+
+print("ANUGA", anuga.__version__)
+# GPU-offload API only exists on the unified/develop line (the source-built GPU
+# image), not in the released PyPI wheel (the CPU image) — query defensively.
+_supported = getattr(anuga, "gpu_offload_supported", None)
+_enabled = getattr(anuga, "gpu_offload_enabled", None)
+print("gpu_offload_supported:", _supported() if _supported else "n/a (release build)",
+      "| gpu_offload_enabled:", _enabled() if _enabled else "n/a")
+
+outdir = os.path.join(os.environ.get("ANUGA_WORKDIR", "/work"), "output")
+os.makedirs(outdir, exist_ok=True)
+
+points, vertices, boundary = anuga.rectangular_cross(40, 40, len1=100.0, len2=100.0)
+domain = anuga.Domain(points, vertices, boundary)
+domain.set_name("example")
+domain.set_datadir(outdir)
+domain.set_quantity("elevation", lambda x, y: -0.05 * x)
+domain.set_quantity("stage", 0.5)
+domain.set_quantity("friction", 0.03)
+
+Br = anuga.Reflective_boundary(domain)
+domain.set_boundary({"left": Br, "right": Br, "top": Br, "bottom": Br})
+
+_mode = getattr(domain, "get_compute_mode", lambda: "n/a")
+print("compute_mode:", _mode(), "| omp_num_threads:", getattr(domain, "omp_num_threads", "n/a"))
+
+for t in domain.evolve(yieldstep=1.0, finaltime=5.0):
+    print(domain.timestepping_statistics())
+
+print("Wrote", os.path.join(outdir, "example.sww"))

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       args:
         # Multi-arch fat binary (AWS p3/g4dn/p4d/g5/p5 + local Blackwell laptop).
         # For a faster laptop-only build, override with e.g. GPU_ARCH=cc120.
-        GPU_ARCH: cc70,cc75,cc80,cc86,cc89,cc90,cc120
+        GPU_ARCH: cc75,cc80,cc86,cc89,cc90,cc120
         # Must be a real nvcr.io/nvidia/nvhpc devel tag whose nvc supports the
         # arches above (cc120/Blackwell needs NVHPC >= 25.1).
         NVHPC_TAG: 25.9-devel-cuda_multi-ubuntu24.04

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       args:
         # Multi-arch fat binary (AWS p3/g4dn/p4d/g5/p5 + local Blackwell laptop).
         # For a faster laptop-only build, override with e.g. GPU_ARCH=cc120.
-        GPU_ARCH: cc70,cc75,cc80,cc86,cc90,cc120
+        GPU_ARCH: cc70,cc75,cc80,cc86,cc89,cc90,cc120
         # Must be a real nvcr.io/nvidia/nvhpc devel tag whose nvc supports the
         # arches above (cc120/Blackwell needs NVHPC >= 25.1).
         NVHPC_TAG: 25.9-devel-cuda_multi-ubuntu24.04

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+# Convenience wrapper for building/running the ANUGA images locally.
+#
+#   docker compose -f docker/docker-compose.yml build anuga-cpu
+#   docker compose -f docker/docker-compose.yml build anuga-gpu
+#   docker compose -f docker/docker-compose.yml run --rm anuga-gpu \
+#       python /work/my_run.py -alg DE0
+#
+# Put input in ./docker/data (mounted at /work); results land there too.
+services:
+  anuga-cpu:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cpu
+    image: anuga:cpu
+    volumes:
+      - ./data:/work
+
+  anuga-gpu:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.gpu
+      args:
+        # Multi-arch fat binary (AWS p3/g4dn/p4d/g5/p5 + local Blackwell laptop).
+        # For a faster laptop-only build, override with e.g. GPU_ARCH=cc120.
+        GPU_ARCH: cc70,cc75,cc80,cc86,cc90,cc120
+        # Must be a real nvcr.io/nvidia/nvhpc devel tag whose nvc supports the
+        # arches above (cc120/Blackwell needs NVHPC >= 25.1).
+        NVHPC_TAG: 25.9-devel-cuda_multi-ubuntu24.04
+    image: anuga:gpu
+    environment:
+      # Opt into GPU offload for unified (mode-2) domains.
+      ANUGA_DEFAULT_COMPUTE_MODE: unified
+    volumes:
+      - ./data:/work
+    # Expose all NVIDIA GPUs to the container (needs NVIDIA Container Toolkit).
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,12 +6,17 @@
 #       python /work/my_run.py -alg DE0
 #
 # Put input in ./docker/data (mounted at /work); results land there too.
+#
+# Run as your host user so output files are owned by you, not root:
+#   UID=$(id -u) GID=$(id -g) docker compose -f docker/docker-compose.yml run --rm anuga-gpu ...
 services:
   anuga-cpu:
     build:
       context: ..
       dockerfile: docker/Dockerfile.cpu
     image: anuga:cpu
+    # Owns output as the host user (avoids root-owned files on the bind mount).
+    user: "${UID:-0}:${GID:-0}"
     volumes:
       - ./data:/work
 
@@ -27,6 +32,8 @@ services:
         # arches above (cc120/Blackwell needs NVHPC >= 25.1).
         NVHPC_TAG: 25.9-devel-cuda_multi-ubuntu24.04
     image: anuga:gpu
+    # Owns output as the host user (avoids root-owned files on the bind mount).
+    user: "${UID:-0}:${GID:-0}"
     environment:
       # Opt into GPU offload for unified (mode-2) domains.
       ANUGA_DEFAULT_COMPUTE_MODE: unified

--- a/environments/environment_3.10.yml
+++ b/environments/environment_3.10.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.10_intel.yml
+++ b/environments/environment_3.10_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.11.yml
+++ b/environments/environment_3.11.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.11_intel.yml
+++ b/environments/environment_3.11_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.12.yml
+++ b/environments/environment_3.12.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.12_intel.yml
+++ b/environments/environment_3.12_intel.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.13.yml
+++ b/environments/environment_3.13.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.13_intel.yml
+++ b/environments/environment_3.13_intel.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.14.yml
+++ b/environments/environment_3.14.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_3.14_intel.yml
+++ b/environments/environment_3.14_intel.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.10.yml
+++ b/environments/environment_win_3.10.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.11.yml
+++ b/environments/environment_win_3.11.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.12.yml
+++ b/environments/environment_win_3.12.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio

--- a/environments/environment_win_3.13.yml
+++ b/environments/environment_win_3.13.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - affine
   - cartopy
+  - contextily
   - cython
   - dill
   - rasterio


### PR DESCRIPTION
## Summary

A `docker/` setup so ANUGA can run in containers locally and on **AWS —
especially GPU runs via AWS Batch**.

| Image | Base | ANUGA source | Use |
|-------|------|--------------|-----|
| `anuga:cpu` | `python:3.12-slim` | portable PyPI wheel (3.3.10+) | CPU runs; small; CPU Batch |
| `anuga:gpu` | `nvcr.io/nvidia/nvhpc:*-devel` | built from source with `nvc` | GPU offload; local Blackwell **and** AWS GPU instances |

There are no GPU wheels (the offload extension is OpenMP-target code only
`nvc` compiles), so the GPU image builds from source.

## Contents

- **`docker/Dockerfile.gpu`** — `gpu_offload=true`; `GPU_ARCH` build ARG defaults
  to a multi-arch fat binary `cc70,cc75,cc80,cc86,cc90,cc120` (AWS
  p3/g4dn/p4d/g5/p5 + local RTX 50-series); `NVHPC_TAG` selects the base.
- **`docker/Dockerfile.cpu`** — slim, `pip install anuga`.
- **`docker/anuga-entrypoint.sh`** — headless entrypoint: optional S3 stage-in
  (`INPUT_S3`) → run the given command → S3 stage-out (`OUTPUT_S3`, with
  `AWS_BATCH_JOB_ARRAY_INDEX` appended for array jobs). No S3 vars ⇒ plain local
  run. Credentials from the instance/job IAM role.
- **`docker/docker-compose.yml`**, **`docker/data/example_run.py`** — local
  build/run + a tiny smoke-test that writes an SWW.
- **`docker/README.md`** — local build/test and AWS Batch (ECR, GPU job def,
  array jobs) usage.
- **`.github/workflows/docker-publish.yml`** — publishes to
  `ghcr.io/anuga-community/anuga`: CPU image on release; GPU image opt-in via
  `workflow_dispatch` (`build_gpu`), since the NVHPC base is large.
- **`.dockerignore`** — keeps package data (`anuga/**/data/*.tsh|*.msh`), drops
  big non-build dirs (`validation_tests`, `examples`, `docs`, `sandpit`).

## Validation

Both images built and run locally:
- **CPU** — runs the released wheel, writes a valid SWW.
- **GPU** (`GPU_ARCH=cc120`) — real OpenMP-target offload on an **RTX 5070
  (Blackwell)** under `docker run --gpus all`: `gpu_offload_enabled: True`,
  `compute_mode: unified`, and the `--- GPU Domain … Arrays mapped to device 0`
  banner.

## Notes

- CI does **not** build or test these images (no GPU runners; the publish
  workflow only runs on release/dispatch). Image builds are a manual/local step.
- GHCR packages default to private on first publish (one-time visibility toggle);
  for AWS, in-region **ECR** is recommended for fast pulls (see README).
- A slimmer multi-stage GPU runtime image (CUDA-runtime base + NVHPC redist libs)
  is a sensible follow-up to cut the ~15 GB image and cold-start pull time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)