### PR TITLE
geo_reference: infer UTM zone/hemisphere for MGA & other non-WGS84 UTM EPSG codes

### DIFF
--- a/anuga/coordinate_transforms/geo_reference.py
+++ b/anuga/coordinate_transforms/geo_reference.py
@@ -252,6 +252,7 @@ class Geo_reference:
             EPSG code to store.
         """
         self._epsg = epsg
+        used_pyproj = False
 
         if _WGS84_UTM_NORTH_BASE < epsg <= _WGS84_UTM_NORTH_BASE + 60:
             inferred_zone = epsg - _WGS84_UTM_NORTH_BASE
@@ -260,11 +261,17 @@ class Geo_reference:
             inferred_zone = epsg - _WGS84_UTM_SOUTH_BASE
             inferred_hemisphere = 'southern'
         else:
-            # Non-UTM EPSG (e.g. EPSG:28992 Netherlands RD New,
-            # EPSG:27700 British National Grid).  No zone or hemisphere to infer.
-            # Populate datum and projection from pyproj if available so that
-            # the SWW file metadata accurately describes the CRS.
+            # Not a WGS84 UTM code. Populate datum/projection/false easting-
+            # northing from pyproj, and — for any UTM-based CRS on another datum
+            # (e.g. GDA2020/GDA94 MGA EPSG 78xx/283xx, or NAD83 UTM) — infer the
+            # UTM zone and hemisphere too. Genuinely non-UTM grids (British
+            # National Grid 27700, RD New 28992, Albers 3577, geographic 4326)
+            # yield (None, None) and keep zone/hemisphere unset.
             self._populate_from_pyproj(epsg)
+            used_pyproj = True
+            inferred_zone, inferred_hemisphere = self._utm_from_pyproj(epsg)
+
+        if inferred_zone is None:
             return
 
         if self.zone == DEFAULT_ZONE:
@@ -275,10 +282,48 @@ class Geo_reference:
 
         if self.hemisphere == DEFAULT_HEMISPHERE:
             self.set_hemisphere(inferred_hemisphere)
-            self.set_false_easting_northing()
+            # The pyproj path already set false easting/northing precisely from
+            # the CRS; only synthesise them for the WGS84 fast path.
+            if not used_pyproj:
+                self.set_false_easting_northing()
         elif self.hemisphere != inferred_hemisphere:
             log.warning(f'EPSG {epsg} implies {inferred_hemisphere} hemisphere but '
                         f'{self.hemisphere} is already set; hemisphere unchanged.')
+
+    def _utm_from_pyproj(self, epsg):
+        """Infer ``(zone, hemisphere)`` from a UTM-based EPSG code via pyproj.
+
+        Recognises any UTM projection regardless of datum — WGS84 UTM, GDA2020/
+        GDA94 MGA (EPSG 78xx / 283xx), NAD83 UTM, etc. — which the WGS84-only
+        32601–32760 fast path in :meth:`_set_epsg` does not cover. PROJ reports
+        these all as ``proj=utm`` with a ``zone``; the hemisphere is taken from
+        the false northing (southern UTM uses 10 000 000 m), since the PROJ
+        ``south`` flag is unreliable across the round-trip.
+
+        Returns ``(None, None)`` for non-UTM CRS or when pyproj is unavailable.
+        """
+        try:
+            from pyproj import CRS
+            crs = CRS.from_epsg(epsg)
+            d = crs.to_dict()
+        except Exception:
+            return None, None
+
+        if d.get('proj') != 'utm' or d.get('zone') is None:
+            return None, None
+        try:
+            zone = int(d['zone'])
+        except (TypeError, ValueError):
+            return None, None
+
+        south = d.get('south')
+        if south is None:
+            try:
+                fn = crs.to_cf().get('false_northing')
+                south = fn is not None and float(fn) > 0
+            except Exception:
+                south = False
+        return zone, ('southern' if south else 'northern')
 
     def _populate_from_pyproj(self, epsg):
         """Use pyproj to set CRS metadata from an EPSG code.

--- a/anuga/coordinate_transforms/tests/test_geo_reference.py
+++ b/anuga/coordinate_transforms/tests/test_geo_reference.py
@@ -840,6 +840,28 @@ class geo_referenceTestCase(unittest.TestCase):
         self.assertEqual(g.zone, DEFAULT_ZONE)
         self.assertEqual(g.hemisphere, DEFAULT_HEMISPHERE)
 
+    def test_epsg_infers_zone_hemisphere_gda2020_mga(self):
+        """GDA2020 MGA (EPSG 78xx) is UTM on another datum: infer zone/hemisphere."""
+        g = Geo_reference(epsg=7856)  # GDA2020 / MGA zone 56 (southern)
+        self.assertEqual(g.zone, 56)
+        self.assertEqual(g.hemisphere, 'southern')
+        self.assertEqual(g.epsg, 7856)
+        self.assertEqual(g.false_northing, 10000000)
+
+    def test_epsg_infers_zone_hemisphere_gda94_mga(self):
+        """GDA94 MGA (EPSG 283xx) also infers zone/hemisphere."""
+        g = Geo_reference(epsg=28356)  # GDA94 / MGA zone 56 (southern)
+        self.assertEqual(g.zone, 56)
+        self.assertEqual(g.hemisphere, 'southern')
+        self.assertEqual(g.epsg, 28356)
+
+    def test_epsg_non_utm_projected_stays_unlocated(self):
+        """A projected non-UTM grid (British National Grid) infers no zone."""
+        g = Geo_reference(epsg=27700)
+        self.assertEqual(g.epsg, 27700)
+        self.assertEqual(g.zone, DEFAULT_ZONE)
+        self.assertEqual(g.hemisphere, DEFAULT_HEMISPHERE)
+
     def test_epsg_setter(self):
         """epsg property setter updates value and infers zone/hemisphere."""
         g = Geo_reference()


### PR DESCRIPTION
## Summary

`Geo_reference` understood **EPSG 32756** (WGS84 UTM zone 56S) but not **EPSG 7856**
(GDA2020 / MGA zone 56) — the link from the EPSG code to UTM zone + hemisphere was
missing for anything outside the WGS84 UTM ranges.

Cause: `_set_epsg` only inferred zone/hemisphere for WGS84 UTM codes
(`32601–32660` N, `32701–32760` S). GDA2020/GDA94 MGA (`78xx` / `283xx`) and
NAD83 UTM are UTM projections on a *different datum*, so they fell through to the
generic path that set datum/projection but left `zone = -1`, `hemisphere = undefined`.

## Fix

Generalise the inference via pyproj: any CRS that PROJ reports as `proj=utm`
yields its `zone`, and the hemisphere is derived from the **false northing**
(10 000 000 m ⇒ southern — the PROJ `south` flag is unreliable across the
round-trip). WGS84 UTM keeps its existing pyproj-free fast path. Genuinely
non-UTM grids (BNG `27700`, Albers `3577`, geographic `4326`) infer nothing and
stay unlocated, exactly as before.

| EPSG | before | after |
|------|--------|-------|
| 7856 (GDA2020 MGA56) | zone −1, undefined | **zone 56, southern** |
| 28356 (GDA94 MGA56) | zone −1, undefined | zone 56, southern |
| 32756 / 32656 (WGS84 UTM) | unchanged | unchanged |
| 27700 / 4326 / 3577 (non-UTM) | unlocated | unlocated (no crash) |

## Tests

Adds regression tests for GDA2020 MGA, GDA94 MGA, and a projected non-UTM grid.
Full `test_geo_reference.py` passes (77), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)