### PR TITLE
GPU arch selection fix (adds V100 coverage), OSM basemap unblock, and HiDPI/GUI fixes

### DIFF
--- a/anuga/shallow_water/meson.build
+++ b/anuga/shallow_water/meson.build
@@ -330,6 +330,18 @@ endif
 #                              Python binary; portable across any conda env path
 #   sys.prefix/lib           — absolute fallback for non-standard layouts
 gpu_link_args = []
+
+# nvc performs the *device* link when producing the shared module, and it picks
+# the target architectures from the -gpu= on the LINK line -- the -gpu= used at
+# compile time does not carry through.  With no -gpu= here nvc guesses: the
+# build host's own GPU when one is visible, or every architecture the bundled
+# CUDA supports when none is (e.g. inside a container).  Either way -Dgpu_arch
+# was silently ignored, so a build "for cc80" could come out as sm_120, and the
+# Docker images were portable only by accident.  Repeat the flags at link time
+# so the requested architectures are the ones actually embedded.
+if gpu_offload and effective_compiler_id == 'nvidia_hpc'
+  gpu_link_args += ['-mp=gpu,multicore', '-gpu=' + gpu_arch]
+endif
 if host_machine.system() == 'darwin' and have_full_mpi
   _py_prefix = run_command(py3, ['-c', 'import sys; print(sys.prefix)'], check: false)
   if _py_prefix.returncode() == 0

--- a/anuga/utilities/animate.py
+++ b/anuga/utilities/animate.py
@@ -41,6 +41,56 @@ def _resolve_provider(cx, provider_str):
     return obj
 
 
