### PR TITLE
gpu mode 2: riverwall crest changes reach the device (#224); degenerate-timestep protection gap made visible (#189)

### DIFF
--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -523,6 +523,10 @@ void gpu_domain_sync_all_from_device(struct gpu_domain *GD);  // Debug: sync ALL
 // Sync boundary values TO GPU (after CPU boundary evaluation)
 void gpu_sync_boundary_values(struct gpu_domain *GD);
 
+// Sync riverwall crest elevations / hydraulic properties TO GPU (after a
+// host-side RiverWall.set_elevation() and friends)
+void gpu_sync_riverwall_to_device(struct gpu_domain *GD);
+
 // Sync edge values FROM GPU (before CPU boundary evaluation)
 void gpu_sync_edge_values_from_device(struct gpu_domain *GD);
 

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -1278,6 +1278,32 @@ void gpu_sync_boundary_values(struct gpu_domain *GD) {
                                  bed_bv[0:nb], height_bv[0:nb])
 }
 
+void gpu_sync_riverwall_to_device(struct gpu_domain *GD) {
+    // Sync riverwall crest elevations and hydraulic properties TO GPU.
+    //
+    // These arrays are mapped once at setup and are never written on the device,
+    // so a host-side change — RiverWall.set_elevation() / set_elevation_offset()
+    // / set_hydraulic_parameter(), e.g. operating a gate mid-run — is invisible
+    // to the kernels until it is pushed back across. Cheap: sized by the number
+    // of riverwall edges, not by the mesh.
+    if (!GD->gpu_initialized) return;
+
+    anuga_int n_rw_edges = GD->D.number_of_riverwall_edges;
+    if (n_rw_edges <= 0) return;
+
+    double *riverwall_elevation = GD->D.riverwall_elevation;
+    if (riverwall_elevation != NULL) {
+        #pragma omp target update to(riverwall_elevation[0:n_rw_edges])
+    }
+
+    double *riverwall_hydraulic_properties = GD->D.riverwall_hydraulic_properties;
+    anuga_int ncol_hp = GD->D.ncol_riverwall_hydraulic_properties;
+    anuga_int nrow_hp = GD->D.nrow_riverwall_hydraulic_properties;
+    if (riverwall_hydraulic_properties != NULL && ncol_hp > 0 && nrow_hp > 0) {
+        #pragma omp target update to(riverwall_hydraulic_properties[0:nrow_hp*ncol_hp])
+    }
+}
+
 void gpu_sync_edge_values_from_device(struct gpu_domain *GD) {
     // Sync ALL edge values FROM GPU - expensive, use sparse version if possible
     if (!GD->gpu_initialized) return;

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -1473,6 +1473,35 @@ class Domain(Generic_Domain):
             self.gpu_interface.sync_to_device()
 
 
+    def _sync_riverwall_to_device(self) -> None:
+        """Push pending host-side riverwall changes out to the device (mode 2).
+
+        The riverwall crest elevations and hydraulic properties are mapped to the
+        device once, when the mode-2 interface is built, and are never written
+        there. A host-side change — RiverWall.set_elevation() to operate a gate,
+        say — therefore has no effect on the device until it is pushed across,
+        which is what this does.
+
+        Called by evolve() at yieldstep boundaries only: that is where a script
+        can make such a change (in the body of the evolve loop) and where the
+        host and device are already in step, so the crest never changes part-way
+        through a timestep or between RK substeps.
+        """
+
+        riverwall_data = getattr(self, 'riverwallData', None)
+        if riverwall_data is None:
+            return
+        if not getattr(riverwall_data, 'device_data_dirty', False):
+            return
+
+        if (self.multiprocessor_mode == MULTIPROCESSOR_GPU
+                and getattr(self, 'gpu_interface', None) is not None):
+            self.gpu_interface.sync_riverwall_to_device()
+
+        # Cleared unconditionally: on the CPU paths the kernels read the host
+        # arrays directly, and a later mode-2 setup maps their current values.
+        riverwall_data.device_data_dirty = False
+
     def set_timezone(self, tz: str | ZoneInfoType | None = None) -> None:
         """Set timezone for domain
 
@@ -3256,6 +3285,10 @@ class Domain(Generic_Domain):
             self._has_cpu_only_fractional_operators()
             self._warn_unsupported_mode2_forcing()
 
+        # Any riverwall change made before evolve() (or between two evolve()
+        # calls) reaches the device here, before the first step.
+        self._sync_riverwall_to_device()
+
         #nvtx marker
         nvtxRangePush('_evolve_base')
 
@@ -3300,6 +3333,11 @@ class Domain(Generic_Domain):
 
             # Pass control on to outer loop for more specific actions
             yield(t)
+
+            # The outer loop may have operated a riverwall (set_elevation() and
+            # friends). In mode 2 the device copy is stale until pushed; do it
+            # here so the change takes effect from the next timestep on.
+            self._sync_riverwall_to_device()
 
             self.yieldstep_counter += 1
 

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -185,6 +185,7 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_domain_sync_from_device(gpu_domain *GD)
     void gpu_domain_sync_all_from_device(gpu_domain *GD)
     void gpu_sync_boundary_values(gpu_domain *GD)
+    void gpu_sync_riverwall_to_device(gpu_domain *GD)
     void gpu_sync_edge_values_from_device(gpu_domain *GD)
     int gpu_boundary_edge_sync_init(gpu_domain *GD, int num_boundary_cells, int *boundary_cell_ids)
     void gpu_boundary_edge_sync_finalize(gpu_domain *GD)
@@ -1234,6 +1235,17 @@ def sync_boundary_values(GPUDomain gpu_dom):
     Call this after Python updates boundary conditions.
     """
     gpu_sync_boundary_values(&gpu_dom.GD)
+
+
+def sync_riverwall_to_device(GPUDomain gpu_dom):
+    """
+    Sync riverwall crest elevations and hydraulic properties from host to device.
+
+    Call this after Python changes a riverwall at runtime (RiverWall.set_elevation(),
+    set_elevation_offset(), set_hydraulic_parameter()). No-op when the domain has no
+    riverwalls.
+    """
+    gpu_sync_riverwall_to_device(&gpu_dom.GD)
 
 
 def sync_edge_values_from_device(GPUDomain gpu_dom):

--- a/anuga/shallow_water/sw_domain_gpu_omp.py
+++ b/anuga/shallow_water/sw_domain_gpu_omp.py
@@ -144,6 +144,11 @@ class GPU_OMP_interface:
         from anuga.shallow_water.sw_domain_gpu_ext import sync_boundary_values
         sync_boundary_values(self.gpu_dom)
 
+    def sync_riverwall_to_device(self):
+        """Sync riverwall elevations / hydraulic properties from host to device."""
+        from anuga.shallow_water.sw_domain_gpu_ext import sync_riverwall_to_device
+        sync_riverwall_to_device(self.gpu_dom)
+
     def sync_edge_values_from_device(self):
         """Sync edge values from device to host."""
         from anuga.shallow_water.sw_domain_gpu_ext import sync_edge_values_from_device

--- a/anuga/shallow_water/tests/test_DE_gpu_omp.py
+++ b/anuga/shallow_water/tests/test_DE_gpu_omp.py
@@ -3221,5 +3221,127 @@ class Test_GPU_ManyCulverts(unittest.TestCase):
                         % self.N_CULVERTS)
 
 
