### PR TITLE
Fix GPU builds targeting the wrong architecture (regression), and add a CUDA-aware MPI image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,11 @@ claude
 
 # Docker's own runtime mount (not build input)
 docker/data
+
+# The Dockerfiles themselves are read by the builder, never needed *inside* the
+# image, and land in the `COPY . .` layer -- so editing one used to invalidate
+# the cache for the whole ANUGA compile that follows (a ~45 min rebuild for a
+# one-line change). Excluding them keeps iteration on the Dockerfiles cheap.
+# docker/anuga-entrypoint.sh is deliberately NOT excluded: it is installed
+# into the image.
+docker/Dockerfile*

--- a/anuga/shallow_water/meson.build
+++ b/anuga/shallow_water/meson.build
@@ -207,6 +207,17 @@ if gpu_offload
   endif
   message('GPU offloading enabled')
   message('GPU architecture: ' + gpu_arch)
+  # The build contains ONLY the architectures named here, and a mismatch is not
+  # a build error -- it fails later, at every kernel launch. Anyone who leaves
+  # the option at its default is very unlikely to want a V100-only build, so say
+  # so while they can still act on it.
+  if gpu_arch == 'cc70'
+    warning('gpu_arch is at its default (cc70 = V100). The build will contain ' +
+            'ONLY that architecture and will fail at every kernel launch on any ' +
+            'other GPU. Pass -Dgpu_arch=<ccXX> for your card ' +
+            '(nvidia-smi --query-gpu=compute_cap --format=csv), or use ' +
+            'tools/install_anuga_nvc.sh, which detects it.')
+  endif
 else
   # CPU multicore execution (no GPU offloading)
   # #pragma omp target teams loop becomes regular OpenMP parallel