+def _configure_tile_client(cx):
+    """Identify ANUGA to tile servers and cache tiles between sessions.
+
+    contextily defaults to ``USER_AGENT = "contextily-" + uuid4().hex`` — a
+    fresh random agent every process.  OpenStreetMap's tile usage policy
+    requires a stable User-Agent identifying the *application*, and treats
+    rotating agents as an attempt to evade rate limits, so it blocks the
+    request.  The block arrives as a normal HTTP 200 tile whose *image* reads
+    "Access blocked ... osm.wiki/Blocked", so nothing raises and the notice is
+    simply drawn onto the map.
+
+    Sending a stable agent naming ANUGA and its project page fixes it, and a
+    persistent on-disk cache keeps repeat views (every redraw, every frame of
+    an animation) off the volunteer-run servers, which the policy also asks
+    for.  Both are best-effort: contextily is a third-party package, so an
+    unexpected version just leaves its defaults in place.
+    """
+    try:
+        from anuga import __version__ as _v
+    except Exception:
+        _v = 'unknown'
+
+    ua = ('ANUGA/%s (hydrodynamic modelling; '
+          '+https://github.com/anuga-community/anuga_core)' % _v)
+
+    try:
+        import contextily.tile as _tile
+        if getattr(_tile, 'USER_AGENT', '').startswith('contextily-'):
+            _tile.USER_AGENT = ua
+    except Exception:
+        pass
+
+    global _TILE_CACHE_SET
+    if not _TILE_CACHE_SET:
+        try:
+            cache_dir = os.path.join(
+                os.environ.get('XDG_CACHE_HOME',
+                               os.path.join(os.path.expanduser('~'), '.cache')),
+                'anuga', 'tiles')
+            os.makedirs(cache_dir, exist_ok=True)
+            cx.set_cache_dir(cache_dir)
+        except Exception:
+            pass
+        _TILE_CACHE_SET = True
+
+
+# set_cache_dir() only needs calling once per session
+_TILE_CACHE_SET = False
+
+
 def _add_basemap(ax, epsg, provider=BASEMAP_DEFAULT, cache=None):
     """Overlay a tile basemap on *ax* using contextily.
 
@@ -71,6 +121,8 @@ def _add_basemap(ax, epsg, provider=BASEMAP_DEFAULT, cache=None):
             "Install it with: conda install contextily  or  pip install contextily",
             stacklevel=3)
         return
+
+    _configure_tile_client(cx)
 
     xl, xr = ax.get_xlim()
     yb, yt = ax.get_ylim()

--- a/anuga/utilities/tests/meson.build
+++ b/anuga/utilities/tests/meson.build
@@ -17,6 +17,7 @@ python_sources = [
 'test_sparse.py',
 'test_spatialInputUtil.py',
 'test_system_tools.py',
+'test_tk_scaling.py',
 'test_toml_view.py',
 'test_where_close.py',
 'test_xml_tools.py',

--- a/anuga/utilities/tests/test_animate.py
+++ b/anuga/utilities/tests/test_animate.py
@@ -680,5 +680,50 @@ class TestDomainPlotter(unittest.TestCase):
         self.assertTrue(os.path.exists(png))
 
 
+class Test_tile_client_config(unittest.TestCase):
+    """ANUGA must identify itself to tile servers (no network needed).
+
+    contextily defaults to USER_AGENT = "contextily-" + uuid4().hex, i.e. a
+    fresh random agent per process.  OpenStreetMap's tile usage policy requires
+    a stable agent identifying the application and blocks rotating ones -- and
+    the block arrives as an HTTP 200 tile whose image reads "Access blocked",
+    so it silently renders onto the map instead of raising.
+    """
+
+    def setUp(self):
+        try:
+            import contextily  # noqa: F401
+        except ImportError:
+            self.skipTest('contextily is not installed')
+
+    def test_contextily_default_agent_is_replaced(self):
+        import contextily as cx
+        import contextily.tile as tile
+        from anuga.utilities import animate
+
+        original = tile.USER_AGENT
+        try:
+            tile.USER_AGENT = 'contextily-0123456789abcdef'
+            animate._configure_tile_client(cx)
+            self.assertIn('ANUGA', tile.USER_AGENT)
+            self.assertFalse(tile.USER_AGENT.startswith('contextily-'))
+        finally:
+            tile.USER_AGENT = original
+
+    def test_user_supplied_agent_is_left_alone(self):
+        """Only contextily's own default is replaced, never a deliberate one."""
+        import contextily as cx
+        import contextily.tile as tile
+        from anuga.utilities import animate
+
+        original = tile.USER_AGENT
+        try:
+            tile.USER_AGENT = 'MyApp/1.0 (+https://example.org)'
+            animate._configure_tile_client(cx)
+            self.assertEqual(tile.USER_AGENT, 'MyApp/1.0 (+https://example.org)')
+        finally:
+            tile.USER_AGENT = original
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/anuga/utilities/tests/test_tk_scaling.py
+++ b/anuga/utilities/tests/test_tk_scaling.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Tests for anuga.utilities.tk_scaling — the HiDPI scale detection.
+#
+# These are pure logic tests: the DPI sources are monkeypatched, so no display,
+# no X server and no xrandr/xrdb binaries are needed.
+
+import unittest
+from unittest import mock
+
+from anuga.utilities import tk_scaling
+
+
+class _FakeRoot:
+    """Stand-in for a Tk root; only used when the X sources give nothing."""
+
+    def winfo_screenwidth(self):
+        return 1920
+
+    def winfo_screenmmwidth(self):
+        return 508          # exactly 96 DPI
+
+    def winfo_fpixels(self, spec):
+        return 96.0
+
+
+class Test_detect_scale(unittest.TestCase):
+
+    def setUp(self):
+        self.root = _FakeRoot()
+
+    def _detect(self, xft=None, panel=None, env=None):
+        with mock.patch.object(tk_scaling, '_xft_dpi', return_value=xft), \
+             mock.patch.object(tk_scaling, '_panel_dpi', return_value=panel), \
+             mock.patch.dict('os.environ', env or {}, clear=False):
+            if env is None:
+                with mock.patch.dict('os.environ', {'ANUGA_GUI_SCALE': ''}):
+                    return tk_scaling.detect_scale(self.root)
+            return tk_scaling.detect_scale(self.root)
+
+    def test_normal_dpi_is_a_no_op(self):
+        """A plain 96 DPI display must not be scaled at all."""
+        self.assertEqual(self._detect(xft=96.0, panel=96.0), 1.0)
+
+    def test_configured_xft_dpi_is_honoured(self):
+        self.assertEqual(self._detect(xft=192.0, panel=192.0), 2.0)
+
+    def test_dense_panel_lifts_a_conservative_xft_setting(self):
+        """287 DPI panel + Xft.dpi 192 -> between the two, not just 2.0.
+
+        This is the laptop case that prompted the change: the desktop is
+        configured for 2x, but on a ~287 DPI panel that still leaves the UI
+        physically small.
+        """
+        scale = self._detect(xft=192.0, panel=286.9)
+        self.assertGreater(scale, 2.0)
+        self.assertLessEqual(scale, 3.0)
+
+    def test_panel_never_shrinks_the_users_setting(self):
+        """A low-density panel must not drag a deliberate 2x setting down."""
+        self.assertEqual(self._detect(xft=192.0, panel=96.0), 2.0)
+
+    def test_env_override_wins(self):
+        scale = self._detect(xft=192.0, panel=286.9,
+                             env={'ANUGA_GUI_SCALE': '1.25'})
+        self.assertEqual(scale, 1.25)
+
+    def test_env_override_can_disable_scaling(self):
+        scale = self._detect(xft=192.0, panel=286.9,
+                             env={'ANUGA_GUI_SCALE': '1'})
+        self.assertEqual(scale, 1.0)
+
+    def test_junk_override_is_ignored(self):
+        """A malformed override must fall back to detection, not crash."""
+        scale = self._detect(xft=192.0, panel=192.0,
+                             env={'ANUGA_GUI_SCALE': 'huge'})
+        self.assertEqual(scale, 2.0)
+
+    def test_scale_is_clamped(self):
+        """An absurdly dense reading cannot blow the UI up without bound."""
+        self.assertLessEqual(self._detect(xft=1200.0, panel=1200.0), 3.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/anuga/utilities/tk_scaling.py
+++ b/anuga/utilities/tk_scaling.py
@@ -67,13 +67,70 @@ def detect_dpi(root):
     return tk_dpi
 
 
-def detect_scale(root, lo=1.0, hi=2.5):
-    """Font/UI scale factor (1.0 == 96 DPI), clamped to [lo, hi]."""
-    return round(min(hi, max(lo, detect_dpi(root) / 96.0)), 2)
+def _panel_dpi():
+    """True panel DPI from xrandr's mode + physical size, or None.
+
+    Used only as a *floor* for very dense panels.  Tk's own numbers are
+    unusable under XWayland (it reports 96 DPI and a fictitious screen size
+    such as 1016x635 mm), whereas xrandr reports the real panel, e.g.
+    ``3840x2400 ... 340mm x 220mm`` -> 287 DPI.
+    """
+    try:
+        out = subprocess.run(['xrandr'], capture_output=True,
+                             text=True, timeout=2).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    # e.g. "eDP-1 connected primary 3840x2400+0+0 (normal ...) 340mm x 220mm"
+    m = re.search(r'^\S+ connected.*?(\d+)x(\d+)\+\d+\+\d+.*?(\d+)mm x (\d+)mm',
+                  out, re.M)
+    if not m:
+        return None
+    px, mm = float(m.group(1)), float(m.group(3))
+    return px * 25.4 / mm if mm > 0 else None
 
 
-def apply_hidpi_scaling(root, lo=1.0, hi=2.5):
-    """Enlarge Tk's named fonts to suit the true screen DPI; return the scale.
+def _override_scale():
+    """Explicit user override from ANUGA_GUI_SCALE, or None."""
+    raw = os.environ.get('ANUGA_GUI_SCALE', '').strip()
+    if not raw:
+        return None
+    try:
+        v = float(raw)
+    except ValueError:
+        return None
+    return v if v > 0 else None
+
+
+def detect_scale(root, lo=1.0, hi=3.0):
+    """Font/UI scale factor (1.0 == 96 DPI), clamped to [lo, hi].
+
+    ANUGA_GUI_SCALE overrides everything (clamped only to something sane), for
+    displays where the automatic answer is not to taste.
+
+    Otherwise the configured Xft.dpi leads, since it reflects the scaling the
+    user asked their desktop for.  On very dense panels that setting can still
+    leave the UI physically small -- a 287 DPI laptop panel set to Xft.dpi 192
+    gets 2.0x, where the panel itself implies 3.0x -- so the true panel density
+    is used to lift the scale halfway towards it.
+    """
+    override = _override_scale()
+    if override is not None:
+        return round(min(4.0, max(0.5, override)), 2)
+
+    scale = detect_dpi(root) / 96.0
+
+    panel = _panel_dpi()
+    if panel:
+        panel_scale = panel / 96.0
+        if panel_scale > scale:
+            # Halfway: honour the user's setting but do not ignore the panel.
+            scale = (scale + panel_scale) / 2.0
+
+    return round(min(hi, max(lo, scale)), 2)
+
+
+def apply_hidpi_scaling(root, lo=1.0, hi=3.0):
+    """Scale Tk's fonts and widget geometry to suit the display; return scale.
 
     A no-op (returns 1.0) on normal-DPI displays, so it is safe to call
     unconditionally just after creating the root window.
@@ -81,6 +138,7 @@ def apply_hidpi_scaling(root, lo=1.0, hi=2.5):
     scale = detect_scale(root, lo, hi)
     if scale <= 1.0:
         return scale
+
     for name in _NAMED_FONTS:
         try:
             f = tkfont.nametofont(name)
@@ -92,4 +150,14 @@ def apply_hidpi_scaling(root, lo=1.0, hi=2.5):
         # Tk sizes: positive = points, negative = pixels. Preserve the sign.
         sign = 1 if size > 0 else -1
         f.configure(size=sign * max(8, int(round(abs(size) * scale))))
+
+    # Fonts alone leave every *non-text* element the same physical size:
+    # padding, borders, ttk element geometry and anything sized in points all
+    # derive from Tk's points-per-pixel, which stays at the 96 DPI value unless
+    # told otherwise.  That is why scaled fonts alone still look cramped.
+    try:
+        root.tk.call('tk', 'scaling', (96.0 * scale) / 72.0)
+    except tk.TclError:
+        pass
+
     return scale

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -31,7 +31,11 @@
 ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG}
 