+class Test_GPU_RiverwallCrestUpdate(unittest.TestCase):
+    """A riverwall crest changed mid-run must reach the device (issue #224).
+
+    `domain.riverwallData.set_elevation()` writes only the host array. In mode 2
+    the riverwall arrays are mapped to the device once, when the interface is
+    built, and are never written there — so operating a gate part-way through a
+    run used to be silently dropped: the run completed normally and produced
+    plausible output computed with the ORIGINAL crest. The fix pushes the host
+    arrays across at yieldstep boundaries (Domain._sync_riverwall_to_device()).
+
+    NOTE ON WHAT THIS CATCHES WHERE. On a CPU build the `omp target` regions run
+    on the host and the "device" arrays ARE the host arrays, so the physics
+    comparison below cannot fail there — it is a real guard only on a GPU-offload
+    build. test_sync_is_issued_at_the_yieldstep is the white-box half that fails
+    everywhere if the push is dropped or moved off the yieldstep boundary.
+    """
+
+    WALL_X = 500.0
+    OPEN = -3.0      # crest below the ponded water: gate open
+    SHUT = 5.0       # crest above it: gate shut
+
+    def _build(self, mode):
+        domain = rectangular_cross_domain(40, 8, len1=1000.0, len2=200.0)
+        domain.set_name('rw_gate')
+        domain.set_datadir(tempfile.mkdtemp())
+        domain.store = False
+        domain.set_flow_algorithm('DE0')
+        domain.set_quantity('elevation', lambda x, y: -x / 100.0)
+        domain.set_quantity('friction', 0.03)
+        # Pond water upstream of the wall only.
+        domain.set_quantity(
+            'stage', lambda x, y: np.where(x < self.WALL_X, 0.0, -x / 100.0))
+        domain.riverwallData.create_riverwalls(
+            {'gate': [[self.WALL_X, 0.0, self.OPEN],
+                      [self.WALL_X, 200.0, self.OPEN]]}, verbose=False)
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+        domain.set_multiprocessor_mode(mode)
+        return domain
+
+    def _downstream_volume(self, domain):
+        centroids = domain.get_centroid_coordinates(absolute=True)
+        downstream = centroids[:, 0] > self.WALL_X
+        h = (domain.quantities['stage'].centroid_values
+             - domain.quantities['elevation'].centroid_values)
+        return float(np.sum(np.maximum(h[downstream], 0.0)
+                            * domain.areas[downstream]))
+
+    def _run(self, mode, shut_gate):
+        """Water ponded upstream drains over an open wall; optionally shut it."""
+        domain = self._build(mode)
+        shut_done = False
+        for t in domain.evolve(yieldstep=20.0, finaltime=200.0):
+            if shut_gate and not shut_done and t >= 100.0:
+                domain.riverwallData.set_elevation('gate', self.SHUT)
+                shut_done = True
+        return self._downstream_volume(domain)
+
+    def test_shut_gate_changes_the_answer(self):
+        """Shutting the gate must hold water back — in mode 2 as in mode 1."""
+        open_1, shut_1 = self._run(1, False), self._run(1, True)
+        open_2, shut_2 = self._run(2, False), self._run(2, True)
+
+        # Sanity: the gate has a large, unambiguous effect on the reference path.
+        self.assertLess(shut_1, 0.9 * open_1,
+                        'test setup is not sensitive to the crest change')
+
+        np.testing.assert_allclose(
+            shut_2, shut_1, rtol=1e-10,
+            err_msg='mode-2 ignored a mid-run riverwall crest change (the device '
+                    'kept the original crest elevations)')
+        np.testing.assert_allclose(open_2, open_1, rtol=1e-10)
+
+    def test_sync_is_issued_at_the_yieldstep(self):
+        """The push happens on resuming from the yield, and only when needed."""
+        domain = self._build(2)
+        domain._ensure_gpu_interface()
+        self.assertIsNotNone(domain.gpu_interface)
+
+        calls = []
+        real = domain.gpu_interface.sync_riverwall_to_device
+
+        def spy():
+            calls.append(domain.get_time())
+            real()
+
+        domain.gpu_interface.sync_riverwall_to_device = spy
+
+        for t in domain.evolve(yieldstep=20.0, finaltime=100.0):
+            if t >= 40.0 and not calls:
+                domain.riverwallData.set_elevation('gate', self.SHUT)
+                # Not pushed yet: the yield body runs before evolve() resumes.
+                self.assertEqual(calls, [])
+
+        self.assertEqual(len(calls), 1,
+                         'expected exactly one device push — one per change, at '
+                         'the yieldstep boundary, got %d' % len(calls))
+        # It fired on the yieldstep at which the change was made, not later.
+        self.assertAlmostEqual(calls[0], 40.0, places=6)
+        self.assertFalse(domain.riverwallData.device_data_dirty)
+
+    def test_no_riverwalls_is_harmless(self):
+        """A domain with no riverwalls must not be disturbed by the new hook."""
+        domain = rectangular_cross_domain(10, 10)
+        domain.set_flow_algorithm('DE0')
+        domain.set_name('rw_none')
+        domain.set_datadir(tempfile.mkdtemp())
+        domain.store = False
+        domain.set_quantity('elevation', -10.0)
+        domain.set_quantity('stage', 2.0)
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+        domain.set_multiprocessor_mode(2)
+
+        for _ in domain.evolve(yieldstep=0.5, finaltime=1.0):
+            pass
+
+        stage = domain.quantities['stage'].centroid_values
+        self.assertTrue(np.all(np.isfinite(stage)))
+        np.testing.assert_allclose(stage, 2.0, atol=1e-8)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/anuga/structures/riverwall.py
+++ b/anuga/structures/riverwall.py
@@ -154,6 +154,15 @@ class RiverWall:
         self.input_riverwall_geo=None
         self.input_riverwallPar=None
 