--- a/docker/Dockerfile.gpu.mpi
+++ b/docker/Dockerfile.gpu.mpi
@@ -1,0 +1,178 @@
+# ANUGA — GPU image WITH CUDA-aware MPI (multi-GPU / HPC runs).
+#
+# Same multi-stage shape as Dockerfile.gpu.slim, plus the MPI stack:
+#   * mpi4py + pymetis, so anuga.parallel can decompose and run distributed,
+#   * ANUGA built with -Dgpu_aware_mpi=true (halo exchange straight from device
+#     buffers, no host staging),
+#   * the HPC-X OpenMPI + UCX runtime copied into the runtime stage.
+#
+# Kept SEPARATE from anuga:gpu-slim on purpose.  The MPI runtime adds several
+# hundred MB (ompi ~235 MB + ucx ~285 MB before trimming) and the slim image
+# exists to keep AWS cold-start pulls fast.  Single-GPU instances (g4dn.xlarge,
+# g6.xlarge) cannot use multi-rank GPU anyway — mode 2 requires one rank per
+# GPU — so use gpu-slim there and this image on multi-GPU nodes.
+#
+# MPI comes from the NVHPC base's bundled HPC-X, which is built CUDA-aware
+# (ompi_info: mpi_built_with_cuda_support:value:true).  There is one HPC-X per
+# bundled CUDA; we take the 12.9 one to match the CUDA the kernels are built
+# for (see GPU_ARCH below).
+#
+# Build + smoke test:
+#   docker build -f docker/Dockerfile.gpu.mpi -t anuga:gpu-mpi .
+#   docker run --rm --gpus all anuga:gpu-mpi \
+#     python -c "from anuga.shallow_water import sw_domain_gpu_ext as e; print(e.gpu_has_mpi())"
+#   docker run --rm --gpus all anuga:gpu-mpi \
+#     mpirun --allow-run-as-root -np 2 python -c "from anuga import myid,numprocs; print(myid,numprocs)"
+#
+# Running as root inside the container makes OpenMPI refuse to start without
+# --allow-run-as-root; that is left to the caller rather than baked in, so the
+# image stays usable under a non-root user too.
+
+ARG NVHPC_TAG=25.9-devel-cuda_multi-ubuntu24.04
+ARG CUDA_RUNTIME_TAG=12.6.2-base-ubuntu24.04
+
+# ---- builder ---------------------------------------------------------------
+FROM nvcr.io/nvidia/nvhpc:${NVHPC_TAG} AS builder
+# See Dockerfile.gpu.slim for why cuda12.9 leads and why cc70 needs it.
+ARG GPU_ARCH=cuda12.9,cc70,cc75,cc80,cc86,cc89,cc90,cc120
+ARG ANUGA_VERSION=
+# HPC-X matching the CUDA the kernels are built for.
+ARG HPCX=/opt/nvidia/hpc_sdk/Linux_x86_64/25.9/comm_libs/12.9/hpcx/hpcx-2.20
+SHELL ["/bin/bash", "-lc"]
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-dev python3-pip git ca-certificates \
+        build-essential libnuma-dev && \
+    rm -rf /var/lib/apt/lists/*
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+WORKDIR /opt/anuga
+COPY . .
+
+# mpi4py FIRST and against HPC-X's mpicc: meson decides whether ANUGA gets real
+# C MPI at *configure* time, and its detection falls back to parsing
+# `mpicc -show` via mpi4py.  Installing mpi4py afterwards would leave the
+# extension built against the single-process stubs with no error (see
+# claude/KNOWN_ISSUES.md, "A reused meson build dir does NOT re-detect MPI").
+# OMPI_CC/OMPI_CXX=gcc: HPC-X's mpicc wrapper drives nvc by default, but
+# mpi4py compiles with the flags Python itself was built with (-fno-strict-
+# overflow, -Wsign-compare, ...) and nvc rejects those outright:
+#     nvc-Error-Unknown switch: -fno-strict-overflow
+# The wrapper only needs to supply MPI's include/link flags, so point it at gcc
+# -- `mpicc -show` still prints the paths meson's MPI detection parses.
+ENV OMPI_CC=gcc OMPI_CXX=g++
+# OPAL_PREFIX: this HPC-X was built under /proj/nv/... and relocated into the
+# SDK, so OpenMPI cannot find its own MCA plugins or help files without being
+# told where it now lives.
+ENV OPAL_PREFIX=${HPCX}/ompi
+# Singleton MPI_Init (a plain `python script.py`, no mpirun) spawns an orted
+# daemon, which hangs in a container.  That matters well beyond MPI runs:
+# `import anuga` imports mpi4py, which initialises MPI on import, so even a
+# serial run would hang.  Isolated singleton init skips the daemon; verified
+# not to disturb real mpirun jobs.
+ENV OMPI_MCA_ess_singleton_isolated=1
+RUN set -euo pipefail && \
+    export PATH="${HPCX}/ompi/bin:$PATH" \
+           LD_LIBRARY_PATH="${HPCX}/ompi/lib:${HPCX}/ucx/lib:${LD_LIBRARY_PATH:-}" && \
+    pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir "numpy>=2.0" cython "meson>=1.4" meson-python ninja pybind11 && \
+    MPICC="$(command -v mpicc)" pip install --no-cache-dir --no-binary=mpi4py mpi4py && \
+    pip install --no-cache-dir pymetis && \
+    python -c "from mpi4py import MPI; print('mpi4py OK:', MPI.Get_library_version().splitlines()[0])"
+
+# CFLAGS=-tp=haswell: portable ISA baseline (see Dockerfile.gpu.slim).
+# gpu_aware_mpi=true: halo exchange passes device pointers to MPI directly.
+RUN set -euo pipefail && \
+    export PATH="${HPCX}/ompi/bin:$PATH" \
+           LD_LIBRARY_PATH="${HPCX}/ompi/lib:${HPCX}/ucx/lib:${LD_LIBRARY_PATH:-}" && \
+    NVC="$(command -v nvc)" && \
+    ANUGA_VERSION="${ANUGA_VERSION}" CC="$NVC" \
+    CFLAGS="-tp=haswell" \
+    pip install --no-cache-dir --no-build-isolation -v \
+        -Csetup-args=-Dgpu_offload=true \
+        -Csetup-args=-Dgpu_arch="${GPU_ARCH}" \
+        -Csetup-args=-Dgpu_aware_mpi=true \
+        ".[data]" && \
+    pip install --no-cache-dir awscli && \
+    install -m 0755 docker/anuga-entrypoint.sh /opt/anuga-entrypoint
+
+# Fail the BUILD if MPI did not get wired in — otherwise the image silently
+# ships a sequential-stub extension that only shows up as wrong answers later.
+# NB: run from OUTSIDE /opt/anuga.  WORKDIR is the source tree, and importing
+# anuga from there picks up the un-built source package rather than the one
+# installed in the venv ("No module named 'anuga._version'").
+RUN set -euo pipefail && \
+    export LD_LIBRARY_PATH="${HPCX}/ompi/lib:${HPCX}/ucx/lib:${LD_LIBRARY_PATH:-}" && \
+    cd /tmp && python -c "\
+from anuga.shallow_water import sw_domain_gpu_ext as e; \
+assert e.gpu_has_mpi(), 'GPU extension was built WITHOUT C MPI'; \
+print('GPU extension has C MPI: OK')"
+
+# NVHPC redistributable runtime libs (see Dockerfile.gpu.slim).
+RUN set -euo pipefail && \
+    GPU_EXT="$(find "$VIRTUAL_ENV" -name 'sw_domain_gpu_ext*.so' | head -1)" && \
+    echo "GPU extension: ${GPU_EXT:-<not found>}" && \
+    if [ -n "$GPU_EXT" ]; then echo '--- ldd sw_domain_gpu_ext ---'; ldd "$GPU_EXT" || true; fi && \
+    mkdir -p /opt/nvhpc-redist && \
+    cp -aL /opt/nvidia/hpc_sdk/Linux_x86_64/*/REDIST/compilers/lib/*.so* /opt/nvhpc-redist/ 2>/dev/null || true
+
+# Stage the MPI runtime, dropping what only a *build* needs: static archives,
+# libtool descriptors, headers, man pages and the compiler wrappers.
+#
+# HPC-X ships mpirun/mpiexec as shell wrappers that source hpcx-mt-init.sh from
+# the HPC-X root (above ompi/, which we do not copy) and call hpcx_load; moved
+# here they print "hpcx_load: command not found" on every launch.  The real
+# binaries sit in bin/.bin/, and we set OPAL_PREFIX and LD_LIBRARY_PATH
+# ourselves, so swap each wrapper for the binary it fronts.
+RUN set -euo pipefail && \
+    mkdir -p /opt/mpi && \
+    cp -aL "${HPCX}/ompi" /opt/mpi/ompi && \
+    cp -aL "${HPCX}/ucx"  /opt/mpi/ucx  && \
+    find /opt/mpi \( -name '*.a' -o -name '*.la' \) -delete && \
+    for w in /opt/mpi/ompi/bin/.bin/*; do \
+        b="$(basename "$w")"; \
+        [ -f "/opt/mpi/ompi/bin/$b" ] && cp -a "$w" "/opt/mpi/ompi/bin/$b"; \
+    done && \
+    rm -rf /opt/mpi/ompi/include /opt/mpi/ucx/include \
+           /opt/mpi/ompi/share/man /opt/mpi/ucx/share/man \
+           /opt/mpi/ompi/share/doc /opt/mpi/ucx/share/doc && \
+    du -sh /opt/mpi/ompi /opt/mpi/ucx
+
+# ---- runtime ---------------------------------------------------------------
+FROM nvidia/cuda:${CUDA_RUNTIME_TAG}
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 libgomp1 ca-certificates libnuma1 openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /opt/venv           /opt/venv
+COPY --from=builder /opt/nvhpc-redist   /opt/nvhpc-redist
+COPY --from=builder /opt/mpi            /opt/mpi
+COPY --from=builder /opt/anuga-entrypoint /usr/local/bin/anuga-entrypoint
+# OPAL_PREFIX: OpenMPI hardcodes its install prefix at build time, and we moved
+# it, so without this mpirun cannot find its own MCA plugins.
+# Container-friendly transport defaults.  HPC-X defaults to the UCX PML, which
+# finds no usable transport inside a plain container and aborts MPI_Init with
+# "no components were able to be opened" -- even for two ranks on one host.
+# ob1 + smcuda works and, unlike vader, is CUDA-aware (CUDA IPC), so
+# device-buffer sends keep working.
+#
+# hwloc binding is disabled because a container usually lacks the privileges
+# for it, and OpenMPI otherwise prints "failed to bind memory" on every run.
+#
+# OVERRIDE THESE on a cluster with a real fabric (InfiniBand/EFA): the settings
+# below would confine you to shared memory and TCP. There, prefer the UCX PML,
+# e.g. `-x OMPI_MCA_pml=ucx -x UCX_TLS=rc,cuda_copy,cuda_ipc,sm,self`.
+ENV PATH="/opt/venv/bin:/opt/mpi/ompi/bin:$PATH" \
+    OPAL_PREFIX=/opt/mpi/ompi \
+    OMPI_MCA_ess_singleton_isolated=1 \
+    OMPI_MCA_pml=ob1 \
+    OMPI_MCA_btl=self,smcuda,tcp \
+    OMPI_MCA_hwloc_base_binding_policy=none \
+    LD_LIBRARY_PATH="/opt/nvhpc-redist:/opt/mpi/ompi/lib:/opt/mpi/ucx/lib:${LD_LIBRARY_PATH}" \
+    ANUGA_WORKDIR=/work HOME=/tmp MPLCONFIGDIR=/tmp
+RUN python -c "import anuga; print('ANUGA', anuga.__version__, 'imports OK')" && \
+    python -c "from mpi4py import MPI; print('mpi4py OK, size', MPI.COMM_WORLD.Get_size())" && \
+    python -c "\
+from anuga.shallow_water import sw_domain_gpu_ext as e; \
+print('GPU extension has C MPI:', e.gpu_has_mpi())"
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/anuga-entrypoint"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -203,8 +203,9 @@ docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu-slim"
 
 ### AWS Batch (GPU)
 
-1. **Compute environment** — EC2 with GPU instance types (`g4dn`/`g5`/`g6`/`p4d`/`p5`;
-   `p3`/V100 is not covered by the default image — see GPU_ARCH note in Dockerfile.gpu)
+1. **Compute environment** — EC2 with GPU instance types (`g4dn`/`g5`/`g6`/`p4d`/`p5`,
+   and `p3`/V100 — the default image now spans cc70–cc120, see the GPU_ARCH note
+   in Dockerfile.gpu)
    using the **ECS GPU-optimized AMI** (driver + `nvidia-container-runtime`
    preinstalled). Spot is fine for interruptible runs.
 2. **Job definition** — key fields:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,8 +26,10 @@ services:
       dockerfile: docker/Dockerfile.gpu
       args:
         # Multi-arch fat binary (AWS p3/g4dn/p4d/g5/p5 + local Blackwell laptop).
+        # Must match Dockerfile.gpu's default: cuda12.9 leads so cc70 (V100) is
+        # available -- the bundled CUDA 13 dropped Volta.
         # For a faster laptop-only build, override with e.g. GPU_ARCH=cc120.
-        GPU_ARCH: cc75,cc80,cc86,cc89,cc90,cc120
+        GPU_ARCH: cuda12.9,cc70,cc75,cc80,cc86,cc89,cc90,cc120
         # Must be a real nvcr.io/nvidia/nvhpc devel tag whose nvc supports the
         # arches above (cc120/Blackwell needs NVHPC >= 25.1).
         NVHPC_TAG: 25.9-devel-cuda_multi-ubuntu24.04

--- a/docs/source/appendices/install_gpu.rst
+++ b/docs/source/appendices/install_gpu.rst
@@ -77,6 +77,11 @@ dir, builds, and runs the isolated GPU tests):
    # options via env vars, e.g. build for an A100 with Python 3.13:
    PY=3.13 GPU_ARCH=cc80 bash tools/install_anuga_nvc.sh
 
+``GPU_ARCH`` defaults to the compute capability of the GPU in the machine you
+are building on, read from ``nvidia-smi``, so you normally do not set it. Set it
+explicitly when building for a *different* card than the one present (e.g. on a
+login node for a compute node with other GPUs).
+
 **Manual build:**
 
 .. code-block:: bash
@@ -99,8 +104,40 @@ Pick ``gpu_arch`` for your card:
      - H100
    * - ``cc80``
      - A100
+   * - ``cc86``
+     - RTX 30-series (Ampere)
+   * - ``cc89``
+     - RTX 40-series / L4 (Ada)
+   * - ``cc75``
+     - T4 / RTX 20-series (Turing)
    * - ``cc70``
      - V100
+
+Several may be given at once for a binary that runs on any of them, e.g.
+``-Dgpu_arch=cc80,cc86,cc90``. Note that the CUDA bundled with recent NVIDIA HPC
+SDKs dropped Volta, so ``cc70`` needs an older CUDA selected alongside it:
+``-Dgpu_arch=cuda12.9,cc70,cc80``.
+
+.. warning::
+
+   **Build for the right architecture.** The build contains only the
+   architectures you ask for. Requesting the wrong one still compiles cleanly
+   and then fails at *every kernel launch* — which appears as the GPU tests
+   reporting ``CRASH`` after an apparently successful install, not as a build
+   error.
+
+   Check what a build actually contains::
+
+       cuobjdump --list-elf $(python -c \
+           "import anuga.shallow_water.sw_domain_gpu_ext as m; print(m.__file__)") \
+           | grep -o 'sm_[0-9]*' | sort -u
+
+   and compare with your card::
+
+       nvidia-smi --query-gpu=name,compute_cap --format=csv
+
+   ``compute_cap`` 8.6 means you want ``cc86``. ``tools/install_anuga_nvc.sh``
+   performs this check for you and reports a mismatch before running the tests.
 
 .. warning::
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -32,8 +32,9 @@ bash tools/install_anuga_nvc.sh          # NVIDIA HPC SDK (nvc) GPU build
 
 Builds the GPU-offload extension (`-Dgpu_offload=true`) with `nvc`, runs the
 isolated GPU test suite, and clears a stale build dir so the compiler switch
-takes effect. Env vars: `PY` (default 3.14), `GPU_ARCH` (default `cc120`),
-`NVHPC_ROOT`. See `../CLAUDE.md` → "Testing a GPU-offload (nvc) build".
+takes effect. Env vars: `PY` (default 3.14), `GPU_ARCH` (default: **detected from this
+machine's GPU** via `nvidia-smi`; a wrong value builds a package that
+compiles but crashes on every kernel launch), `NVHPC_ROOT`. See `../CLAUDE.md` → "Testing a GPU-offload (nvc) build".
 
 ## Contents
 

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -13,7 +13,13 @@
 #
 #   PY          Python version to use (default: 3.14)
 #   GPU_ARCH    GPU compute capability, e.g. cc120 (RTX 5070 Blackwell),
-#               cc90 (H100), cc80 (A100), cc70 (V100).  Default: cc120
+#               cc86 (RTX 30xx Ampere), cc90 (H100), cc80 (A100), cc70 (V100).
+#               Default: DETECTED from the GPU in this machine via nvidia-smi,
+#               falling back to a multi-architecture build if that fails.
+#               Getting this wrong matters: the build now contains only the
+#               architectures asked for, so a mismatched value produces a
+#               package that compiles fine and then crashes on every kernel
+#               launch.
 #   NVHPC_ROOT  Override path to NVIDIA HPC SDK root if auto-detection fails.
 #               e.g. /opt/nvidia/hpc_sdk/Linux_x86_64/26.3
 #
@@ -26,7 +32,28 @@
 #   - conda environment anuga_env_${PY} created via install_miniforge.sh
 
 PY=${PY:-"3.14"}
-GPU_ARCH=${GPU_ARCH:-"cc120"}
+
+# Detect this machine's GPU rather than assuming one.  nvidia-smi reports the
+# compute capability as e.g. "8.6", which becomes cc86.
+#
+# This used to be hardcoded to cc120 (the author's laptop) and nobody noticed,
+# because -Dgpu_arch was not reaching nvc's device link: nvc fell back to the
+# GPU it found on the build machine, so any value happened to work.  Once that
+# was fixed the hardcoded default started producing sm_120-only builds that
+# crash on every other card.
+detect_gpu_arch() {
+    local cap
+    cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+          | head -1 | tr -d ' ')
+    if [[ "$cap" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo "cc${cap//./}"
+    else
+        # No usable nvidia-smi (headless build node, driver not loaded, ...):
+        # build for every architecture ANUGA supports rather than guess one.
+        echo "cc70,cc75,cc80,cc86,cc89,cc90,cc120"
+    fi
+}
+GPU_ARCH=${GPU_ARCH:-"$(detect_gpu_arch)"}
 
 set -e
 
@@ -216,6 +243,40 @@ $CONDA_RUN bash -c \
      -Csetup-args=-Dgpu_arch=${GPU_ARCH}"
 
 echo " "
+# ---------------------------------------------------------------------------
+# Sanity check: does the built extension actually contain code for THIS GPU?
+#
+# A mismatch here is the difference between "it works" and every GPU test
+# reporting CRASH: the build succeeds either way, and the kernels only fail
+# when they are launched.  Diagnose it up front rather than leaving the user
+# to interpret a wall of crashes.
+# ---------------------------------------------------------------------------
+GPU_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
+if [[ "$GPU_CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    WANT_SM="sm_${GPU_CAP//./}"
+    GPU_EXT=$($CONDA_RUN python -c \
+        "import anuga.shallow_water.sw_domain_gpu_ext as m; print(m.__file__)" 2>/dev/null | tail -1)
+    CUOBJDUMP=$(command -v cuobjdump || ls "${NVHPC_ROOT}"/cuda/bin/cuobjdump 2>/dev/null | head -1)
+    if [[ -n "$GPU_EXT" && -n "$CUOBJDUMP" && -f "$GPU_EXT" ]]; then
+        BUILT_SM=$("$CUOBJDUMP" --list-elf "$GPU_EXT" 2>/dev/null \
+                   | grep -oE 'sm_[0-9]+' | sort -uV | tr '\n' ' ')
+        echo "# GPU in this machine : ${WANT_SM} (compute capability ${GPU_CAP})"
+        echo "# Built for           : ${BUILT_SM:-<none found>}"
+        if [[ -n "$BUILT_SM" && " $BUILT_SM " != *" $WANT_SM "* ]]; then
+            echo ""
+            echo "#=================================================================="
+            echo "# WARNING: this build does NOT include ${WANT_SM}, the GPU in this"
+            echo "# machine.  It compiled cleanly, but every GPU kernel launch will"
+            echo "# fail and the tests below will report CRASH."
+            echo "#"
+            echo "# Rebuild for this GPU:"
+            echo "#     GPU_ARCH=cc${GPU_CAP//./} bash ${SCRIPT}"
+            echo "#=================================================================="
+            echo ""
+        fi
+    fi
+fi
+
 echo "#============================================================"
 echo "# Running GPU test suite (isolated runner)"
 echo "#   One fresh process per test.  A plain 'pytest' on this file"


### PR DESCRIPTION
**Regression fix — please prioritise.** GPU installs made with `tools/install_anuga_nvc.sh` since #220 merged produce a package that compiles cleanly and then crashes on every GPU kernel launch. Reported on an RTX 30xx; the isolated GPU tests report a wall of `CRASH` after an apparently successful install.

## What happened

`tools/install_anuga_nvc.sh` defaulted to `GPU_ARCH=cc120` — the compute capability of the machine it was written on. That was harmless for as long as `-Dgpu_arch` was **not reaching nvc's device link**: nvc fell back to whichever GPU it found on the build machine, so any value happened to produce a working build.

#220 (`5b7dc93f`) fixed that plumbing, so the requested architecture is now honoured. The hardcoded default immediately started producing `sm_120`-only builds on every other card. A mismatch is not a build error — the kernels only fail when launched.

**Workaround for anyone affected right now**, without waiting for this PR:

```bash
GPU_ARCH=cc86 bash tools/install_anuga_nvc.sh    # cc86 = RTX 30xx; use your card's value
```

## Fixes

**`install_anuga_nvc.sh`** now defaults `GPU_ARCH` to the compute capability reported by `nvidia-smi` (`8.6` → `cc86`), falling back to a multi-architecture build when `nvidia-smi` is unavailable (headless build node, driver not loaded) rather than guessing a single one.

It also checks, before running the test suite, whether the built extension contains code for the GPU actually present, and says so plainly if not:

```
GPU in this machine : sm_86 (compute capability 8.6)
Built for           : sm_120
WARNING: this build does NOT include sm_86 ... every GPU kernel launch will
fail and the tests below will report CRASH.
Rebuild for this GPU: GPU_ARCH=cc86 bash <script>
```

**Swept the rest of the tree for the same assumption**, all of it previously masked by the old behaviour: `docker-compose.yml` pinned an arch list out of step with the Dockerfiles; `tools/README.md` and the docs still documented the old `cc120` default; `docker/README.md` still claimed V100 was not covered by the default image (it is now, cc70–cc120).

**`meson.build` warns when a GPU build leaves `gpu_arch` at its default** (`cc70` = V100). Nobody building on a modern card wants a V100-only package, and the failure is otherwise silent until run time.

**The GPU install appendix** gains the common architectures that were missing (cc86 RTX 30xx, cc89 RTX 40xx/L4, cc75 T4/RTX 20xx), a note that several can be combined, the `cuda12.9` requirement for `cc70`, and a warning showing how to check what a build contains (`cuobjdump --list-elf`) against what the card needs (`nvidia-smi --query-gpu=compute_cap`).

## Also included: `anuga:gpu-mpi`

A separate GPU image with CUDA-aware MPI (`Dockerfile.gpu.mpi`) — mpi4py, pymetis and `-Dgpu_aware_mpi=true`, using the NVHPC base's bundled HPC-X OpenMPI 4.1.7a1 (`mpi_built_with_cuda_support:value:true`). Kept separate from `gpu-slim` because the MPI runtime costs ~540 MB and single-GPU instances cannot use multi-rank GPU anyway.

Four container-specific issues are solved and documented in the file: `OMPI_CC=gcc` (HPC-X's mpicc drives nvc, which rejects Python's build flags), `OPAL_PREFIX` (HPC-X was built elsewhere and relocated), `OMPI_MCA_ess_singleton_isolated=1` (singleton `MPI_Init` spawns an orted that hangs — this bites *serial* runs too, since `import anuga` imports mpi4py), and container transport defaults (`pml=ob1, btl=self,smcuda,tcp`; `smcuda` keeps CUDA-awareness — **override these on a cluster with a real fabric**).

`.dockerignore` now excludes `docker/Dockerfile*`: they landed in the `COPY . .` layer, so a one-line Dockerfile edit invalidated the ~45 min ANUGA compile. That rebuild is now 2.6 s with 14 layers cached.

## Testing

Fast suite **2716 passed / 219 skipped**. Verified on a cc120 machine that arch detection returns `cc120`, that the fallback list is used when `nvidia-smi` is missing, and that a deliberate `-Dgpu_arch=cc86` build produces an `sm_86`-only extension which the new check flags. In the built MPI image: CUDA-aware MPI reported true, serial run works, `mpirun -np 2` clean, a real 2-rank ANUGA distribute+evolve completes, and single-rank GPU offload gives the same answer as `gpu-slim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)