-ARG GPU_ARCH=cc75,cc80,cc86,cc89,cc90,cc120
+# cuda12.9 first: the cuda_multi base bundles CUDA 12.9 and 13.0 and defaults
+# to 13.0, whose libnvvm dropped Volta ("-arch=compute_70 is an unsupported
+# option").  12.9 supports Volta AND Blackwell (sm_120, added in 12.8), so one
+# fat binary covers cc70 (V100) through cc120 (RTX 50-series).
+ARG GPU_ARCH=cuda12.9,cc70,cc75,cc80,cc86,cc89,cc90,cc120
 # PEP 440 version to stamp into the build (.git is excluded from the context, so
 # `git describe` can't run inside the image). Pass what it would have produced:
 #   --build-arg ANUGA_VERSION="$(python _git_version.py)"

--- a/docker/Dockerfile.gpu.slim
+++ b/docker/Dockerfile.gpu.slim
@@ -31,7 +31,13 @@ ARG CUDA_RUNTIME_TAG=12.6.2-base-ubuntu24.04
 
 # ---- builder: compile anuga with nvc (as in Dockerfile.gpu) -----------------
 FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG} AS builder
-ARG GPU_ARCH=cc75,cc80,cc86,cc89,cc90,cc120
+# cuda12.9 is deliberate, and must come first.  The cuda_multi base bundles
+# CUDA 12.9 and 13.0 and defaults to 13.0, whose libnvvm dropped Volta:
+# cc70 then fails with "-arch=compute_70 is an unsupported option".  CUDA 12.9
+# still supports Volta and already supports Blackwell (sm_120, added in 12.8),
+# so selecting it is what lets ONE fat binary span V100 (cc70) through the
+# RTX 50-series (cc120) — no separate V100 image needed.
+ARG GPU_ARCH=cuda12.9,cc70,cc75,cc80,cc86,cc89,cc90,cc120
 ARG ANUGA_VERSION=
 SHELL ["/bin/bash", "-lc"]
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/scripts/anuga_sww_gui.py
+++ b/scripts/anuga_sww_gui.py
@@ -675,6 +675,10 @@ class SWWAnimationGUI:
         ttk.Button(ts_ctrl, text='Export CSV',
                    command=self._export_timeseries).pack(side=tk.RIGHT, padx=4)
 
