### PR TITLE
animate: live derived quantities in Domain_plotter, correct absolute triangulation in SWW_plotter

### DIFF
--- a/anuga/utilities/animate.py
+++ b/anuga/utilities/animate.py
@@ -216,22 +216,44 @@ class Domain_plotter:
 
         self.friction = domain.quantities['friction'].centroid_values
 
-        self.depth = self.stage - self.elev
-
-        with np.errstate(invalid='ignore'):
-            self.xvel = np.where(self.depth > self.min_depth,
-                             self.xmom / self.depth, 0.0)
-            self.yvel = np.where(self.depth > self.min_depth,
-                             self.ymom / self.depth, 0.0)
-
-        self.speed = np.sqrt(self.xvel**2 + self.yvel**2)
-
-        self.speed_depth = self.speed*self.depth
-
         self.domain = domain
         self._depth_frame_count = 0
         self._stage_frame_count = 0
         self._speed_frame_count = 0
+
+    # ------------------------------------------------------------------
+    # Derived quantities.
+    #
+    # self.stage/elev/xmom/ymom are references into the domain's centroid
+    # arrays, so they follow the evolution.  These are computed on access so
+    # they follow it too -- caching them in __init__ froze them at t = 0, and
+    # anything sampling e.g. plotter.speed inside an evolve loop silently
+    # recorded the initial value at every yieldstep.
+    # ------------------------------------------------------------------
+
+    @property
+    def depth(self):
+        return self.stage - self.elev
+
+    @property
+    def xvel(self):
+        depth = self.depth
+        with np.errstate(invalid='ignore'):
+            return np.where(depth > self.min_depth, self.xmom / depth, 0.0)
+
+    @property
+    def yvel(self):
+        depth = self.depth
+        with np.errstate(invalid='ignore'):
+            return np.where(depth > self.min_depth, self.ymom / depth, 0.0)
+
+    @property
+    def speed(self):
+        return np.sqrt(self.xvel**2 + self.yvel**2)
+
+    @property
+    def speed_depth(self):
+        return self.speed * self.depth
 
 
     #------------------------------------------
@@ -261,8 +283,6 @@ class Domain_plotter:
 
         name = os.path.basename(self.domain.get_name())
         time = self.domain.get_time()
-
-        self.depth[:] = self.stage - self.elev
 
         md = self.min_depth
 
@@ -376,8 +396,6 @@ class Domain_plotter:
 
         name = os.path.basename(self.domain.get_name())
         time = self.domain.get_time()
-
-        self.depth[:] = self.stage - self.elev
 
         md = self.min_depth
 
@@ -495,16 +513,6 @@ class Domain_plotter:
         time = self.domain.get_time()
 
         md = self.min_depth
-
-        self.depth[:] = self.stage - self.elev
-
-        with np.errstate(invalid='ignore'):
-            self.xvel = np.where(self.depth > self.min_depth,
-                             self.xmom / self.depth, 0.0)
-            self.yvel = np.where(self.depth > self.min_depth,
-                             self.ymom / self.depth, 0.0)
-
-        self.speed = np.sqrt(self.xvel**2 + self.yvel**2)
 
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
 
@@ -777,8 +785,6 @@ class SWW_plotter:
         vols1 = self.triangles[:, 1]
         vols2 = self.triangles[:, 2]
 
-        self.triang = tri.Triangulation(self.x, self.y, self.triangles)
-
         self.xc = (self.x[vols0]+self.x[vols1]+self.x[vols2])/3.0
         self.yc = (self.y[vols0]+self.y[vols1]+self.y[vols2])/3.0
 
@@ -799,6 +805,11 @@ class SWW_plotter:
 
             self.xc[:] = self.xc + self.xllcorner
             self.yc[:] = self.yc + self.yllcorner
+
+        # Built after the absolute shift above: Triangulation copies the
+        # coordinate arrays it is given, so constructing it first would leave
+        # self.triang in relative coordinates while self.x/self.xc are absolute.
+        self.triang = tri.Triangulation(self.x, self.y, self.triangles)
 
         # Absolute-coordinate triangulation used when drawing a basemap
         if self.epsg is not None and not absolute:

--- a/anuga/utilities/tests/test_animate.py
+++ b/anuga/utilities/tests/test_animate.py
@@ -306,6 +306,15 @@ class TestSWWPlotter(unittest.TestCase):
         np.testing.assert_allclose(sp_abs.x, sp_rel.x + sp_rel.xllcorner, atol=1.0)
         np.testing.assert_allclose(sp_abs.y, sp_rel.y + sp_rel.yllcorner, atol=1.0)
 
+    def test_init_absolute_mode_triangulation_is_absolute(self):
+        # Regression: triang was built before the absolute shift, and
+        # Triangulation copies its coordinate arrays, so triang.x stayed
+        # relative while x/xc were absolute -- anything plotted against
+        # absolute axes landed off the map.
+        sp = self._make(absolute=True)
+        np.testing.assert_allclose(sp.triang.x, sp.x)
+        np.testing.assert_allclose(sp.triang.y, sp.y)
+
     def test_name_attribute(self):
         sp = self._make()
         self.assertEqual(sp.name, 'test')
@@ -633,6 +642,25 @@ class TestDomainPlotter(unittest.TestCase):
         self.assertEqual(dp._depth_frame_count, 0)
         self.assertEqual(dp._stage_frame_count, 0)
         self.assertEqual(dp._speed_frame_count, 0)
+
+    def test_derived_quantities_track_domain(self):
+        # Regression: depth/xvel/yvel/speed/speed_depth were cached in
+        # __init__, so sampling them inside an evolve loop returned the t = 0
+        # values for the whole run.
+        domain = _make_mock_domain(self.tmpdir)
+        dp = Domain_plotter(domain, plot_dir=self.plot_dir)
+
+        np.testing.assert_allclose(dp.depth, [1.5, 0.8])
+
+        # Advance the domain the way evolve() does: in place, on the centroids.
+        domain.quantities['stage'].centroid_values[:] = [2.5, 1.3]
+        domain.quantities['xmomentum'].centroid_values[:] = [7.0, 0.0]
+        domain.quantities['ymomentum'].centroid_values[:] = [0.0, 0.0]
+
+        np.testing.assert_allclose(dp.depth, [3.5, 1.8])
+        np.testing.assert_allclose(dp.xvel[0], 2.0)
+        np.testing.assert_allclose(dp.speed[0], 2.0)
+        np.testing.assert_allclose(dp.speed_depth[0], 7.0)
 
     def test_init_absolute_mode(self):
         domain = _make_mock_domain(self.tmpdir)

--- a/claude/SESSION_GUIDE.md
+++ b/claude/SESSION_GUIDE.md
@@ -451,6 +451,67 @@ Findings:
 
 ## Recent session summaries (sessions 21–53)
 
