### PR TITLE
Installer scripts: report what was built, probe what the toolchain can build, and survive re-runs

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -32,7 +32,8 @@ bash tools/install_anuga_nvc.sh          # NVIDIA HPC SDK (nvc) GPU build
 
 Builds the GPU-offload extension (`-Dgpu_offload=true`) with `nvc`, runs the
 isolated GPU test suite, and clears a stale build dir so the compiler switch
-takes effect. Env vars: `PY` (default 3.14), `GPU_ARCH` (default: **detected from this
+takes effect. Env vars: `PY` (default 3.12, same as `install_miniforge.sh`; ignored when a
+conda env is already active), `GPU_ARCH` (default: **detected from this
 machine's GPU** via `nvidia-smi`; a wrong value builds a package that
 compiles but crashes on every kernel launch), `NVHPC_ROOT`. See `../CLAUDE.md` → "Testing a GPU-offload (nvc) build".
 

--- a/tools/anuga_build_report.py
+++ b/tools/anuga_build_report.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""Report what this ANUGA install actually is, and whether it fits this machine.
+
+Run it after an install, or paste its output into a bug report::
+
+    python tools/anuga_build_report.py
+
+A GPU build names the architectures it was compiled for, and contains *only*
+those.  Asking for the wrong one is not a build error -- it compiles cleanly and
+then fails at every kernel launch, which surfaces as the GPU tests reporting
+CRASH.  ``--check`` exits non-zero on that mismatch (and on a broken install) so
+an install script can stop and say why:
+
+    python tools/anuga_build_report.py --check
+"""
+
+import argparse
+import glob
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _run(cmd, timeout=10):
+    """Return stdout of *cmd*, or '' if it cannot be run."""
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return out.stdout.strip() if out.returncode == 0 else ''
+    except (OSError, subprocess.SubprocessError):
+        return ''
+
+
+def gpu_compute_caps():
+    """Compute capabilities of the GPUs present, e.g. ['8.6']."""
+    out = _run(['nvidia-smi', '--query-gpu=compute_cap', '--format=csv,noheader'])
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def gpu_names():
+    out = _run(['nvidia-smi', '--query-gpu=name', '--format=csv,noheader'])
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _find_cuobjdump():
+    exe = shutil.which('cuobjdump')
+    if exe:
+        return exe
+    pattern = '/opt/nvidia/hpc_sdk/Linux_x86_64/*/cuda/bin/cuobjdump'
+    found = sorted(glob.glob(pattern))
+    return found[-1] if found else None
+
+
+def built_sm_architectures(so_path):
+    """SM architectures embedded in *so_path*, e.g. ['sm_80', 'sm_86'].
+
+    Returns None when it cannot be determined (no cuobjdump available), which
+    is different from an empty list (a CPU build with no device code).
+    """
+    cuobjdump = _find_cuobjdump()
+    if not cuobjdump or not so_path or not os.path.isfile(so_path):
+        return None
+    out = _run([cuobjdump, '--list-elf', so_path], timeout=60)
+    if not out:
+        return []
+    archs = {tok for line in out.splitlines() for tok in line.split()
+             if tok.startswith('sm_')}
+    # also catch "sm_80" appearing inside a filename like foo.sm_80.cubin
+    for line in out.splitlines():
+        for part in line.replace('.', ' ').split():
+            if part.startswith('sm_') and part[3:].isdigit():
+                archs.add(part)
+    return sorted(archs, key=lambda a: int(a[3:]))
+
+
+def collect():
+    """Gather everything worth knowing; never raises."""
+    info = {}
+    info['python'] = '%d.%d.%d' % sys.version_info[:3]
+    info['executable'] = sys.executable
+    info['platform'] = _run(['uname', '-sr']) or sys.platform
+    info['conda_env'] = os.environ.get('CONDA_DEFAULT_ENV', '(none)')
+    info['compute_mode_env'] = os.environ.get('ANUGA_DEFAULT_COMPUTE_MODE',
+                                              '(unset -> legacy)')
+
+    try:
+        import anuga
+    except Exception as exc:                      # noqa: BLE001 - report anything
+        info['anuga'] = 'IMPORT FAILED: %s: %s' % (type(exc).__name__, exc)
+        return info
+
+    info['anuga'] = getattr(anuga, '__version__', '(unknown)')
+    info['anuga_path'] = getattr(anuga, '__file__', '(unknown)')
+    # An editable install imports from the source tree and keeps its compiled
+    # extensions in build/cp<ver>; deleting that directory breaks the install.
+    info['editable'] = 'site-packages' not in (info['anuga_path'] or '')
+
+    try:
+        info['gpu_offload_build'] = bool(anuga.gpu_offload_enabled())
+    except Exception:
+        info['gpu_offload_build'] = None
+
+    ext_path = None
+    try:
+        import anuga.shallow_water.sw_domain_gpu_ext as ext
+        ext_path = getattr(ext, '__file__', None)
+        info['ext_path'] = ext_path
+        try:
+            info['mpi'] = bool(ext.gpu_has_mpi())
+        except Exception:
+            info['mpi'] = None
+    except Exception as exc:                      # noqa: BLE001
+        info['ext_path'] = 'IMPORT FAILED: %s' % exc
+        info['mpi'] = None
+
+    info['built_for'] = built_sm_architectures(ext_path)
+    info['gpu_caps'] = gpu_compute_caps()
+    info['gpu_names'] = gpu_names()
+    return info
+
+
+def mismatch(info):
+    """(problem, advice) if the build cannot run on this machine, else None."""
+    if str(info.get('anuga', '')).startswith('IMPORT FAILED'):
+        advice = 'Reinstall: the package does not import.'
+        path = info.get('anuga_path') or ''
+        if 'build/cp' in str(info.get('anuga', '')) or 'No such file' in str(info.get('anuga', '')):
+            advice = ('An editable install lost its build directory. '
+                      'Reinstall with pip install --no-build-isolation -e . '
+                      '(plus your -Dgpu_* options).')
+        return ('ANUGA does not import', advice)
+
+    built = info.get('built_for')
+    caps = info.get('gpu_caps') or []
+    # Only meaningful for a GPU build on a machine that has a GPU and where the
+    # architectures could actually be read.
+    if not built or not caps or not info.get('gpu_offload_build'):
+        return None
+
+    # Compatibility is one-directional.  nvc embeds PTX alongside the SASS, and
+    # the driver JIT-compiles PTX *forward*, so a build for an older
+    # architecture runs on a newer GPU (verified: a cc86 build runs on sm_120).
+    # The reverse is impossible -- PTX for compute_120 cannot target sm_86 --
+    # so the build is unusable only when EVERY architecture in it is newer than
+    # the GPU present.
+    built_nums = sorted(int(''.join(c for c in a[3:] if c.isdigit()))
+                        for a in built)
+    cap_nums = sorted(int(c.split('.')[0]) * 10 + int(c.split('.')[1])
+                      for c in caps if '.' in c)
+    if not built_nums or not cap_nums:
+        return None
+
+    newest_gpu = max(cap_nums)
+    if min(built_nums) > newest_gpu:
+        return ('this build targets only GPUs newer than the one present '
+                '(built for %s, GPU is sm_%d)'
+                % (' '.join(built), newest_gpu),
+                'Rebuild for this GPU: GPU_ARCH=cc%d bash '
+                'tools/install_anuga_nvc.sh' % newest_gpu)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--check', action='store_true',
+                        help='exit non-zero if this build cannot run here')
+    args = parser.parse_args()
+
+    info = collect()
+
+    def row(label, value):
+        print('#   %-22s %s' % (label + ':', value))
+
+    print('#' + '=' * 62)
+    print('# ANUGA build report')
+    print('#' + '=' * 62)
+    row('anuga', info.get('anuga'))
+    row('imported from', info.get('anuga_path'))
+    if info.get('editable'):
+        row('install type', 'editable (needs its build/cp* directory kept)')
+    else:
+        row('install type', 'copied into site-packages')
+    row('python', '%s  (%s)' % (info.get('python'), info.get('conda_env')))
+    row('platform', info.get('platform'))
+    row('compute mode default', info.get('compute_mode_env'))
+
+    gpu_build = info.get('gpu_offload_build')
+    row('GPU offload build', {True: 'yes', False: 'no (CPU multicore)',
+                              None: 'unknown'}[gpu_build])
+    if info.get('mpi') is not None:
+        row('MPI in GPU ext', 'yes' if info['mpi'] else 'no (sequential stubs)')
+
+    built = info.get('built_for')
+    if built is None:
+        row('built for', '(cuobjdump not available - cannot tell)')
+    elif built:
+        row('built for', ' '.join(built))
+
+    names, caps = info.get('gpu_names') or [], info.get('gpu_caps') or []
+    if caps:
+        for name, cap in zip(names or ['GPU'] * len(caps), caps):
+            row('GPU present', '%s (compute capability %s -> sm_%s)'
+                % (name, cap, cap.replace('.', '')))
+    else:
+        row('GPU present', 'none detected (nvidia-smi unavailable)')
+    print('#' + '=' * 62)
+
+    problem = mismatch(info)
+    if problem:
+        what, advice = problem
+        print('#')
+        print('# PROBLEM: %s' % what)
+        print('#')
+        print('# %s' % advice)
+        print('#' + '=' * 62)
+        if args.check:
+            return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -134,6 +134,9 @@ arch_compiles() {
     return $rc
 }
 
+GPU_ARCH_EXPLICIT=1
+[ "$GPU_ARCH" = "auto" ] && GPU_ARCH_EXPLICIT=0
+
 if [ "$GPU_ARCH" = "auto" ]; then
     CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
     if [[ "$CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
@@ -186,9 +189,24 @@ fi
 echo "# Checking that nvc accepts -gpu=${GPU_ARCH} ..."
 if ! arch_compiles "$GPU_ARCH"; then
     echo "#   rejected: ${PROBE_ERR}"
-    # Much the most common cause is cc70 on a CUDA-13-only SDK. Retry without it
-    # rather than failing a build that would otherwise be fine.
+    # Dropping an architecture the user asked for by name would hand them a
+    # build that crashes on the very GPU they were targeting, so only the
+    # auto-resolved list is narrowed. An explicit GPU_ARCH is their decision to
+    # correct.
     GPU_ARCH_NO70=$(echo "$GPU_ARCH" | sed 's/cuda12\.[0-9]*,//; s/cc70,//; s/,cc70//')
+    if [ "$GPU_ARCH_EXPLICIT" = "1" ] && [ "$GPU_ARCH_NO70" != "$GPU_ARCH" ]; then
+        echo "#====================================================="
+        echo "# ERROR: you asked for ${GPU_ARCH}, but this nvc cannot build cc70."
+        echo "#        ${PROBE_ERR}"
+        echo "#"
+        echo "# cc70 (V100) needs a CUDA <= 12.x toolkit; CUDA 13 dropped Volta."
+        echo "# Either load an nvhpc module built against CUDA 12.x, or drop"
+        echo "# cc70 yourself and accept that the build will not run on a V100:"
+        echo "#"
+        echo "#     GPU_ARCH=${GPU_ARCH_NO70} bash ${SCRIPT}"
+        echo "#====================================================="
+        exit 1
+    fi
     if [ "$GPU_ARCH_NO70" != "$GPU_ARCH" ] && arch_compiles "$GPU_ARCH_NO70"; then
         echo "#   retrying without cc70 (V100): ${GPU_ARCH_NO70}"
         echo "#   NOTE: the result will NOT run on a V100."

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -67,6 +67,11 @@ echo " "
 # ------------------------------------------------------------------
 if [ -n "$NVHPC_ROOT" ]; then
     NVC="$NVHPC_ROOT/compilers/bin/nvc"
+elif command -v nvc >/dev/null 2>&1; then
+    # An nvc already on PATH is the user's choice -- on HPC systems it comes
+    # from a module and is often a wrapper (e.g. Gadi:
+    # /apps/nvidia-hpc-sdk/wrappers/nvc), not the /opt SDK layout below.
+    NVC=$(command -v nvc)
 else
     # Search /opt/nvidia/hpc_sdk/Linux_x86_64/ for the newest installed version
     NVHPC_BASE="/opt/nvidia/hpc_sdk/Linux_x86_64"
@@ -83,7 +88,12 @@ if [ -z "$NVC" ] || [ ! -x "$NVC" ]; then
     echo "#=====================================================";
     echo "# ERROR: nvc not found."
     echo "#"
-    echo "# Install the NVIDIA HPC SDK first:"
+    echo "# On an HPC system, load it as a module first, e.g.:"
+    echo "#"
+    echo "#   module avail nvhpc          # see what is available"
+    echo "#   module load nvhpc"
+    echo "#"
+    echo "# Otherwise install the NVIDIA HPC SDK:"
     echo "#"
     echo "#   curl -fsSL https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK \\"
     echo "#     | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg"
@@ -112,16 +122,13 @@ echo " "
 #     matching the current driver version ... was not installed"), because
 #     CUDA 13's libnvvm dropped Volta.
 # ------------------------------------------------------------------
-NVHPC_DIR=$(dirname "$(dirname "$NVC")")          # .../<version>
-CUDA12=$(ls -d "${NVHPC_DIR}"/cuda/12.* 2>/dev/null | sort -V | tail -1)
-
 arch_compiles() {
     # Tiny OpenMP-target probe; ~2s. Returns 0 if nvc accepts this -gpu= string.
-    local arch="$1" tmp
+    local arch="$1" tmp rc
     tmp=$(mktemp -d)
     printf '#include <stdio.h>\nint main(void){double a[10];\n#pragma omp target teams distribute parallel for map(tofrom:a[0:10])\nfor(int i=0;i<10;i++)a[i]=i;\nprintf("%%f\\n",a[9]);return 0;}\n' > "$tmp/probe.c"
     "$NVC" -mp=gpu -gpu="$arch" -c "$tmp/probe.c" -o "$tmp/probe.o" >"$tmp/log" 2>&1
-    local rc=$?
+    rc=$?
     [ $rc -ne 0 ] && PROBE_ERR=$(head -1 "$tmp/log")
     rm -rf "$tmp"
     return $rc
@@ -133,19 +140,46 @@ if [ "$GPU_ARCH" = "auto" ]; then
         GPU_ARCH="cc${CAP//./}"
         echo "# GPU_ARCH=auto -> ${GPU_ARCH} (detected: compute capability ${CAP})"
     else
-        # No GPU visible (login node, driver not loaded).  Build for everything
-        # this SDK can target, so the result runs on the compute nodes.
-        if [ -n "$CUDA12" ]; then
-            GPU_ARCH="cuda$(basename "$CUDA12"),cc70,cc75,cc80,cc86,cc89,cc90,cc120"
-            echo "# GPU_ARCH=auto -> multi-architecture (no GPU visible here)."
-            echo "#   This SDK ships CUDA $(basename "$CUDA12"), so cc70/V100 is included."
-        else
-            GPU_ARCH="cc75,cc80,cc86,cc89,cc90,cc120"
-            echo "# GPU_ARCH=auto -> multi-architecture (no GPU visible here)."
-            echo "#   This SDK ships no CUDA 12.x, so cc70/V100 CANNOT be built:"
-            echo "#   CUDA 13 dropped Volta. Load an SDK with CUDA 12.x if you"
-            echo "#   need V100 support."
+        # No GPU visible: an HPC login node, or a driver that is not loaded.
+        # Build for everything this SDK can target, so the result runs on the
+        # compute nodes.
+        #
+        # Which architectures those are cannot be read off the filesystem: nvc
+        # may be a module wrapper (Gadi: /apps/nvidia-hpc-sdk/wrappers/nvc) with
+        # no SDK layout beneath it.  cc70 (V100) additionally needs a CUDA <=
+        # 12.x, since CUDA 13's libnvvm dropped Volta -- and when an SDK ships
+        # both, the CUDA 13 default must be overridden explicitly.  So ASK the
+        # compiler: try the widest list first and keep the first that builds.
+        echo "# GPU_ARCH=auto -> no GPU visible here; probing what this nvc can build."
+        ALL="cc75,cc80,cc86,cc89,cc90,cc120"
+        GPU_ARCH=""
+        for CANDIDATE in "cc70,${ALL}" \
+                         "cuda12.9,cc70,${ALL}" \
+                         "cuda12.8,cc70,${ALL}" \
+                         "cuda12.6,cc70,${ALL}" \
+                         "${ALL}"; do
+            printf '#   trying %-34s ... ' "$CANDIDATE"
+            if arch_compiles "$CANDIDATE"; then
+                echo "ok"
+                GPU_ARCH="$CANDIDATE"
+                break
+            fi
+            echo "no"
+        done
+        if [ -z "$GPU_ARCH" ]; then
+            echo "#====================================================="
+            echo "# ERROR: nvc rejected every architecture list tried."
+            echo "#        Last error: ${PROBE_ERR}"
+            echo "#        Set GPU_ARCH explicitly, e.g. GPU_ARCH=cc80"
+            echo "#====================================================="
+            exit 1
         fi
+        case "$GPU_ARCH" in
+            *cc70*) echo "#   V100 (cc70) IS included - this build covers V100 through Blackwell." ;;
+            *)      echo "#   NOTE: cc70/V100 could not be built with this SDK (CUDA 13 dropped"
+                    echo "#         Volta). This build will NOT run on a V100; load an nvhpc"
+                    echo "#         module with CUDA 12.x if you need one." ;;
+        esac
     fi
 fi
 

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -11,7 +11,9 @@
 #
 # Environment variables (all optional):
 #
-#   PY          Python version to use (default: 3.14)
+#   PY          Python version to use (default: 3.12, matching
+#               install_miniforge.sh).  Ignored when a conda environment is
+#               already activated -- that one is used.
 #   GPU_ARCH    GPU compute capability, e.g. cc120 (RTX 5070 Blackwell),
 #               cc86 (RTX 30xx Ampere), cc90 (H100), cc80 (A100), cc70 (V100).
 #               Default: DETECTED from the GPU in this machine via nvidia-smi,
@@ -31,7 +33,10 @@
 #   - NVIDIA HPC SDK installed (see KNOWN_ISSUES.md for apt install recipe)
 #   - conda environment anuga_env_${PY} created via install_miniforge.sh
 
-PY=${PY:-"3.14"}
+# Keep this default in step with tools/install_miniforge.sh: the documented flow
+# is to run that script and then this one, and if the two disagree this one
+# looks for an environment the other never created.
+PY=${PY:-"3.12"}
 
 # Detect this machine's GPU rather than assuming one.  nvidia-smi reports the
 # compute capability as e.g. "8.6", which becomes cc86.
@@ -139,9 +144,17 @@ else
     fi
     ENV_NAME="anuga_env_${PY}"
     if ! "$CONDA_BIN/conda" env list | grep -q "${ENV_NAME}"; then
+        FOUND=$("$CONDA_BIN/conda" env list | awk '/^anuga_env_/ {print $1}' | tr '\n' ' ')
         echo "#=====================================================";
         echo "# ERROR: conda environment '${ENV_NAME}' not found."
-        echo "# Run install_miniforge.sh first (PY=${PY}), or activate your env."
+        if [ -n "$FOUND" ]; then
+            echo "#"
+            echo "# These anuga environments do exist: ${FOUND}"
+            echo "# Activate one, or name it explicitly, e.g."
+            echo "#     PY=<version> bash ${SCRIPT}"
+        else
+            echo "# Run install_miniforge.sh first (PY=${PY}), or activate your env."
+        fi
         echo "#=====================================================";
         exit 1
     fi

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -57,6 +57,12 @@ GPU_ARCH=${GPU_ARCH:-"$(detect_gpu_arch)"}
 
 set -e
 
+# Keep a transcript -- this is the file to ask for when someone reports that a
+# GPU build "installed fine but every test crashes".
+LOGFILE=${LOGFILE:-"$HOME/anuga_gpu_install_$(date +%Y%m%d_%H%M%S).log"}
+exec > >(tee -a "$LOGFILE") 2>&1
+echo "# Logging this installation to: $LOGFILE"
+
 trap 'echo ""; echo "#====================================================="; echo "# Installation failed at line $LINENO"; echo "#====================================================="; exit 1' ERR
 
 SCRIPT=$(realpath "$0")
@@ -237,45 +243,50 @@ echo "# Removing any stale meson build directory (build/cp*) for a clean nvc con
 rm -rf "${ANUGA_CORE_PATH}"/build/cp*
 echo " "
 
+# EDITABLE=0 installs a copy into site-packages instead, which survives having
+# the source tree or its build directory removed.  The default stays editable
+# (this script is mostly used on a development checkout), but note the
+# dependency: an editable install imports from ${ANUGA_CORE_PATH} and loads its
+# compiled extensions from build/cp<ver>.  Delete that directory later and
+# `import anuga` fails with a FileNotFoundError naming a missing build path,
+# which does not obviously mean "reinstall".
+if [ "${EDITABLE:-1}" = "1" ]; then
+    PIP_TARGET_ARGS="-e ."
+    echo "# Installing EDITABLE (in place). Keep ${ANUGA_CORE_PATH}/build/cp* -"
+    echo "# removing it breaks 'import anuga'. Use EDITABLE=0 for a standalone copy."
+else
+    PIP_TARGET_ARGS="."
+    echo "# Installing a COPY into site-packages (EDITABLE=0)."
+fi
+echo " "
+
 $CONDA_RUN bash -c \
-    "CC='$NVC' pip install --no-build-isolation -v -e . \
+    "CC='$NVC' pip install --no-build-isolation -v ${PIP_TARGET_ARGS} \
      -Csetup-args=-Dgpu_offload=true \
      -Csetup-args=-Dgpu_arch=${GPU_ARCH}"
 
 echo " "
 # ---------------------------------------------------------------------------
-# Sanity check: does the built extension actually contain code for THIS GPU?
+# Report what was built, and stop if it cannot run on this machine.
 #
-# A mismatch here is the difference between "it works" and every GPU test
-# reporting CRASH: the build succeeds either way, and the kernels only fail
-# when they are launched.  Diagnose it up front rather than leaving the user
-# to interpret a wall of crashes.
+# A build that targets only architectures NEWER than the GPU present compiles
+# cleanly and then fails at every kernel launch -- which surfaces as a wall of
+# CRASH from the tests below, with nothing explaining why.  (The reverse is
+# fine: nvc embeds PTX, which the driver JIT-compiles forward, so a build for an
+# older architecture runs on a newer GPU.)
 # ---------------------------------------------------------------------------
-GPU_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
-if [[ "$GPU_CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
-    WANT_SM="sm_${GPU_CAP//./}"
-    GPU_EXT=$($CONDA_RUN python -c \
-        "import anuga.shallow_water.sw_domain_gpu_ext as m; print(m.__file__)" 2>/dev/null | tail -1)
-    CUOBJDUMP=$(command -v cuobjdump || ls "${NVHPC_ROOT}"/cuda/bin/cuobjdump 2>/dev/null | head -1)
-    if [[ -n "$GPU_EXT" && -n "$CUOBJDUMP" && -f "$GPU_EXT" ]]; then
-        BUILT_SM=$("$CUOBJDUMP" --list-elf "$GPU_EXT" 2>/dev/null \
-                   | grep -oE 'sm_[0-9]+' | sort -uV | tr '\n' ' ')
-        echo "# GPU in this machine : ${WANT_SM} (compute capability ${GPU_CAP})"
-        echo "# Built for           : ${BUILT_SM:-<none found>}"
-        if [[ -n "$BUILT_SM" && " $BUILT_SM " != *" $WANT_SM "* ]]; then
-            echo ""
-            echo "#=================================================================="
-            echo "# WARNING: this build does NOT include ${WANT_SM}, the GPU in this"
-            echo "# machine.  It compiled cleanly, but every GPU kernel launch will"
-            echo "# fail and the tests below will report CRASH."
-            echo "#"
-            echo "# Rebuild for this GPU:"
-            echo "#     GPU_ARCH=cc${GPU_CAP//./} bash ${SCRIPT}"
-            echo "#=================================================================="
-            echo ""
-        fi
-    fi
+echo "#============================================================"
+echo "# Build report"
+echo "#============================================================"
+if ! $CONDA_RUN python "${ANUGA_CORE_PATH}/tools/anuga_build_report.py" --check; then
+    echo ""
+    echo "#====================================================="
+    echo "# Stopping before the tests: the build above cannot run"
+    echo "# on this machine, so every GPU test would report CRASH."
+    echo "#====================================================="
+    exit 1
 fi
+echo " "
 
 echo "#============================================================"
 echo "# Running GPU test suite (isolated runner)"
@@ -290,8 +301,12 @@ echo "#   'pip install -e .' does not place on PATH)."
 echo "#============================================================"
 echo " "
 
-$CONDA_RUN \
-    python "${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"
+if [ "${SKIP_TESTS:-0}" = "1" ]; then
+    echo "SKIP_TESTS=1 - skipping the GPU test suite."
+else
+    $CONDA_RUN \
+        python "${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"
+fi
 
 echo " "
 echo "#=================================================================="

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -38,27 +38,10 @@
 # looks for an environment the other never created.
 PY=${PY:-"3.12"}
 
-# Detect this machine's GPU rather than assuming one.  nvidia-smi reports the
-# compute capability as e.g. "8.6", which becomes cc86.
-#
-# This used to be hardcoded to cc120 (the author's laptop) and nobody noticed,
-# because -Dgpu_arch was not reaching nvc's device link: nvc fell back to the
-# GPU it found on the build machine, so any value happened to work.  Once that
-# was fixed the hardcoded default started producing sm_120-only builds that
-# crash on every other card.
-detect_gpu_arch() {
-    local cap
-    cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
-          | head -1 | tr -d ' ')
-    if [[ "$cap" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        echo "cc${cap//./}"
-    else
-        # No usable nvidia-smi (headless build node, driver not loaded, ...):
-        # build for every architecture ANUGA supports rather than guess one.
-        echo "cc70,cc75,cc80,cc86,cc89,cc90,cc120"
-    fi
-}
-GPU_ARCH=${GPU_ARCH:-"$(detect_gpu_arch)"}
+# GPU_ARCH is resolved AFTER nvc is located (see below): choosing it needs to
+# know which CUDA toolkits this HPC SDK actually ships, not just which GPU is
+# present.  "auto" means "work it out".
+GPU_ARCH=${GPU_ARCH:-auto}
 
 set -e
 
@@ -116,6 +99,78 @@ fi
 
 echo "# nvc found: $NVC"
 "$NVC" --version
+echo " "
+
+# ------------------------------------------------------------------
+# Resolve GPU_ARCH=auto, then PROVE the choice compiles before spending
+# several minutes on the real build.
+#
+# Two things constrain the answer, and neither is guessable:
+#   * which GPU is present (nvidia-smi) -- absent on a login node;
+#   * which CUDA toolkits this SDK ships.  cc70 (V100) needs CUDA <= 12.x;
+#     an SDK carrying only CUDA 13 rejects it outright ("A CUDA toolkit
+#     matching the current driver version ... was not installed"), because
+#     CUDA 13's libnvvm dropped Volta.
+# ------------------------------------------------------------------
+NVHPC_DIR=$(dirname "$(dirname "$NVC")")          # .../<version>
+CUDA12=$(ls -d "${NVHPC_DIR}"/cuda/12.* 2>/dev/null | sort -V | tail -1)
+
+arch_compiles() {
+    # Tiny OpenMP-target probe; ~2s. Returns 0 if nvc accepts this -gpu= string.
+    local arch="$1" tmp
+    tmp=$(mktemp -d)
+    printf '#include <stdio.h>\nint main(void){double a[10];\n#pragma omp target teams distribute parallel for map(tofrom:a[0:10])\nfor(int i=0;i<10;i++)a[i]=i;\nprintf("%%f\\n",a[9]);return 0;}\n' > "$tmp/probe.c"
+    "$NVC" -mp=gpu -gpu="$arch" -c "$tmp/probe.c" -o "$tmp/probe.o" >"$tmp/log" 2>&1
+    local rc=$?
+    [ $rc -ne 0 ] && PROBE_ERR=$(head -1 "$tmp/log")
+    rm -rf "$tmp"
+    return $rc
+}
+
+if [ "$GPU_ARCH" = "auto" ]; then
+    CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
+    if [[ "$CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        GPU_ARCH="cc${CAP//./}"
+        echo "# GPU_ARCH=auto -> ${GPU_ARCH} (detected: compute capability ${CAP})"
+    else
+        # No GPU visible (login node, driver not loaded).  Build for everything
+        # this SDK can target, so the result runs on the compute nodes.
+        if [ -n "$CUDA12" ]; then
+            GPU_ARCH="cuda$(basename "$CUDA12"),cc70,cc75,cc80,cc86,cc89,cc90,cc120"
+            echo "# GPU_ARCH=auto -> multi-architecture (no GPU visible here)."
+            echo "#   This SDK ships CUDA $(basename "$CUDA12"), so cc70/V100 is included."
+        else
+            GPU_ARCH="cc75,cc80,cc86,cc89,cc90,cc120"
+            echo "# GPU_ARCH=auto -> multi-architecture (no GPU visible here)."
+            echo "#   This SDK ships no CUDA 12.x, so cc70/V100 CANNOT be built:"
+            echo "#   CUDA 13 dropped Volta. Load an SDK with CUDA 12.x if you"
+            echo "#   need V100 support."
+        fi
+    fi
+fi
+
+echo "# Checking that nvc accepts -gpu=${GPU_ARCH} ..."
+if ! arch_compiles "$GPU_ARCH"; then
+    echo "#   rejected: ${PROBE_ERR}"
+    # Much the most common cause is cc70 on a CUDA-13-only SDK. Retry without it
+    # rather than failing a build that would otherwise be fine.
+    GPU_ARCH_NO70=$(echo "$GPU_ARCH" | sed 's/cuda12\.[0-9]*,//; s/cc70,//; s/,cc70//')
+    if [ "$GPU_ARCH_NO70" != "$GPU_ARCH" ] && arch_compiles "$GPU_ARCH_NO70"; then
+        echo "#   retrying without cc70 (V100): ${GPU_ARCH_NO70}"
+        echo "#   NOTE: the result will NOT run on a V100."
+        GPU_ARCH="$GPU_ARCH_NO70"
+    else
+        echo "#====================================================="
+        echo "# ERROR: nvc cannot build for -gpu=${GPU_ARCH}"
+        echo "#        ${PROBE_ERR}"
+        echo "#"
+        echo "# Pick architectures this SDK supports, e.g."
+        echo "#     GPU_ARCH=cc80,cc90 bash ${SCRIPT}"
+        echo "#====================================================="
+        exit 1
+    fi
+fi
+echo "#   ok - building for ${GPU_ARCH}"
 echo " "
 
 # ------------------------------------------------------------------

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -22,6 +22,10 @@
 #               architectures asked for, so a mismatched value produces a
 #               package that compiles fine and then crashes on every kernel
 #               launch.
+#   SKIP_TESTS  1 = do not run the GPU test suite at all.
+#   FORCE_TESTS 1 = run it even when no GPU is visible (default: skip, so an
+#               HPC login node does not spend a long time on tests that
+#               cannot pass).
 #   NVHPC_ROOT  Override path to NVIDIA HPC SDK root if auto-detection fails.
 #               e.g. /opt/nvidia/hpc_sdk/Linux_x86_64/26.3
 #
@@ -421,8 +425,36 @@ echo "#   'pip install -e .' does not place on PATH)."
 echo "#============================================================"
 echo " "
 
+# Do not run the GPU tests where there is no GPU.  The usual case is an HPC
+# login node: every test would fail or skip after a long wait, and running a
+# heavy suite there is antisocial (many sites forbid it outright).  The build is
+# still complete and usable -- the tests just have to happen where the GPUs are.
+HAVE_GPU=0
+if nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1 && \
+   [ -n "$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)" ]; then
+    HAVE_GPU=1
+fi
+
 if [ "${SKIP_TESTS:-0}" = "1" ]; then
     echo "SKIP_TESTS=1 - skipping the GPU test suite."
+elif [ "$HAVE_GPU" = "0" ] && [ "${FORCE_TESTS:-0}" != "1" ]; then
+    echo "#=================================================================="
+    echo "# Skipping the GPU test suite: no GPU is visible here."
+    echo "#"
+    echo "# The build itself is complete. These tests need a GPU, and this"
+    echo "# looks like a login node - running them here would take a long"
+    echo "# time, fail anyway, and load a shared machine."
+    echo "#"
+    echo "# Run them where the GPUs are, in a job or interactive session:"
+    echo "#"
+    echo "#   python ${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"
+    echo "#"
+    echo "# and check the build suits that node's GPU with:"
+    echo "#"
+    echo "#   python ${ANUGA_CORE_PATH}/tools/anuga_build_report.py --check"
+    echo "#"
+    echo "# FORCE_TESTS=1 runs them here regardless."
+    echo "#=================================================================="
 else
     $CONDA_RUN \
         python "${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -22,6 +22,14 @@
 #               architectures asked for, so a mismatched value produces a
 #               package that compiles fine and then crashes on every kernel
 #               launch.
+#   GPU_AWARE_MPI  1 = build with -Dgpu_aware_mpi=true (default 0).
+#               Halo buffers are then allocated with omp_target_alloc and staged
+#               with omp_target_memcpy, instead of mapped host buffers moved
+#               with 'target update'.  NOTE this does NOT pass device pointers
+#               to MPI: anuga/shallow_water/gpu/gpu_halo.c stages every halo
+#               through host memory in both paths, because some UCX transports
+#               (uct_mm intra-node shared memory) SIGSEGV on device pointers.
+#               So it needs no CUDA-aware MPI, and gives no GPUDirect.
 #   SKIP_TESTS  1 = do not run the GPU test suite at all.
 #   FORCE_TESTS 1 = run it even when no GPU is visible (default: skip, so an
 #               HPC login node does not spend a long time on tests that
@@ -351,7 +359,7 @@ echo " "
 echo "#============================================================"
 echo "# Building ANUGA with GPU offloading"
 echo "#   CC=$NVC"
-echo "#   gpu_offload=true  gpu_arch=${GPU_ARCH}"
+echo "#   gpu_offload=true  gpu_arch=${GPU_ARCH}  gpu_aware_mpi=${GPU_AWARE_MPI:-0}"
 echo "#============================================================"
 echo " "
 
@@ -384,10 +392,26 @@ else
 fi
 echo " "
 
+GPU_AWARE_MPI_ARG=""
+if [ "${GPU_AWARE_MPI:-0}" = "1" ]; then
+    GPU_AWARE_MPI_ARG="-Csetup-args=-Dgpu_aware_mpi=true"
+    echo "# GPU_AWARE_MPI=1: building with -Dgpu_aware_mpi=true"
+    echo "#   (device-allocated halo buffers; MPI itself still receives host"
+    echo "#    pointers - see gpu_halo.c. No CUDA-aware MPI is required.)"
+    if ! $CONDA_RUN python -c "import mpi4py" >/dev/null 2>&1; then
+        echo "#   WARNING: mpi4py is not installed in this environment, so the"
+        echo "#            extension will be built against the single-process"
+        echo "#            stubs and this flag will have no effect. Install"
+        echo "#            mpi4py (and pymetis) first if you want parallel runs."
+    fi
+    echo " "
+fi
+
 $CONDA_RUN bash -c \
     "CC='$NVC' pip install --no-build-isolation -v ${PIP_TARGET_ARGS} \
      -Csetup-args=-Dgpu_offload=true \
-     -Csetup-args=-Dgpu_arch=${GPU_ARCH}"
+     -Csetup-args=-Dgpu_arch=${GPU_ARCH} \
+     ${GPU_AWARE_MPI_ARG}"
 
 echo " "
 # ---------------------------------------------------------------------------

--- a/tools/install_miniforge.sh
+++ b/tools/install_miniforge.sh
@@ -22,7 +22,14 @@
 
 PY=${PY:-"3.12"}
 
-set -e 
+set -e
+
+# Keep a transcript.  An install that goes wrong is usually reported second-hand
+# ("it failed"), and this is the file to ask for.
+LOGFILE=${LOGFILE:-"$HOME/anuga_install_$(date +%Y%m%d_%H%M%S).log"}
+exec > >(tee -a "$LOGFILE") 2>&1
+echo "# Logging this installation to: $LOGFILE"
+
 
 trap 'echo ""; echo "#====================================================="; echo "# Installation failed at line $LINENO"; echo "#====================================================="; exit 1' ERR
 
@@ -66,7 +73,21 @@ echo "#==============================================="
 echo "# create conda environment anuga_env_${PY}"
 echo "#==============================================="
 echo "..."
-./miniforge3/bin/conda env create --file ${SCRIPTPATH}/../environments/environment_${PY}.yml
+ENV_YML="${SCRIPTPATH}/../environments/environment_${PY}.yml"
+if [ ! -f "$ENV_YML" ]; then
+     echo "ERROR: no environment file for Python ${PY}: $ENV_YML"
+     echo "Available: $(ls ${SCRIPTPATH}/../environments/environment_3.*.yml \
+                        | grep -v intel | sed 's#.*environment_##;s#\.yml##' | tr '\n' ' ')"
+     exit 1
+fi
+# Re-running the script must not fail on an environment that already exists:
+# `conda env create` errors out in that case, so update it in place instead.
+if ./miniforge3/bin/conda env list | grep -qE "^anuga_env_${PY}\s"; then
+     echo "Environment anuga_env_${PY} already exists - updating it in place."
+     ./miniforge3/bin/conda env update --name anuga_env_${PY} --file "$ENV_YML" --prune
+else
+     ./miniforge3/bin/conda env create --file "$ENV_YML"
+fi
 
 echo " "
 echo "#======================================"
@@ -83,17 +104,38 @@ echo "..."
 
 cd ${SCRIPTPATH}
 cd ..
-pip install --no-build-isolation .
+# Non-editable (a copy into site-packages) on purpose: it keeps working no
+# matter what happens to this source tree or its build/ directory.  Developers
+# who want to edit the sources in place can pass EDITABLE=1, but then the
+# build/cp<ver> directory must be kept -- deleting it breaks `import anuga`.
+if [ "${EDITABLE:-0}" = "1" ]; then
+     echo "# EDITABLE=1: installing in place (keep the build/cp* directory!)"
+     pip install --no-build-isolation -e .
+else
+     pip install --no-build-isolation .
+fi
+echo " "
+
+echo "#==========================="
+echo "# Build report"
+echo "#==========================="
+python "${ANUGA_CORE_PATH}/tools/anuga_build_report.py" || true
 echo " "
 
 echo "#==========================="
 echo "# Run unittests"
 echo "#==========================="
+echo "#   Set SKIP_TESTS=1 to skip, or FAST_TESTS=1 for the quick subset."
 echo " "
 
 cd sandpit
-#pytest -q --disable-warnings --pyargs anuga
-pytest --pyargs anuga
+if [ "${SKIP_TESTS:-0}" = "1" ]; then
+     echo "SKIP_TESTS=1 - skipping the test suite."
+elif [ "${FAST_TESTS:-0}" = "1" ]; then
+     pytest --pyargs anuga --run-fast
+else
+     pytest --pyargs anuga
+fi
 
 echo " "
 echo "#=================================================================="

--- a/tools/install_miniforge.sh
+++ b/tools/install_miniforge.sh
@@ -18,6 +18,19 @@
 # PY=3.9 bash /path/to/anuga_core/tools/install_miniforge.sh
 #
 # Then the script will install python 3.9 and create the anuga_env_3.9 environment.
+#
+# This builds the CPU (gcc) package, which is the right one for CPU and MPI
+# runs. A GPU build is a SEPARATE build with different trade-offs: it offloads
+# to the GPU, but its CPU fallback is single-threaded and much slower than this
+# one (see docs/source/appendices/install_gpu.rst). The script therefore does
+# NOT switch compilers just because a GPU is present -- it tells you the GPU
+# path exists and leaves the choice to you.
+#
+# To do both in one go, add GPU=1:
+#
+#   GPU=1 bash /path/to/anuga_core/tools/install_miniforge.sh
+#
+# which runs the CPU install, then chains into tools/install_anuga_nvc.sh.
 
 
 PY=${PY:-"3.12"}
@@ -149,6 +162,72 @@ echo "# "
 echo "# source ~/miniforge3/bin/activate anuga_env_${PY}"
 echo "# "
 echo "#=================================================================="
+
+# ---------------------------------------------------------------------------
+# GPU: report what is possible on this machine, and act only if asked.
+#
+# Deliberately NOT automatic. A gpu_offload=true (nvc) build is not a superset
+# of this one: NVHPC's host fallback does not scale with threads, so a GPU
+# build used on the CPU is several times slower than this gcc build (measured;
+# see claude/KNOWN_ISSUES.md). Choosing the compiler from the hardware would
+# silently downgrade anyone whose work is CPU or MPI bound, and would also
+# break the test step above, which must be run per-process on a GPU build.
+# ---------------------------------------------------------------------------
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)
+GPU_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
+NVC_PATH=$(command -v nvc 2>/dev/null)
+if [ -z "$NVC_PATH" ]; then
+     NVC_PATH=$(ls -d /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers/bin/nvc 2>/dev/null | sort -V | tail -1)
+fi
+
+if [ -n "$GPU_NAME" ]; then
+     echo " "
+     echo "#=================================================================="
+     echo "# A CUDA GPU was detected:"
+     echo "#     ${GPU_NAME} (compute capability ${GPU_CAP:-unknown} -> cc${GPU_CAP//./})"
+     echo "#"
+     echo "# What you have just installed is the CPU (gcc) build. Keep it for"
+     echo "# CPU and MPI runs: it is several times faster on the host than a"
+     echo "# GPU build is, because NVHPC's host fallback is single-threaded."
+     if [ -n "$NVC_PATH" ]; then
+          echo "#"
+          echo "# nvc is installed (${NVC_PATH}), so you can also build for the GPU:"
+          echo "#"
+          echo "#     bash ${SCRIPTPATH}/install_anuga_nvc.sh"
+          echo "#"
+          echo "# It detects cc${GPU_CAP//./} automatically. Note it REPLACES this"
+          echo "# build in this environment - the two cannot coexist in one env."
+     else
+          echo "#"
+          echo "# For GPU offload you would also need the NVIDIA HPC SDK (nvc),"
+          echo "# which is not installed. See docs/source/appendices/install_gpu.rst."
+     fi
+     echo "#=================================================================="
+fi
+
+if [ "${GPU:-0}" = "1" ]; then
+     echo " "
+     echo "#=================================================================="
+     echo "# GPU=1 - continuing with the GPU (nvc) build"
+     echo "#=================================================================="
+     if [ -z "$NVC_PATH" ]; then
+          echo "#====================================================="
+          echo "# ERROR: GPU=1 was requested but nvc was not found."
+          echo "#        Install the NVIDIA HPC SDK first, or drop GPU=1."
+          echo "#        See docs/source/appendices/install_gpu.rst"
+          echo "#====================================================="
+          exit 1
+     fi
+     if [ -z "$GPU_NAME" ]; then
+          echo "# NOTE: no GPU detected by nvidia-smi. Building anyway (GPU=1);"
+          echo "#       install_anuga_nvc.sh will build for every supported"
+          echo "#       architecture when it cannot see a GPU."
+     fi
+     # PY targets the environment just created (though the GPU script will
+     # prefer the one this script activated, which is the same one).  LOGFILE is
+     # shared so a GPU=1 run leaves a single transcript rather than two.
+     PY="${PY}" LOGFILE="${LOGFILE}" bash "${SCRIPTPATH}/install_anuga_nvc.sh"
+fi
 
 echo "#=================================================================="
 echo "# NOTE: If you run the command"


### PR DESCRIPTION
Follow-up to #221. That PR fixed the immediate regression (a hardcoded `GPU_ARCH` producing builds that crash on every other card); this one makes the installers hard to get wrong in the first place.

The thread running through all of it: **a GPU build that targets the wrong architecture compiles cleanly and only fails at kernel launch**, so nothing between "install succeeded" and "every test reports CRASH" tells the user what happened.

## Say what was built

New `tools/anuga_build_report.py`, run at the end of both scripts and useful standalone for bug reports:

```
#   anuga:                 3.3.10.dev947+gb99c5c46
#   install type:          editable (needs its build/cp* directory kept)
#   python:                3.14.5  (anuga_env_3.14)
#   GPU offload build:     yes
#   MPI in GPU ext:        yes
#   built for:             sm_120
#   GPU present:           NVIDIA GeForce RTX 5070 Laptop GPU (compute capability 12.0 -> sm_120)
```

`--check` exits non-zero when the build cannot run on this machine, and the GPU script stops there rather than running tests that would all crash. Both scripts also `tee` a transcript to a log file — the artefact to ask for when someone reports a failed install.

**Compatibility is one-directional**, which the earlier check in #221 got wrong: nvc embeds PTX and the driver JIT-compiles it *forward*, so a cc86 build runs fine on an sm_120 GPU (verified). Only "build newer than the GPU" is fatal. Measured cost of relying on JIT: +0.38 s at first kernel launch, no throughput difference — which matters mainly for the isolated test runner, containers, and MPI ranks, where the JIT cache is cold.

## Ask the toolchain what it can build

`GPU_ARCH=auto` (the new default) resolves from `nvidia-smi` when a GPU is visible. With no GPU — an HPC login node — it **probes** rather than assumes, because neither the GPU nor the available CUDA toolkits can be read off the filesystem when `nvc` is a module wrapper:

```
#   trying cc70,cc75,cc80,cc86,cc89,cc90,cc120 ... no
#   trying cuda12.9,cc70,cc75,...              ... no
#   trying cc75,cc80,cc86,cc89,cc90,cc120      ... ok
#   NOTE: cc70/V100 could not be built with this SDK (CUDA 13 dropped Volta)
```

`cc70`/V100 needs a CUDA <= 12.x toolkit and an SDK shipping only CUDA 13 rejects it; where an SDK ships both, the CUDA 13 default must be overridden explicitly, hence the `cuda12.x` candidates. Each probe is a ~2 s OpenMP-target compile, so a bad `-gpu=` string (or a typo like `sm_86`) is caught in seconds rather than minutes into the real build.

An **explicitly requested** architecture is never silently narrowed: `GPU_ARCH=cc70,cc80,cc90` on an SDK that cannot build cc70 stops with the compiler's error and the exact command to proceed without it. Dropping it quietly would hand back a build that crashes on the GPU it was asked to target.

`nvc` is now also found on `PATH` (an HPC module often provides a wrapper such as `/apps/nvidia-hpc-sdk/wrappers/nvc`), and the not-found error suggests `module load nvhpc` rather than only `apt-get`.

## Editable vs copied, made deliberate

`install_miniforge.sh` installs a copy into site-packages; `install_anuga_nvc.sh` stays editable, as it is mostly run on a development checkout. Both now accept `EDITABLE=0|1`, and the GPU script states that an editable install depends on `build/cp<ver>` — remove that directory and `import anuga` fails with a `FileNotFoundError` naming a missing build path, which does not read as "reinstall".

## Re-runnable, and honest about GPUs

- `conda env create` failed outright if the environment existed, so a second run died partway; it now updates in place, and checks the `environment_<PY>.yml` for the requested version exists before starting.
- Both scripts defaulted to **different** Python versions (3.12 vs 3.14), so following the documented "run one, then the other" flow failed to find the environment the first script created. Both are now 3.12.
- `install_miniforge.sh` detects a GPU and *says so*, pointing at `install_anuga_nvc.sh`, but deliberately does **not** switch compilers: an nvc build's host fallback does not scale with threads (KNOWN_ISSUES microbenchmark, 8 threads: 4.48 s vs 0.76 s for gcc; towradgi small: 60–100 s vs ~17 s), so inferring the compiler from the hardware would silently downgrade anyone doing CPU or MPI work — and would break the test step, which must run per-process on a GPU build. `GPU=1` opts in explicitly and chains the two, sharing `PY` and the log file.
- Both gain `SKIP_TESTS=1`; `install_miniforge.sh` gains `FAST_TESTS=1`.

## Testing

Fast suite 2716 passed / 219 skipped; ruff clean; both scripts pass `bash -n`. The report was verified in both directions by actually building for cc86 and cc120 on a cc120 machine, and every new branch was exercised: GPU present / absent, nvc present / absent, `GPU=1` without nvc (exits 1), explicit vs auto architecture handling, and the environment-exists path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)