+        # NB: do not set dpi here for the on-screen figures.  matplotlib's Tk
+        # backend already scales the canvas by Tk's points-per-pixel (set from
+        # the UI scale in tk_scaling), so passing a scaled dpi as well makes the
+        # plots twice as large as intended.
         self._ts_fig, self._ts_ax = plt.subplots(figsize=(10, 1.8))
         self._ts_fig.tight_layout(pad=1.5)
         self._ts_canvas = FigureCanvasTkAgg(self._ts_fig, master=self._ts_outer)
@@ -3547,9 +3551,19 @@ def main():
                         metavar='PROVIDER',
                         help=('Basemap tile provider. Choices: '
                               + ', '.join(BASEMAP_PROVIDERS.keys())))
+    parser.add_argument('--ui-scale', type=float, default=None, metavar='FACTOR',
+                        help=('Scale the interface (fonts, spacing and on-screen '
+                              'plots). Default: detected from the display. Use '
+                              'e.g. 3 on a very high-DPI laptop panel, 1 to '
+                              'disable. Equivalent to ANUGA_GUI_SCALE.'))
+
     parser.set_defaults(basemap=None)
 
     args = parser.parse_args()
+
+    # Feed --ui-scale to the detector via the same env var users can export.
+    if args.ui_scale is not None:
+        os.environ['ANUGA_GUI_SCALE'] = str(args.ui_scale)
 
     # Load TOML config (if given); explicit CLI args take precedence.
     cfg = {}