+        # Set when riverwall_elevation / hydraulic_properties are changed from
+        # Python after they may already have been copied to a GPU device. The
+        # device holds its own copy (mapped once when the mode-2 interface is
+        # built) and never writes these arrays, so a host-side change has to be
+        # pushed across. Domain.evolve() does that at yieldstep boundaries — see
+        # Domain._sync_riverwall_to_device(). Harmless (and ignored) on the CPU
+        # paths, where the kernels read these host arrays directly.
+        self.device_data_dirty = False
+
 
     def create_riverwalls(self, riverwalls, riverwallPar=None,
                           default_riverwallPar=None,
@@ -286,6 +295,11 @@ class RiverWall:
         connectedness = self.check_riverwall_connectedness(verbose=verbose)
         self.export_riverwalls_to_text(output_dir=output_dir)
 
+        # These are freshly allocated arrays. A mode-2 device interface built
+        # earlier holds pointers to the *previous* ones, so the riverwalls
+        # created here would never reach the GPU kernels.
+        self._warn_if_device_interface_already_built()
+
         if verbose:
             printInfo = edge_printInfo + hydro_printInfo
             if domain.parallel:
@@ -302,6 +316,30 @@ class RiverWall:
                 if domain.parallel:
                     barrier()
         return
+
+    def _warn_if_device_interface_already_built(self):
+        """Warn if riverwalls are (re)created after the GPU interface exists.
+
+        In mode 2 ('unified') the device copy of the riverwall arrays is mapped
+        when the interface is built, from the array objects that existed then.
+        create_riverwalls() replaces those arrays, so anything created afterwards
+        is invisible to the device kernels. Create riverwalls before switching to
+        mode 2 (or before anything that builds the interface, such as
+        set_boundary() / distribute_to_vertices_and_edges() on a domain that is
+        already in mode 2).
+        """
+        domain = self.domain
+        if getattr(domain, 'gpu_interface', None) is None:
+            return
+        if getattr(domain, 'multiprocessor_mode', 1) != 2:
+            return
+        import warnings
+        warnings.warn(
+            'create_riverwalls() was called after the mode-2 (GPU) device '
+            'interface was built; the riverwalls just created are NOT on the '
+            'device and will be ignored by the GPU flux computation. Create '
+            'riverwalls before calling set_multiprocessor_mode(2) or evolve().',
+            stacklevel=3)
 
     def _validate_riverwall_inputs(self, riverwalls, riverwallPar,
                                    default_riverwallPar, verbose):
@@ -527,6 +565,15 @@ class RiverWall:
         elevation : float or array-like of length n
             Scalar applied uniformly to all edges, or array matching the
             number of edges exactly.
+
+        Notes
+        -----
+        In GPU mode (``set_multiprocessor_mode(2)``) the device holds its own
+        copy of the crest elevations, refreshed by ``evolve()`` at yieldstep
+        boundaries. So a change made from inside an evolve loop takes effect on
+        the *next* yieldstep, not part-way through the current one — which is
+        where a script can observe it anyway. On the CPU paths the change is
+        immediate.
         """
         idx = self._name_to_index(name)
         mask = self.hydraulic_properties_rowIndex == idx
@@ -540,12 +587,17 @@ class RiverWall:
             raise ValueError(
                 "elevation length {} does not match {} edges for "
                 "riverwall '{}'".format(len(elev), n, name))
+        self.device_data_dirty = True
 
     def set_elevation_offset(self, name, offset):
-        """Add *offset* (m) to the current crest elevation of riverwall *name*."""
+        """Add *offset* (m) to the current crest elevation of riverwall *name*.
+
+        See :meth:`set_elevation` for when the change reaches a GPU device.
+        """
         idx = self._name_to_index(name)
         mask = self.hydraulic_properties_rowIndex == idx
         self.riverwall_elevation[mask] += float(offset)
+        self.device_data_dirty = True
 
     def get_hydraulic_parameter(self, name, param):
         """Return the hydraulic parameter *param* for riverwall *name*.
@@ -562,10 +614,13 @@ class RiverWall:
 
         Valid parameter names: ``Qfactor``, ``s1``, ``s2``, ``h1``, ``h2``,
         ``Cd_through``.
+
+        See :meth:`set_elevation` for when the change reaches a GPU device.
         """
         idx = self._name_to_index(name)
         col = self._param_to_col(param)
         self.hydraulic_properties[idx, col] = float(value)
+        self.device_data_dirty = True
 
     #####################################################################################
 


### PR DESCRIPTION
Fixes #224 and #189. Two mode-2 ('unified') silent-gap fixes; the second was pushed to the same branch after the PR was opened.

## The bug

In GPU mode (`set_multiprocessor_mode(2)`) the riverwall arrays are mapped to the device once, when the interface is built, and are never written there. `domain.riverwallData.set_elevation()` updates only the host array, so operating a gate mid-run was **silently dropped** — the run completed normally and produced plausible output computed with the original crest elevations.

`set_elevation_offset()` and `set_hydraulic_parameter()` had the same gap.

## The fix

- `gpu_sync_riverwall_to_device()` (`gpu/gpu_domain_core.c`) — `target update to` on `riverwall_elevation` and `riverwall_hydraulic_properties`. Sized by the number of riverwall edges, not by the mesh; a no-op when the domain has no riverwalls. Exposed via `sw_domain_gpu_ext.pyx` → `GPU_OMP_interface.sync_riverwall_to_device()`.
- The three `RiverWall` setters mark `device_data_dirty`.
- `Domain._sync_riverwall_to_device()` pushes when dirty, called from `evolve()` **at yieldstep boundaries only** — once before the stepping loop starts, and once on resuming from each `yield`. A change made in the loop body takes effect from the next timestep, never part-way through a step or between RK substeps, which is also the only point at which a script can observe it. The flag is cleared unconditionally, since the CPU paths read the host arrays directly.

Also warns when `create_riverwalls()` is called *after* the mode-2 interface exists: that reallocates the arrays, leaving the device holding pointers to the old ones, so those riverwalls are absent from the GPU flux computation. Same class of silent wrong answer, but not fixable by a push — the riverwalls have to be created first.

## Tests

`Test_GPU_RiverwallCrestUpdate` in `test_DE_gpu_omp.py` — the issue's gate scenario shrunk to 1280 elements / 200 s (~1.2 s):

- `test_shut_gate_changes_the_answer` — downstream volume with the gate shut at t=100 must match mode 1 and differ from the never-shut run (93543 vs 150379 m³).
- `test_sync_is_issued_at_the_yieldstep` — white-box: exactly one push, at the yieldstep where the change was made, not before `evolve()` resumes. This half also fails on a CPU build, where host/device aliasing hides the physics error.
- `test_no_riverwalls_is_harmless`.

Both of the first two fail with the push disabled and pass with it.

Verified on an nvc GPU-offload build (RTX 5070): `run_gpu_tests_isolated.sh` all 24 classes green; `anuga/shallow_water/tests/` in legacy mode 360 passed; `test_riverwall_structure.py` 43 passed; full fast suite 2718 passed, 218 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# #189 — degenerate-timestep protection is absent in mode 2, silently

`apply_protection_against_isolated_degenerate_timesteps()` damps the momentum of triangles whose timestep is anomalously small. It is reached only from `update_timestep()`, and mode 2 never effectively gets there: the C step loops return before it, and the Python-orchestrated GPU loops that *do* call it find a host `max_speed` the device never syncs back (the flux kernel writes the device copy), so the routine's own `max(max_speed) < 10` guard returns immediately.

The feature is default-off, so the sharp edge is the user who turns it on under GPU offload and gets no protection **and** no warning.

**This is option 1 from the issue** — make the gap visible. It warns once per domain, consistent with how mode 2 already reports unsupported forcing terms, and makes the absence explicit in the routine itself: in mode 2 it warns and returns, rather than relying on the stale-array accident to do nothing. Implementing the protection on the device remains open.

`Test_GPU_DegenerateTimestepProtection`: warns once when enabled in mode 2; silent at the default; silent in mode 1; and, called directly with a host `max_speed` carrying the exact signature the routine looks for, mode 1 damps the isolated triangle while mode 2 declines to act and warns. Three of the five fail without the change.

Suites re-run with both commits in: all 24 GPU classes green under the isolated runner, `anuga/shallow_water/tests/` 360 passed in legacy mode, full fast suite 2718 passed / 219 skipped, ruff clean.