+**Session 55 (2026-08-13):** A regression of our own making, the culvert crash,
+and hardening the installers so neither can happen quietly again.
+
+- **gpu culvert stack overflow (#217, PR merged via #218).** 101 culverts wedged
+  at `Time = 0` then segfaulted on a NaN-bit-pattern pointer.
+  `gpu_culverts_apply_all()` sized its per-step buffers as fixed stack arrays of
+  `MAX_CULVERTS` (64) but looped over `num_culverts`: 24240 bytes into 15360, on
+  every timestep. `MAX_CULVERTS` is only the *initial* capacity — registration
+  grows by doubling. Buffers moved to the heap. Regression test
+  `Test_GPU_ManyCulverts` (80 culverts) hangs on the old code, passes in 1.3 s.
+- **`-Dgpu_arch` never selected anything (PR #220).** nvc device-links at the
+  LINK step and `gpu_link_args` was empty, so it built for the build host's GPU,
+  or — with no GPU visible, as in a container — every arch the CUDA supports.
+  The "multi-arch" images were portable *by accident*. Fixed by repeating
+  `-gpu=<arch>` at link.
+- **…which then broke Petar's RTX 30xx (PR #221).** With the flag working,
+  `install_anuga_nvc.sh`'s hardcoded `GPU_ARCH=cc120` produced sm_120-only
+  builds that compile cleanly and crash at every kernel launch. Now detected
+  from `nvidia-smi`.
+- **Compatibility is ONE-DIRECTIONAL** (measured, not assumed): nvc embeds PTX
+  and the driver JIT-compiles it *forward*, so a cc86 build runs on sm_120;
+  a cc120 build can never run on sm_86. JIT costs +0.38 s at first launch, no
+  throughput difference — matters where the cache is cold (isolated runner,
+  containers, MPI ranks). `cc70`/V100 needs a CUDA ≤ 12.x in the SDK; CUDA 13
+  dropped Volta.
+- **Installers (PR #222, open).** New `tools/anuga_build_report.py` (also for bug
+  reports) prints version/install type/GPU build/MPI/SM archs/GPU present, and
+  `--check` fails a build that cannot run here. Both scripts log a transcript.
+  `GPU_ARCH=auto` probes what the toolchain can build rather than assuming (nvc
+  on Gadi is a module wrapper with no SDK layout beneath it). Explicit arch lists
+  are never silently narrowed. `install_miniforge.sh` is re-runnable, detects a
+  GPU and *advises* (does not switch compilers — the nvc host fallback is
+  several times slower than gcc), `GPU=1` opts in. GPU tests are skipped when no
+  GPU is visible (they were running on a Gadi login node).
+- **`anuga:gpu-mpi` image** (2.69 GB, in ECR): HPC-X OpenMPI 4.1.7a1, CUDA-aware,
+  mpi4py + pymetis, `-Dgpu_aware_mpi=true`. Four container gotchas solved and
+  documented: `OMPI_CC=gcc`, `OPAL_PREFIX`, `OMPI_MCA_ess_singleton_isolated=1`
+  (singleton `MPI_Init` hangs — bites *serial* runs, since `import anuga` pulls
+  in mpi4py), and container transports (`pml=ob1, btl=self,smcuda,tcp`).
+- **`.dockerignore` excludes `docker/Dockerfile*`** — they landed in the
+  `COPY . .` layer, so a one-line Dockerfile edit invalidated the ~45 min ANUGA
+  compile. Now 2.6 s with 14 layers cached.
+- **Issue #223 (open):** `-Dgpu_aware_mpi=true` is not GPU-aware — `gpu_halo.c`
+  stages every halo through host memory in *both* paths (UCX `uct_mm` SIGSEGVs
+  on device pointers). Measure halo cost before implementing real GPUDirect.
+
+**RESUME STATE (as of 2026-08-13):**
+- `develop` = `stoiver/develop`, **8 commits ahead of origin/develop**, all in
+  **PR #222** (installer hardening). CI was green on `5d53d602`; later commits
+  only touch shell scripts, which CI does not exercise.
+- Merged this session: #218, #220, #221. Closed: #219 (superseded — its fix rode
+  in with #218), issue #217.
+- **Open: PR #222, issue #223.**
+- ECR (ap-southeast-2, `067589750115`): `anuga:gpu-slim` 460 MB (cc70–cc120,
+  portable, AMD-verified on g6) and `anuga:gpu-mpi` 599 MB.
+- Uncommitted, deliberately: `towradgi.toml` arithmetic demo. Untracked:
+  `sandpit/culvert_issue/` (48 MB reporter model — do not commit).
+- Gadi: build works from a login node; the open question is whether that
+  `nvhpc` module can build `cc70` — run `tools/anuga_build_report.py --check`
+  on a `gpuvolta` node to find out.
+
 **Session 54 (2026-08-11):** Portable GPU image proven on AMD, C-level output
 captured in the logfile, and the first GPU scaling numbers at 1.6M triangles.
 - **`-tp=haswell` fix never actually built.** 394b61b8 set `CXXFLAGS=-tp=haswell`

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -26,6 +26,52 @@ ANUGA was created by Geoscience Australia and the Mathematical Sciences Institut
 at the Australian National University, and is now maintained by a community of
 volunteers.
 
+Key publications
+----------------
+
+Two papers describe the method ANUGA implements, and are the usual citations for
+the model itself. The first develops the finite-volume solution of the
+two-dimensional shallow water equations on unstructured triangular meshes that
+ANUGA is built on; the second describes its application to coastal inundation:
+
+* Zoppou, C. & Roberts, S. (1999). Catastrophic collapse of water supply
+  reservoirs in urban areas. *Journal of Hydraulic Engineering*, 125(7),
+  686–695. https://doi.org/10.1061/(ASCE)0733-9429(1999)125:7(686)
+
+* Nielsen, O., Roberts, S., Gray, D., McPherson, A. & Hitchman, A. (2005).
+  Hydrodynamic modelling of coastal inundation. In A. Zerger & R. M. Argent
+  (Eds.), *MODSIM 2005 International Congress on Modelling and Simulation*
+  (pp. 518–523). Modelling and Simulation Society of Australia and New Zealand.
+  https://www.mssanz.org.au/modsim05/papers/nielsen.pdf
+
+.. code-block:: bibtex
+
+   @article{zoppou1999catastrophic,
+     author  = {Zoppou, Christopher and Roberts, Stephen},
+     title   = {Catastrophic Collapse of Water Supply Reservoirs in Urban Areas},
+     journal = {Journal of Hydraulic Engineering},
+     volume  = {125},
+     number  = {7},
+     pages   = {686--695},
+     year    = {1999},
+     doi     = {10.1061/(ASCE)0733-9429(1999)125:7(686)}
+   }
+
+   @inproceedings{nielsen2005hydrodynamic,
+     author    = {Nielsen, Ole and Roberts, Stephen and Gray, Duncan and
+                  McPherson, Andrew and Hitchman, Adrian},
+     title     = {Hydrodynamic Modelling of Coastal Inundation},
+     booktitle = {MODSIM 2005 International Congress on Modelling and Simulation},
+     editor    = {Zerger, Andre and Argent, Robert M.},
+     pages     = {518--523},
+     year      = {2005},
+     publisher = {Modelling and Simulation Society of Australia and New Zealand},
+     url       = {https://www.mssanz.org.au/modsim05/papers/nielsen.pdf}
+   }
+
+Both are also cited from :doc:`mathematical_background`, where the numerical
+method is described.
+
 User manual
 -----------
 


### PR DESCRIPTION
Two bugs in `anuga/utilities/animate.py`, both found while plotting a Tohoku tsunami run.

## `Domain_plotter` derived quantities were frozen at t = 0

`depth`, `xvel`, `yvel`, `speed` and `speed_depth` were computed once in `__init__`. `stage`/`elev`/`xmom`/`ymom` are references into the domain's centroid arrays and so track the evolution, but the derived arrays did not. Sampling them inside an evolve loop returned the initial values at every yieldstep:

```python
dplotter = anuga.Domain_plotter(domain)
for t in domain.evolve(yieldstep=120, finaltime=7200):
    speed.append(dplotter.speed[tid])   # same number every time
```

`_depth_frame`/`_stage_frame`/`_speed_frame` recomputed in place before drawing, which is why saved frames and animations looked correct and the problem only showed up when sampling the attributes directly.

They are now properties computed on access, and the manual refreshes are gone.

## `SWW_plotter(absolute=True)` left `triang` in relative coordinates

`self.triang` was built before the `absolute=True` shift. `matplotlib.tri.Triangulation` copies the coordinate arrays it is given, so the later in-place `self.x[:] = self.x + self.xllcorner` never reached it. The result was `sp.x` absolute but `sp.triang.x` relative — an offset of the full `xllcorner`, so `ax.tripcolor(sp.triang, ...)` against UTM axes drew entirely off-screen and produced a blank figure with no error.

The triangulation is now built after the shift.

## Tests

Two regression tests added to `anuga/utilities/tests/test_animate.py`; both fail on the current `develop` and pass with the fix.

- `test_animate.py`: 61 passed
- `pytest --pyargs anuga --run-fast`: 2718 passed, 219 skipped

## Note on scope

This branch also carries 10 earlier commits already on `stoiver/develop` (installer hardening, session notes, docs). The animate fix is the last commit, `d417693d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)