--- a/scripts/anuga_sww_gui.py
+++ b/scripts/anuga_sww_gui.py
@@ -714,6 +714,8 @@ class SWWAnimationGUI:
         self._canvas_frame.pack(fill=tk.BOTH, expand=True)
         self._canvas = FigureCanvasTkAgg(self._fig, master=self._canvas_frame)
         self._canvas.draw()
+        # ... and once more after the window has been laid out for real.
+        self.root.after_idle(self._sync_canvas_sizes)
         self._canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         self._hover_cid = self._canvas.mpl_connect(
             'motion_notify_event', self._on_hover)
@@ -1282,6 +1284,38 @@ class SWWAnimationGUI:
         self._update_xs_overlay()
         self._set_status(f'Loaded {n} frames  |  {plot_dir}')
 
+    def _sync_canvas_sizes(self):
+        """Match each embedded figure to its widget's real pixel size.
+
+        matplotlib's Tk backend sizes a figure from the first <Configure> it
+        receives, but on a HiDPI display that arrives before the canvas knows
+        its device-pixel-ratio, so the figure comes out ui_scale times larger
+        than the widget: the image then renders to an oversized canvas and only
+        its corner is visible, un-centred and at the wrong scale.  Any later
+        resize corrects it, which is why nudging the window "fixed" it.
+
+        Re-assert the size once the widget geometry is real.  Safe to call
+        repeatedly; a widget that is not laid out yet (1x1) is skipped.
+        """
+        for fig, canvas in ((self._fig, self._canvas),
+                            (self._ts_fig, self._ts_canvas),
+                            (self._xs_fig, self._xs_fig_canvas)):
+            try:
+                w = canvas.get_tk_widget()
+                wpx, hpx = w.winfo_width(), w.winfo_height()
+                if wpx <= 1 or hpx <= 1:
+                    continue
+                dpi = fig.get_dpi()
+                if dpi <= 0:
+                    continue
+                want_w, want_h = wpx / dpi, hpx / dpi
+                have_w, have_h = fig.get_size_inches()
+                if (abs(want_w - have_w) > 0.01 or abs(want_h - have_h) > 0.01):
+                    fig.set_size_inches(want_w, want_h, forward=False)
+                    canvas.draw_idle()
+            except (tk.TclError, AttributeError):
+                continue
+
     def _show_frame(self, idx):
         if not self._frames:
             return
@@ -1299,6 +1333,9 @@ class SWWAnimationGUI:
         if self._im is None:
             self._im = self._ax.imshow(img, aspect='equal')
             self._im.set_extent([0, img.shape[1], img.shape[0], 0])
+            # First image: the canvas may still be carrying the oversized
+            # figure from its initial <Configure> (see _sync_canvas_sizes).
+            self.root.after_idle(self._sync_canvas_sizes)
         else:
             self._im.set_data(img)
             self._im.set_extent([0, img.shape[1], img.shape[0], 0])

--- a/scripts/anuga_sww_gui.py
+++ b/scripts/anuga_sww_gui.py
@@ -333,7 +333,37 @@ class SWWAnimationGUI:
     # UI construction                                                 #
     # -------------------------------------------------------------- #
 
+    def _build_menubar(self):
+        """File menu — Open/config/Quit, reusing the toolbar's handlers.
+
+        Quit goes through _on_close so it does exactly what the window's close
+        button does: cancel any running generation, stop playback and close the
+        matplotlib figures.  Calling root.destroy() directly would leave a
+        worker pool and open figures behind.
+        """
+        menubar = tk.Menu(self.root)
+
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label='Open SWW...', accelerator='Ctrl+O',
+                              command=self._browse_sww)
+        file_menu.add_separator()
+        file_menu.add_command(label='Load Config...', command=self._load_config)
+        file_menu.add_command(label='Save Config...', command=self._save_config)
+        file_menu.add_separator()
+        file_menu.add_command(label='Quit', accelerator='Ctrl+Q',
+                              command=self._on_close)
+        menubar.add_cascade(label='File', menu=file_menu)
+
+        self.root.config(menu=menubar)
+
+        # Keyboard accelerators (the labels above are only cosmetic; tk needs
+        # the bindings made explicitly).
+        self.root.bind_all('<Control-o>', lambda e: self._browse_sww())
+        self.root.bind_all('<Control-q>', lambda e: self._on_close())
+
     def _build_ui(self):
+        self._build_menubar()
+
         # ---- status bar (packed first so it anchors to the bottom) ----
         status_frame = ttk.Frame(self.root)
         status_frame.pack(side=tk.BOTTOM, fill=tk.X)


### PR DESCRIPTION
Five commits: one build fix with real consequences for the GPU images, and four fixes to the SWW GUI / basemap.

## 1. `-Dgpu_arch` never selected the target architectures (`5b7dc93f`)

The most consequential one. nvc performs the **device** link when the shared module is produced and takes the target architectures from the `-gpu=` on the *link* line; the `-gpu=` used at compile time does not carry through. `gpu_link_args` was empty, so nvc guessed:

| build environment | what was actually produced |
|---|---|
| a GPU visible | the build host's own GPU only — `-Dgpu_arch=cc80` came out as `sm_120` on a Blackwell laptop |
| no GPU visible (any container) | every architecture the bundled CUDA supports — `sm_75…sm_121` |

So the "multi-arch cc75–cc120 fat binary" in the published images was never real: both slim images contained a byte-identical arch set regardless of the `GPU_ARCH` they were built with, and they ran on T4/A10G/L4/Blackwell only because a GPU-less builder happens to emit every CUDA 13 architecture. It also explains why adding `cc70` to `GPU_ARCH` did nothing — CUDA 13 dropped Volta, and the compile-time flag was being ignored anyway.

Fix: repeat `-mp=gpu,multicore -gpu=<arch>` in `gpu_link_args` for nvc. Verified — `-Dgpu_arch=cc80` now yields exactly `sm_80`.

With selection working, both GPU Dockerfiles move to `GPU_ARCH=cuda12.9,cc70,…,cc120`. The `cuda_multi` base bundles CUDA 12.9 and 13.0 and defaults to 13.0, whose libnvvm rejects `cc70`; 12.9 supports Volta *and* Blackwell (sm_120, added in 12.8), so a single image now spans V100 → RTX 50-series and no separate V100 image is needed. The rebuilt slim image contains exactly `sm_70 sm_75 sm_80 sm_86 sm_89 sm_90 sm_120`, is still 2.15 GB, runs a real GPU-offload evolve locally, and has been validated on AWS (rc=0, results bit-identical to previous runs).

**Note for reviewers:** builds are now genuinely restricted to the architectures requested rather than accidentally universal. That is correct and deterministic, but a narrow `-Dgpu_arch` will now produce a binary that will not run elsewhere, where previously it happened to. `sm_70` itself is compile-verified only — AWS has retired p3 in ap-southeast-2 and no V100 was reachable to run it on.

## 2. OpenStreetMap basemaps were being blocked (`8d48dc93`)

Generating an OSM basemap drew tiles reading *"403 Access blocked — App is not following the tile usage policy of OpenStreetMap's volunteer-run servers"*. contextily sets `USER_AGENT = "contextily-" + uuid.uuid4().hex`, so every session requests tiles under a different, non-identifying agent; OSM's policy requires a stable agent naming the application and treats rotating ones as rate-limit evasion. The block arrives as a normal HTTP 200 whose *image* carries the message, so nothing raised and the notice was simply painted onto the map.

Now sends a stable agent naming ANUGA, its version and project page, and points contextily at a persistent tile cache under `XDG_CACHE_HOME` (the policy asks for caching too). Confirmed against the live server: the default agent returns the 6987-byte "Access blocked" tile, the ANUGA agent a real 14779-byte map tile.

## 3–5. SWW GUI

- **File menu** (`9553cdf6`) — the window had no menubar at all. Adds Open SWW…, Load/Save Config…, and Quit (Ctrl+O / Ctrl+Q). Quit routes through the existing `_on_close`, so it cancels running frame generation, stops playback and closes figures rather than stranding them.
- **HiDPI scaling** (`212234db`) — the GUI stayed physically tiny on a 3840x2400 / 340x220 mm panel (~287 DPI). Only fonts were being scaled; padding, borders and ttk geometry derive from Tk's points-per-pixel, which stayed at its 96 DPI value. Now sets `tk scaling` too (matplotlib's Tk backend derives its canvas ratio from the same value, so embedded plots scale for free). The scale also came solely from `Xft.dpi`, which on a dense panel is conservative — the true panel density from xrandr now lifts it halfway (2.0x → 2.49x here). Adds `ANUGA_GUI_SCALE` / `--ui-scale` as an override.
- **First-display figure sizing** (`9a06d846`) — the first frame appeared off-centre and wrongly scaled until the window was resized. matplotlib sizes a figure from the first `<Configure>`, which on HiDPI arrives before the canvas knows its device-pixel-ratio, leaving the figure `ui_scale`x larger than its widget (5332x2831 in a 2141x1137 widget). `_sync_canvas_sizes()` re-asserts the size once the geometry is real.

## Testing

Fast suite **2716 passed / 219 skipped**, ruff clean. 10 new offline tests (8 for scale detection, 2 for the tile agent) — no display, X server, xrandr/xrdb or network needed, so they run in CI. The GUI fixes were verified by screenshotting the running application at 1.0x and 2.49x and by measuring widget-vs-figure geometry directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)