### PR TITLE
structures: level the inlet stage instead of flattening the depth (#229)

### DIFF
--- a/anuga/parallel/parallel_inlet.py
+++ b/anuga/parallel/parallel_inlet.py
@@ -516,6 +516,26 @@ class Parallel_Inlet(Inlet):
         stages = self.get_stages()
         stages_order = stages.argsort()
 
+    def set_average_depth(self, new_average_depth, old_average_depth=None):
+        """Level this rank's share of the inlet (see Inlet.set_average_depth).
+
+        `old_average_depth` must be the GLOBAL average over the whole inlet: the
+        caller derived `new_average_depth` from it, and the difference is the
+        per-area volume change every rank must apply. Each rank then applies
+        that change to its own cells (its local average moves by the same
+        amount), leveling locally. Volume is exact; the level found on one rank
+        can differ from its neighbour's where an inlet straddles a partition,
+        which is the same order of seam the old uniform-depth write had on a
+        sloping bed.
+        """
+
+        if old_average_depth is None:
+            old_average_depth = self.get_global_average_depth()
+
+        delta = new_average_depth - old_average_depth
+        local_average = self.get_average_depth()
+        Inlet.set_average_depth(self, local_average + delta, local_average)
+
     def set_depths_evenly(self,volume):
         """ Distribute volume over all exchange
         cells with equal depth of water

--- a/anuga/parallel/parallel_structure_operator.py
+++ b/anuga/parallel/parallel_structure_operator.py
@@ -374,9 +374,15 @@ class Parallel_Structure_operator(anuga.Operator):
 
         # Inflow inlet procs sets new attributes
         if self.myid in self.inlet_procs[self.inflow_index]:
-            self.inlets[self.inflow_index].set_depths(new_inflow_depth)
-            self.inlets[self.inflow_index].set_xmoms(new_inflow_xmom)
-            self.inlets[self.inflow_index].set_ymoms(new_inflow_ymom)
+            # old_inflow_depth is the GLOBAL average over the whole inlet (every
+            # inflow-inlet rank computed it collectively above), which is what
+            # new_inflow_depth was derived from. Each rank levels its own share
+            # of the inlet by that per-area change — see
+            # Parallel_Inlet.set_average_depth.
+            self.inlets[self.inflow_index].set_average_depth(
+                new_inflow_depth, old_inflow_depth)
+            self.inlets[self.inflow_index].set_average_momenta(
+                new_inflow_xmom, new_inflow_ymom)
 
         # Get outflow inlet attributes, all processors associated with outflow inlet must call
         if self.myid in self.inlet_procs[self.outflow_index]:
@@ -474,9 +480,10 @@ class Parallel_Structure_operator(anuga.Operator):
 
         # outflow inlet procs sets new outflow attributes
         if self.myid in self.inlet_procs[self.outflow_index]:
-            self.inlets[self.outflow_index].set_depths(new_outflow_depth)
-            self.inlets[self.outflow_index].set_xmoms(new_outflow_xmom)
-            self.inlets[self.outflow_index].set_ymoms(new_outflow_ymom)
+            self.inlets[self.outflow_index].set_average_depth(
+                new_outflow_depth, outflow_average_depth)
+            self.inlets[self.outflow_index].set_average_momenta(
+                new_outflow_xmom, new_outflow_ymom)
 
     def __process_non_skew_culvert(self):
         """Create lines at the end of a culvert inlet and outlet.

--- a/anuga/shallow_water/gpu/gpu_culvert_operator.c
+++ b/anuga/shallow_water/gpu/gpu_culvert_operator.c
@@ -667,7 +667,7 @@ void gpu_culverts_finalize_all(struct gpu_domain *GD) {
         double *ad = CO->scratch_avg_depth;
         double *ax = CO->scratch_avg_xmom;
         double *ay = CO->scratch_avg_ymom;
-        double *nd = CO->scratch_slot_depth;
+        double *nd = CO->scratch_slot_shift;
         double *nx = CO->scratch_slot_xmom;
         double *ny = CO->scratch_slot_ymom;
         int *sst = CO->scratch_slot_start;
@@ -697,7 +697,7 @@ void gpu_culverts_finalize_all(struct gpu_domain *GD) {
     if (CO->scratch_avg_depth) { free(CO->scratch_avg_depth); CO->scratch_avg_depth = NULL; }
     if (CO->scratch_avg_xmom) { free(CO->scratch_avg_xmom); CO->scratch_avg_xmom = NULL; }
     if (CO->scratch_avg_ymom) { free(CO->scratch_avg_ymom); CO->scratch_avg_ymom = NULL; }
-    if (CO->scratch_slot_depth) { free(CO->scratch_slot_depth); CO->scratch_slot_depth = NULL; }
+    if (CO->scratch_slot_shift) { free(CO->scratch_slot_shift); CO->scratch_slot_shift = NULL; }
     if (CO->scratch_slot_xmom) { free(CO->scratch_slot_xmom); CO->scratch_slot_xmom = NULL; }
     if (CO->scratch_slot_ymom) { free(CO->scratch_slot_ymom); CO->scratch_slot_ymom = NULL; }
     if (CO->scratch_inlet_indices) { free(CO->scratch_inlet_indices); CO->scratch_inlet_indices = NULL; }
@@ -758,7 +758,7 @@ void gpu_culverts_map(struct gpu_domain *GD) {
     CO->scratch_avg_depth = (double*)calloc(ne, sizeof(double));
     CO->scratch_avg_xmom  = (double*)calloc(ne, sizeof(double));
     CO->scratch_avg_ymom  = (double*)calloc(ne, sizeof(double));
-    CO->scratch_slot_depth = (double*)calloc(ne, sizeof(double));
+    CO->scratch_slot_shift = (double*)calloc(ne, sizeof(double));
     CO->scratch_slot_xmom  = (double*)calloc(ne, sizeof(double));
     CO->scratch_slot_ymom  = (double*)calloc(ne, sizeof(double));
 
@@ -806,7 +806,7 @@ void gpu_culverts_map(struct gpu_domain *GD) {
     double *ad = CO->scratch_avg_depth;
     double *ax = CO->scratch_avg_xmom;
     double *ay = CO->scratch_avg_ymom;
-    double *nd = CO->scratch_slot_depth;
+    double *nd = CO->scratch_slot_shift;
     double *nx = CO->scratch_slot_xmom;
     double *ny = CO->scratch_slot_ymom;
     int *sst = CO->scratch_slot_start;
@@ -969,6 +969,130 @@ static void gpu_culvert_gather_inlets(struct gpu_domain *GD,
 // Batched Scatter: write updated depths/momenta back to GPU
 // ============================================================================
 
+// Level one inlet to a new average depth — water finds its level (issue #229).
+//
+// The single implementation of the structure write-back on the device, matching
+// level_stages_to_average() + Inlet.set_average_momenta() on the host path.
+//
+// Stage: adding volume raises the LOWEST stages to a common level; removing
+// volume lowers the HIGHEST stages to a common level, clamping each cell at its
+// bed (if the inlet holds less than asked for, it is drained dry and no more).
+// A zero transfer leaves the stages untouched, which is what makes the update
+// well balanced: a lake at rest on a sloping bed is not disturbed. Writing a
+// uniform DEPTH (the old behaviour) tilted the surface onto the bed; a shape-
+// preserving SHIFT (tried first) destabilised discharge into an initially dry
+// inlet. The level is found by bisection on the monotone volume(L) function;
+// 100 iterations pins it to the last bit of a double.
+//
+// Momentum: the physics produces ONE momentum value per inlet. It is written
+// depth-weighted — cell i gets m * depth_i / average_depth — so the VELOCITY
+// field is uniform and the area-weighted average momentum is exactly m. A
+// uniform-momentum write over the now non-uniform depths would give a nearly
+// dry cell an enormous velocity and collapse the global timestep.
+#pragma omp declare target
+static void culvert_level_inlet_surface(const int * restrict idx,
+                                        const double * restrict areas,
+                                        int ntri, double delta_avg_depth,
+                                        double new_xmom, double new_ymom,
+                                        double * restrict stage_c,
+                                        const double * restrict bed_c,
+                                        double * restrict xmom_c,
+                                        double * restrict ymom_c) {
+    if (ntri <= 0) return;
+
+    double total_area = 0.0;
+    for (int j = 0; j < ntri; j++) total_area += areas[j];
+    double volume = delta_avg_depth * total_area;
+
+    if (volume > 0.0 && total_area > 0.0) {
+        // Fill: find L with  A(L) = sum a_i * max(L - s_i, 0) == volume.
+        // A(max_s + volume/total_area) >= volume, so L lies in [lo, hi].
+        double lo = stage_c[idx[0]];
+        double hi = stage_c[idx[0]];
+        for (int j = 1; j < ntri; j++) {
+            double sj = stage_c[idx[j]];
+            if (sj < lo) lo = sj;
+            if (sj > hi) hi = sj;
+        }
+        hi += volume / total_area;
+        for (int it = 0; it < 100; it++) {
+            double mid = 0.5 * (lo + hi);
+            double added = 0.0;
+            for (int j = 0; j < ntri; j++) {
+                double a = mid - stage_c[idx[j]];
+                if (a > 0.0) added += a * areas[j];
+            }
+            if (added < volume) lo = mid; else hi = mid;
+        }
+        for (int j = 0; j < ntri; j++) {
+            int i = idx[j];
+            if (stage_c[i] < hi) stage_c[i] = hi;
+        }
+    } else if (volume < 0.0 && total_area > 0.0) {
+        // Drawdown: find L with
+        //   R(L) = sum a_i * min(depth_i, max(s_i - L, 0)) == -volume,
+        // then s_i' = max(bed_i, min(s_i, L)).
+        double to_remove = -volume;
+        double water = 0.0;
+        double lo = bed_c[idx[0]];
+        double hi = stage_c[idx[0]];
+        for (int j = 0; j < ntri; j++) {
+            int i = idx[j];
+            double d = stage_c[i] - bed_c[i];
+            if (d > 0.0) water += d * areas[j];
+            if (bed_c[i] < lo) lo = bed_c[i];
+            if (stage_c[i] > hi) hi = stage_c[i];
+        }
+        if (to_remove >= water) {
+            // Asked for more than the inlet holds: drain it dry, no further.
+            for (int j = 0; j < ntri; j++) {
+                int i = idx[j];
+                if (stage_c[i] > bed_c[i]) stage_c[i] = bed_c[i];
+            }
+        } else {
+            for (int it = 0; it < 100; it++) {
+                double mid = 0.5 * (lo + hi);
+                double removed = 0.0;
+                for (int j = 0; j < ntri; j++) {
+                    int i = idx[j];
+                    double d = stage_c[i] - bed_c[i];
+                    if (d < 0.0) d = 0.0;
+                    double r = stage_c[i] - mid;
+                    if (r < 0.0) r = 0.0;
+                    if (r > d) r = d;
+                    removed += r * areas[j];
+                }
+                if (removed > to_remove) lo = mid; else hi = mid;
+            }
+            for (int j = 0; j < ntri; j++) {
+                int i = idx[j];
+                double s_new = stage_c[i] < lo ? stage_c[i] : lo;
+                if (s_new < bed_c[i]) s_new = bed_c[i];
+                stage_c[i] = s_new;
+            }
+        }
+    }
+    // volume == 0: stages untouched (the exact lake-at-rest no-op).
+
+    // Depth-weighted momentum over the post-level depths.
+    double avg_depth = 0.0;
+    for (int j = 0; j < ntri; j++) {
+        int i = idx[j];
+        double d = stage_c[i] - bed_c[i];
+        if (d > 0.0) avg_depth += d * areas[j];
+    }
+    avg_depth = (total_area > 0.0) ? avg_depth / total_area : 0.0;
+    for (int j = 0; j < ntri; j++) {
+        int i = idx[j];
+        double d = stage_c[i] - bed_c[i];
+        double w = (avg_depth > 0.0 && d > 0.0) ? d / avg_depth : 0.0;
+        xmom_c[i] = new_xmom * w;
+        ymom_c[i] = new_ymom * w;
+    }
+}
+#pragma omp end declare target
+
+
 static void gpu_culvert_scatter(struct gpu_domain *GD,
                                 struct culvert_transfer *transfers) {
     struct culvert_operators *CO = &GD->culvert_ops;
@@ -978,22 +1102,30 @@ static void gpu_culvert_scatter(struct gpu_domain *GD,
 
     if (nt == 0) return;
 
-    // Build ONE (depth, xmom, ymom) triple per inlet on the host — the physics
-    // already produced these as a single value per inlet region. Inlet
-    // inlet_local is the inflow when inlet_local == inflow_idx, else the outflow.
-    double *nd = CO->scratch_slot_depth;
+    // Build ONE (delta average depth, xmom, ymom) triple per inlet on the host —
+    // the physics already produced these as a single value per inlet region.
+    // Inlet inlet_local is the inflow when inlet_local == inflow_idx, else the
+    // outflow.
+    //
+    // The delta is (new average depth - the average depth the physics started
+    // from); the kernel levels the inlet to absorb exactly that volume change.
+    // Writing the new average depth to every cell instead would flatten the
+    // water surface onto the bed and tilt a lake at rest (issue #229).
+    double *nd = CO->scratch_slot_shift;
     double *nx = CO->scratch_slot_xmom;
     double *ny = CO->scratch_slot_ymom;
     for (int c = 0; c < nc; c++) {
         struct culvert_transfer *t = &transfers[c];
         for (int inlet = 0; inlet < 2; inlet++) {
             int s = 2 * c + inlet;
+            double old_avg_depth = (inlet == 0) ? CO->host_data0[c].avg_depth
+                                                : CO->host_data1[c].avg_depth;
             if (inlet == t->inflow_idx) {
-                nd[s] = t->new_inflow_depth;
+                nd[s] = t->new_inflow_depth - old_avg_depth;
                 nx[s] = t->new_inflow_xmom;
                 ny[s] = t->new_inflow_ymom;
             } else {
-                nd[s] = t->new_outflow_depth;
+                nd[s] = t->new_outflow_depth - old_avg_depth;
                 nx[s] = t->new_outflow_xmom;
                 ny[s] = t->new_outflow_ymom;
             }
@@ -1014,19 +1146,13 @@ static void gpu_culvert_scatter(struct gpu_domain *GD,
     double * restrict ymom_c = GD->D.ymom_centroid_values;
     double * restrict bed_c = GD->D.bed_centroid_values;
 
+    double *sa = CO->scratch_inlet_areas;
+
     #pragma omp target teams distribute parallel for
     for (int s = 0; s < ne; s++) {
-        double depth = nd[s];
-        double new_xmom = nx[s];
-        double new_ymom = ny[s];
-        int start = sst[s];
-        int cnt = scn[s];
-        for (int j = 0; j < cnt; j++) {
-            int i = si[start + j];
-            stage_c[i] = bed_c[i] + depth;
-            xmom_c[i] = new_xmom;
-            ymom_c[i] = new_ymom;
-        }
+        culvert_level_inlet_surface(si + sst[s], sa + sst[s], scn[s],
+                                    nd[s], nx[s], ny[s],
+                                    stage_c, bed_c, xmom_c, ymom_c);
     }
 }
 
@@ -1295,27 +1421,6 @@ static void mpi_exchange_results(struct gpu_domain *GD,
 // per call; stage = bed + depth is computed entirely on-device.
 // ============================================================================
 
-static void scatter_single_inlet(struct gpu_domain *GD,
-                                  int *tri_indices, int ntri,
-                                  double new_depth, double new_xmom, double new_ymom) {
-    if (ntri == 0) return;
-
-    double * restrict stage_c = GD->D.stage_centroid_values;
-    double * restrict xmom_c = GD->D.xmom_centroid_values;
-    double * restrict ymom_c = GD->D.ymom_centroid_values;
-    double * restrict bed_c = GD->D.bed_centroid_values;
-
-    // Single fused device kernel: read bed, write stage/xmom/ymom. No host
-    // loop, no stack staging arrays.
-    int *idx = tri_indices;
-    #pragma omp target teams distribute parallel for map(to: idx[0:ntri])
-    for (int k = 0; k < ntri; k++) {
-        int i = idx[k];
-        stage_c[i] = bed_c[i] + new_depth;
-        xmom_c[i] = new_xmom;
-        ymom_c[i] = new_ymom;
-    }
-}
 
 // ============================================================================
 // Main entry point: execute ALL culverts in one batched cycle
@@ -1787,24 +1892,12 @@ void gpu_culverts_apply_all(struct gpu_domain *GD, double timestep) {
     if (has_parallel) {
         mpi_exchange_results(GD, transfers, mpi_bufs);
 
-        // Non-master ranks scatter to their local GPU inlets
-        for (int c = 0; c < nc; c++) {
-            struct culvert_indices *ci = &CO->indices[c];
-            if (ci->is_local) continue;
-            if (myrank == ci->master_proc) continue;
-
-            for (int inlet = 0; inlet < 2; inlet++) {
-                if (myrank != ci->inlet_master_proc[inlet]) continue;
-
-                int ntri = (inlet == 0) ? ci->inlet0_num : ci->inlet1_num;
-                int *tri_idx = (inlet == 0) ? ci->inlet0_indices : ci->inlet1_indices;
-                double new_depth = mpi_bufs->result_recv[c][inlet][0];
-                double new_xmom  = mpi_bufs->result_recv[c][inlet][1];
-                double new_ymom  = mpi_bufs->result_recv[c][inlet][2];
-
-                scatter_single_inlet(GD, tri_idx, ntri, new_depth, new_xmom, new_ymom);
-            }
-        }
+        // No scatter here: a non-master rank that owns an inlet received the
+        // master's values into its transfers[c] above, and PHASE 4's batched
+        // scatter writes every slot this rank holds triangles for — including
+        // that one. Scattering here as well used to be harmless because the
+        // write was an idempotent "stage = bed + depth"; now that the write is
+        // a surface SHIFT (issue #229), applying it twice would double it.
     }
 
     // ----------------------------------------------------------------

--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -378,7 +378,7 @@ struct culvert_operators {
     double *scratch_avg_ymom;
 
     // Per-inlet scatter values, pushed H2D each step then written on-device.
-    double *scratch_slot_depth;     // [2*nc] new water depth per inlet
+    double *scratch_slot_shift;     // [2*nc] delta average depth per inlet (new - old)
     double *scratch_slot_xmom;      // [2*nc]
     double *scratch_slot_ymom;      // [2*nc]
 

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -419,7 +419,7 @@ int gpu_domain_init(struct gpu_domain *GD, MPI_Comm comm, int rank, int nprocs) 
     GD->culvert_ops.scratch_avg_depth = NULL;
     GD->culvert_ops.scratch_avg_xmom = NULL;
     GD->culvert_ops.scratch_avg_ymom = NULL;
-    GD->culvert_ops.scratch_slot_depth = NULL;
+    GD->culvert_ops.scratch_slot_shift = NULL;
     GD->culvert_ops.scratch_slot_xmom = NULL;
     GD->culvert_ops.scratch_slot_ymom = NULL;
 

--- a/anuga/shallow_water/tests/test_DE_gpu_omp.py
+++ b/anuga/shallow_water/tests/test_DE_gpu_omp.py
@@ -3474,8 +3474,10 @@ class Test_GPU_LargeInlet(unittest.TestCase):
         domain.set_name('big_inlet')
         domain.set_datadir(tempfile.mkdtemp())
         domain.store = False
-        domain.set_quantity('elevation', lambda x, y: -5.0 + x / 200.0)
-        domain.set_quantity('stage', 1.0)
+        # A real head across the culvert (ponded upstream, low downstream), so
+        # the discharge is large and deterministic rather than set by roundoff.
+        domain.set_quantity('elevation', -5.0)
+        domain.set_quantity('stage', lambda x, y: np.where(x < 100.0, 1.0, -1.0))
         Br = Reflective_boundary(domain)
         domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
 
@@ -3488,7 +3490,7 @@ class Test_GPU_LargeInlet(unittest.TestCase):
 
         inlet_sizes = [len(inlet.triangle_indices) for inlet in culvert.inlets]
 
-        for _ in domain.evolve(yieldstep=2.0, finaltime=10.0):
+        for _ in domain.evolve(yieldstep=1.0, finaltime=5.0):
             pass
 
         return (inlet_sizes,
@@ -3506,11 +3508,127 @@ class Test_GPU_LargeInlet(unittest.TestCase):
                            'the old MAX_INLET_TRIANGLES cap of 64; got %s' % sizes_1)
 
         np.testing.assert_allclose(
-            stage_2, stage_1, rtol=0, atol=1e-6,
+            stage_2, stage_1, rtol=0, atol=1e-10,
             err_msg='mode-2 culvert with a >64-triangle inlet does not match mode 1')
         self.assertAlmostEqual(q_2, q_1, places=6)
         self.assertGreater(abs(q_1), 1.0,
                            'the culvert should actually be passing flow')
+
+
+class Test_GPU_StructureSurfaceLevel(unittest.TestCase):
+    """The device write-back levels the inlet, as the host path does (#229).
+
+    A structure operator used to write a uniform DEPTH across its inlet, which on
+    a sloping bed tilts the water surface onto the bed and disturbs a lake at
+    rest. Both the host paths and the mode-2 device scatter now apply the volume
+    change by filling to / drawing down from a level ("water finds its level"),
+    clamping cells at their bed, and write the per-inlet momentum depth-weighted
+    so the velocity field stays bounded. A zero transfer is an exact no-op.
+    """
+
+    def _lake_at_rest(self, mode, slope_denominator=50.0):
+        from anuga import Boyd_box_operator
+
+        domain = rectangular_cross_domain(30, 15, len1=200.0, len2=50.0)
+        domain.set_flow_algorithm('DE0')
+        domain.set_name('gpu_well_balanced')
+        domain.set_datadir(tempfile.mkdtemp())
+        domain.store = False
+        domain.set_quantity('elevation',
+                            lambda x, y: -5.0 + x / slope_denominator)
+        domain.set_quantity('stage', 1.0)
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+        Boyd_box_operator(
+            domain, end_points=[[60.0, 25.0], [140.0, 25.0]],
+            enquiry_points=[[40.0, 25.0], [160.0, 25.0]],
+            losses=1.5, width=20.0, height=3.0, apron=5.0,
+            use_momentum_jet=False, use_velocity_head=False,
+            manning=0.013, verbose=False)
+        domain.set_multiprocessor_mode(mode)
+
+        for _ in domain.evolve(yieldstep=0.5, finaltime=1.0):
+            pass
+
+        stage = domain.quantities['stage'].centroid_values
+        return float(np.abs(stage - 1.0).max())
+
+    def test_lake_at_rest_holds_in_mode2(self):
+        """No head, no flow, no disturbance — on the device as on the host."""
+        gpu = self._lake_at_rest(2)
+        cpu = self._lake_at_rest(1)
+        # 6.8e-02 in both modes with the old uniform-depth write.
+        self.assertLess(gpu, 1e-5,
+                        'mode-2 culvert disturbed a lake at rest by %.3e m' % gpu)
+        self.assertLess(cpu, 1e-5)
+
+    def _drain_shallow_inlet(self, mode):
+        """Drain a shallow, sloping inlet into a deep pool: cells must go dry."""
+        from anuga import Boyd_box_operator
+
+        domain = rectangular_cross_domain(40, 20, len1=200.0, len2=50.0)
+        domain.set_flow_algorithm('DE0')
+        domain.set_name('gpu_wetdry')
+        domain.set_datadir(tempfile.mkdtemp())
+        domain.store = False
+        # Shallow sloping shelf upstream (depths 0.027-0.052 m over the inlet),
+        # deep pool downstream, so the culvert asks for more water than the
+        # shallow end of the inlet holds.
+        def bed(x, y):
+            return np.where(x < 100.0, -1.0 + 0.005 * x, -6.0)
+
+        domain.set_quantity('elevation', bed)
+        # Clamped at the bed so no cell starts below it — otherwise the solver's
+        # first protect step lifts those cells and creates ~100 m^3, swamping the
+        # volume check below.
+        domain.set_quantity(
+            'stage', lambda x, y: np.where(x < 100.0,
+                                           np.maximum(bed(x, y), -0.66), -5.0))
+        Br = Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+        culvert = Boyd_box_operator(
+            domain, end_points=[[60.0, 25.0], [140.0, 25.0]],
+            enquiry_points=[[40.0, 25.0], [170.0, 25.0]],
+            losses=1.5, width=10.0, height=3.0, apron=5.0,
+            use_momentum_jet=False, use_velocity_head=False,
+            manning=0.013, verbose=False)
+        domain.set_multiprocessor_mode(mode)
+
+        inlet0 = culvert.inlets[0].triangle_indices.copy()
+
+        def volume():
+            bed = domain.quantities['elevation'].centroid_values
+            stage = domain.quantities['stage'].centroid_values
+            return float(np.sum((stage - bed) * domain.areas))
+
+        start_volume = volume()
+        dried = 0
+        for _ in domain.evolve(yieldstep=0.5, finaltime=6.0):
+            bed = domain.quantities['elevation'].centroid_values
+            stage = domain.quantities['stage'].centroid_values
+            depth = stage - bed
+            dried = max(dried, int(np.sum(depth[inlet0] <= 1e-12)))
+
+        return (volume() - start_volume, dried,
+                domain.quantities['stage'].centroid_values.copy())
+
+    def test_wet_dry_clamp_conserves_volume(self):
+        """Draining past dry must clamp at the bed, not invent or lose water."""
+        results = {mode: self._drain_shallow_inlet(mode) for mode in (1, 2)}
+
+        for mode, (drift, dried, _) in results.items():
+            self.assertGreater(dried, 5,
+                               'mode %d: the clamp is not being exercised — no '
+                               'inlet cells went dry' % mode)
+            # An unclamped write drives cells negative; the solver's protect
+            # step then lifts them back to zero, creating water.
+            self.assertLess(abs(drift), 1e-6,
+                            'mode %d: volume drifted by %.3e m^3 draining an '
+                            'inlet dry' % (mode, drift))
+
+        np.testing.assert_allclose(
+            results[2][2], results[1][2], rtol=0, atol=1e-10,
+            err_msg='the device clamp does not match the host clamp')
 
 
 if __name__ == "__main__":

--- a/anuga/structures/inlet.py
+++ b/anuga/structures/inlet.py
@@ -9,6 +9,95 @@ import math
 
 import numpy as num
 
+def level_stages_to_average(stages, elevations, areas,
+                            old_average_depth, new_average_depth):
+    """Move an inlet to a new average depth by filling or drawing down to a level.
+
+    Returns the new per-cell stages. The volume change is
+    ``(new_average_depth - old_average_depth) * total_area``, applied with the
+    "well-mixed reservoir" model the structure operators assume — water finds
+    its level:
+
+    * adding volume raises the LOWEST stages to a common level (a high cell is
+      never pulled down);
+    * removing volume lowers the HIGHEST stages to a common level (a low cell is
+      never lifted), clamping each cell at its bed; if the inlet holds less
+      water than asked for, it is drained dry and no more.
+
+    This replaces writing a uniform DEPTH across the inlet, which on a sloping
+    bed tilts the water surface to follow the bed and disturbs a lake at rest by
+    half the bed elevation range across the inlet (issue #229). Leveling is well
+    balanced — a level surface with no transfer is untouched — while keeping the
+    smoothing property of the old write that the culvert feedback loop relies on
+    (a shape-preserving shift was tried first and destabilised discharge into an
+    initially dry inlet; see the issue). On a flat bed, filling a dry or level
+    inlet reproduces the old uniform-depth result exactly.
+
+    The level is found by bisection on the monotone volume-of-water-above /
+    below-a-level function; 100 iterations pins it to the last bit of a double.
+
+    Parameters
+    ----------
+    stages, elevations, areas : array
+        Current per-cell stage, bed elevation and area.
+    old_average_depth : float
+        The average depth the caller's ``new_average_depth`` was derived from.
+        In parallel this is the GLOBAL average over the whole inlet while the
+        arrays are one rank's share, so it is passed in rather than recomputed.
+    new_average_depth : float
+        Target average depth.
+    """
+
+    stages = num.asarray(stages, dtype=float)
+    elevations = num.asarray(elevations, dtype=float)
+    areas = num.asarray(areas, dtype=float)
+
+    total_area = float(areas.sum())
+    volume = (new_average_depth - old_average_depth) * total_area
+
+    # Exactly zero transfer must be exactly a no-op: this is the lake-at-rest /
+    # well-balancedness case, and it must not be disturbed even at roundoff.
+    if volume == 0.0 or total_area <= 0.0:
+        return stages.copy()
+
+    if volume > 0.0:
+        # Fill: raise the lowest stages to a common level L, where the volume
+        # added below L, A(L) = sum a_i * max(L - s_i, 0), equals `volume`.
+        # A is continuous, increasing, and A(max_s + volume/total_area) >=
+        # total_area * (volume/total_area) = volume, so L lies in [lo, hi].
+        lo = float(stages.min())
+        hi = float(stages.max()) + volume / total_area
+        for _ in range(100):
+            mid = 0.5 * (lo + hi)
+            if float(num.dot(areas, num.maximum(mid - stages, 0.0))) < volume:
+                lo = mid
+            else:
+                hi = mid
+        return num.maximum(stages, hi)
+
+    # Drawdown: lower the highest stages to a common level L, clamping at the
+    # bed. Removed volume R(L) = sum a_i * min(depth_i, max(s_i - L, 0)) is
+    # continuous and decreasing, with R(min_z) = all the water and R(max_s) = 0.
+    to_remove = -volume
+    depths = num.maximum(stages - elevations, 0.0)
+    water = float(num.dot(areas, depths))
+    if to_remove >= water:
+        # Asked for more than the inlet holds: drain it dry, no further.
+        return num.where(depths > 0.0, elevations, stages).astype(float)
+
+    lo = float(elevations.min())
+    hi = float(stages.max())
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        removed = float(num.dot(
+            areas, num.minimum(depths, num.maximum(stages - mid, 0.0))))
+        if removed > to_remove:
+            lo = mid
+        else:
+            hi = mid
+    return num.maximum(elevations, num.minimum(stages, lo))
+
+
 class Inlet:
     """Contains information associated with each inlet
     """
@@ -173,6 +262,48 @@ class Inlet:
     def set_stages(self,stage):
 
         self.domain.quantities['stage'].centroid_values.put(self.triangle_indices, stage)
+
+    def set_average_momenta(self, xmom, ymom):
+        """Write inlet-average momenta (xmom, ymom), distributed per cell ∝ depth.
+
+        The structure operators compute ONE new momentum value per inlet. The old
+        write applied it uniformly, which was consistent with the old uniform-
+        depth write (uniform depth + uniform momentum = uniform velocity). With
+        the leveling write-back the depths across the inlet differ, and a uniform
+        momentum over a nearly-dry cell is an enormous velocity — enough to
+        collapse the global timestep. Weighting by depth keeps the VELOCITY field
+        uniform instead: cell i gets ``m * depth_i / average_depth``, so the
+        area-weighted average momentum is exactly ``m`` and velocity is bounded
+        by ``m / average_depth`` everywhere. On uniform depth this reduces to the
+        old uniform write.
+        """
+
+        depths = num.maximum(self.get_stages() - self.get_elevations(), 0.0)
+        average_depth = float(num.dot(depths, self.get_areas())) / self.area
+        if average_depth <= 0.0:
+            weights = 0.0 * depths
+        else:
+            weights = depths / average_depth
+        self.set_xmoms(xmom * weights)
+        self.set_ymoms(ymom * weights)
+
+    def set_average_depth(self, new_average_depth, old_average_depth=None):
+        """Fill or draw down the inlet to give `new_average_depth`.
+
+        The structure operators' way of writing back a transfer. Unlike
+        set_depths(), which flattens the DEPTH and so tilts the water surface on
+        a sloping bed, this levels the STAGE — water finds its level — and
+        clamps cells at their bed rather than driving them to negative depth.
+        See level_stages_to_average().
+        """
+
+        if old_average_depth is None:
+            old_average_depth = self.get_average_depth()
+
+        new_stages = level_stages_to_average(
+            self.get_stages(), self.get_elevations(), self.get_areas(),
+            old_average_depth, new_average_depth)
+        self.set_stages(new_stages)
 
 
     def set_xmoms(self,xmom):

--- a/anuga/structures/structure_operator.py
+++ b/anuga/structures/structure_operator.py
@@ -105,6 +105,10 @@ def _call_c_culvert(op):
 
     g0 = gather(i0)
     g1 = gather(i1)
+    # Index 5 of a gather tuple is that inlet's average depth — the value the C
+    # kernel derived its new depths from, and so the one the write-back levels
+    # the surface from (see Inlet.set_average_depth).
+    average_depths = (g0[5], g1[5])
     res = apply_fn(
         ctype, d.g,
         float(getattr(op, 'culvert_width', 0.0)),
@@ -134,12 +138,10 @@ def _call_c_culvert(op):
     op.inflow = inflow
     op.outflow = outflow
 
-    inflow.set_depths(nid)
-    inflow.set_xmoms(nix)
-    inflow.set_ymoms(niy)
-    outflow.set_depths(nod)
-    outflow.set_xmoms(nox)
-    outflow.set_ymoms(noy)
+    inflow.set_average_depth(nid, average_depths[inflow_idx])
+    inflow.set_average_momenta(nix, niy)
+    outflow.set_average_depth(nod, average_depths[1 - inflow_idx])
+    outflow.set_average_momenta(nox, noy)
 
     # Reporting (matches the Python discharge routine and the mode-2 readback)
     op.accumulated_flow += rg
@@ -445,13 +447,12 @@ class Structure_operator(anuga.Operator):
             new_inflow_xmom = old_inflow_xmom*factor2
             new_inflow_ymom = old_inflow_ymom*factor2
 
-        self.inflow.set_depths(new_inflow_depth)
+        self.inflow.set_average_depth(new_inflow_depth, old_inflow_depth)
 
         #inflow.set_xmoms(Q/inflow.get_area())
         #inflow.set_ymoms(0.0)
 
-        self.inflow.set_xmoms(new_inflow_xmom)
-        self.inflow.set_ymoms(new_inflow_ymom)
+        self.inflow.set_average_momenta(new_inflow_xmom, new_inflow_ymom)
 
         loss = (old_inflow_depth - new_inflow_depth)*self.inflow.get_area()
         xmom_loss = (old_inflow_xmom - new_inflow_xmom)*self.inflow.get_area()
@@ -478,9 +479,10 @@ class Structure_operator(anuga.Operator):
         self.outlet_depth = outlet_depth
 
 
-        new_outflow_depth = self.outflow.get_average_depth() + outflow_extra_depth
+        old_outflow_depth = self.outflow.get_average_depth()
+        new_outflow_depth = old_outflow_depth + outflow_extra_depth
 
-        self.outflow.set_depths(new_outflow_depth)
+        self.outflow.set_average_depth(new_outflow_depth, old_outflow_depth)
 
         if self.use_momentum_jet:
             # FIXME (SR) Review momentum to account for possible hydraulic jumps at outlet
@@ -505,8 +507,7 @@ class Structure_operator(anuga.Operator):
             new_outflow_xmom = self.outflow.get_average_xmom() + xmom_loss/self.outflow.get_area()
             new_outflow_ymom = self.outflow.get_average_ymom() + ymom_loss/self.outflow.get_area()
 
-        self.outflow.set_xmoms(new_outflow_xmom)
-        self.outflow.set_ymoms(new_outflow_ymom)
+        self.outflow.set_average_momenta(new_outflow_xmom, new_outflow_ymom)
 
 
 

--- a/anuga/structures/tests/test_structure_operator.py
+++ b/anuga/structures/tests/test_structure_operator.py
@@ -7,6 +7,7 @@ import numpy
 import anuga
 from anuga.abstract_2d_finite_volumes.mesh_factory import rectangular_cross
 from anuga.shallow_water.shallow_water_domain import Domain
+from anuga.structures.inlet import level_stages_to_average
 from anuga.structures.inlet_enquiry import Inlet_enquiry
 
 
@@ -306,8 +307,177 @@ class Test_Inlet_enquiry(unittest.TestCase):
         self.assertLess(inlet.enquiry_index, num_triangles)
 
 
+class Test_level_stages_to_average(unittest.TestCase):
+    """The inlet write-back kernel behind Inlet.set_average_depth() (issue #229).
+
+    Fills raise the lowest stages to a common level; drawdowns lower the highest
+    stages to a common level, clamping at the bed — the "water finds its level"
+    model the structure operators assume, applied to STAGE rather than depth.
+    """
+
+    @staticmethod
+    def _volume(stages, beds, areas):
+        return float(numpy.dot(numpy.maximum(stages - beds, 0.0), areas))
+
+    def test_level_surface_stays_level(self):
+        """A level lake over a sloping bed must stay level through a transfer."""
+        beds = numpy.array([0.0, 1.0, 2.0, 3.0])
+        stages = numpy.full(4, 5.0)
+        areas = numpy.ones(4)
+        avg = float(numpy.dot(stages - beds, areas) / areas.sum())
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg - 0.5)
+        numpy.testing.assert_allclose(out, 4.5, rtol=0, atol=1e-12,
+                                      err_msg='drawdown should stay level')
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg + 0.25)
+        numpy.testing.assert_allclose(out, 5.25, rtol=0, atol=1e-12,
+                                      err_msg='fill should stay level')
+
+    def test_zero_change_is_exactly_a_no_op(self):
+        """No transfer must be bit-exact — the well-balanced case."""
+        beds = numpy.array([0.0, 1.0, 2.0, 3.0])
+        stages = numpy.array([5.0, 4.5, 3.5, 3.2])
+        areas = numpy.array([1.0, 2.0, 1.0, 2.0])
+        avg = self._volume(stages, beds, areas) / areas.sum()
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg)
+        numpy.testing.assert_array_equal(out, stages)
+
+    def test_volume_change_is_exact(self):
+        """The volume moved is exactly what the caller asked for."""
+        beds = numpy.array([0.0, 1.0, 2.0, 3.0])
+        stages = numpy.array([5.0, 4.5, 3.5, 3.2])
+        areas = numpy.array([1.0, 2.0, 1.0, 2.0])
+        total_area = float(areas.sum())
+        avg = self._volume(stages, beds, areas) / total_area
+
+        for delta in (-0.15, -0.02, 0.3, 2.0):
+            out = level_stages_to_average(stages, beds, areas, avg, avg + delta)
+            moved = (self._volume(out, beds, areas)
+                     - self._volume(stages, beds, areas))
+            self.assertAlmostEqual(moved, delta * total_area, places=9)
+
+    def test_fill_raises_only_the_lowest(self):
+        """Water finds its level: a high cell is never pulled down."""
+        beds = numpy.zeros(4)
+        stages = numpy.array([5.0, 4.0, 3.0, 2.0])
+        areas = numpy.ones(4)
+        avg = stages.mean()
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg + 0.5)
+        self.assertEqual(out[0], 5.0)          # highest untouched
+        self.assertAlmostEqual(out[2], out[3], places=12)  # lowest at one level
+        self.assertGreaterEqual(out[1], 4.0)
+
+    def test_drawdown_lowers_only_the_highest(self):
+        """A low cell is never lifted by a removal."""
+        beds = numpy.zeros(4)
+        stages = numpy.array([5.0, 4.0, 3.0, 2.0])
+        areas = numpy.ones(4)
+        avg = stages.mean()
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg - 0.5)
+        self.assertEqual(out[3], 2.0)          # lowest untouched
+        self.assertAlmostEqual(out[0], out[1], places=9)  # highest at one level
+        numpy.testing.assert_allclose(out, [3.5, 3.5, 3.0, 2.0], atol=1e-9)
+
+    def test_wet_dry_clamp(self):
+        """Cells that reach their bed dry out; the deep cells supply the rest."""
+        beds = numpy.array([4.9, 4.8, 0.0, 0.0])
+        stages = numpy.full(4, 5.0)
+        areas = numpy.ones(4)
+        avg = self._volume(stages, beds, areas) / areas.sum()
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg - 2.0)
+        self.assertAlmostEqual(out[0], 4.9, places=12)   # clamped at bed
+        self.assertAlmostEqual(out[1], 4.8, places=12)
+        self.assertAlmostEqual(out[2], out[3], places=9)
+        moved = (self._volume(out, beds, areas)
+                 - self._volume(stages, beds, areas))
+        self.assertAlmostEqual(moved, -2.0 * areas.sum(), places=9,
+                               msg='clamping must not change the volume moved')
+
+    def test_draining_everything_leaves_it_dry(self):
+        """Asking for more water than the inlet holds empties it, no further."""
+        beds = numpy.array([0.0, 0.5])
+        stages = numpy.array([1.0, 2.0])
+        areas = numpy.ones(2)
+        avg = self._volume(stages, beds, areas) / areas.sum()
+
+        out = level_stages_to_average(stages, beds, areas, avg, avg - 10.0)
+        numpy.testing.assert_array_equal(out, beds)
+
+    def test_flat_bed_fill_matches_old_uniform_depth(self):
+        """On a flat bed from level water, leveling == the old set_depths()."""
+        beds = numpy.zeros(4)
+        stages = numpy.full(4, 0.4)
+        areas = numpy.ones(4)
+
+        out = level_stages_to_average(stages, beds, areas, 0.4, 0.7)
+        numpy.testing.assert_allclose(out, 0.7, rtol=0, atol=1e-12)
+        out = level_stages_to_average(stages, beds, areas, 0.4, 0.1)
+        numpy.testing.assert_allclose(out, 0.1, rtol=0, atol=1e-12)
+
+
+class Test_Structure_well_balanced(unittest.TestCase):
+    """A structure must not disturb a lake at rest (issue #229).
+
+    The inlet write-back used to set a uniform DEPTH, which on a sloping bed
+    tilts the water surface onto the bed — a lake at rest picked up an error of
+    about half the bed elevation range across the inlet, every timestep, with no
+    flow through the structure at all.
+    """
+
+    def _lake_at_rest(self, slope_denominator, with_culvert=True):
+        domain = anuga.rectangular_cross_domain(30, 15, len1=200.0, len2=50.0)
+        domain.set_flow_algorithm('DE0')
+        domain.set_name('well_balanced')
+        domain.store = False
+        domain.set_quantity('elevation',
+                            lambda x, y: -5.0 + x / slope_denominator)
+        domain.set_quantity('stage', 1.0)       # level surface: nothing to drive
+        Br = anuga.Reflective_boundary(domain)
+        domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+
+        if with_culvert:
+            anuga.Boyd_box_operator(
+                domain, end_points=[[60.0, 25.0], [140.0, 25.0]],
+                # Enquiry points well clear of the inlet regions: an enquiry
+                # cell just outside a wide inlet is strongly coupled to what the
+                # operator writes, which makes the run amplify roundoff and
+                # measures something other than well-balancedness.
+                enquiry_points=[[40.0, 25.0], [160.0, 25.0]],
+                losses=1.5, width=20.0, height=3.0, apron=5.0,
+                use_momentum_jet=False, use_velocity_head=False,
+                manning=0.013, verbose=False)
+
+        for _ in domain.evolve(yieldstep=0.5, finaltime=1.0):
+            pass
+
+        stage = domain.quantities['stage'].centroid_values
+        return float(numpy.abs(stage - 1.0).max())
+
+    def test_lake_at_rest_on_a_sloping_bed(self):
+        """The steeper the bed, the worse the old behaviour was; now: nothing."""
+        for slope_denominator in (50.0, 200.0):
+            deviation = self._lake_at_rest(slope_denominator)
+            # Was 6.8e-02 (1/50) and 1.8e-02 (1/200) with the uniform-depth
+            # write; both are now at roundoff level over this interval.
+            self.assertLess(
+                deviation, 1e-5,
+                'a culvert passing no flow disturbed a lake at rest by %.3e m '
+                'on a 1/%g bed' % (deviation, slope_denominator))
+
+    def test_matches_a_domain_without_the_structure(self):
+        """The structure should be as quiet as not having one at all."""
+        self.assertLess(self._lake_at_rest(50.0, with_culvert=False), 1e-12)
+
+
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(Test_Structure_operator)
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test_Inlet_enquiry))
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test_level_stages_to_average))
+    suite.addTests(unittest.TestLoader().loadTestsFromTestCase(Test_Structure_well_balanced))
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/claude/DECISIONS.md
+++ b/claude/DECISIONS.md
@@ -471,3 +471,51 @@ inline array, so legacy multi-file dumps still load and `single_file=False` rest
 old layout. (2) Pickle is Python-only and version-fragile; that is acceptable for a
 regenerable internal cache, but is precisely why the *mesh* artifact — which users may
 inspect, archive and share — was kept on NetCDF.
+
+---
+
+## Structure inlets: level the stage, don't flatten the depth (issue #229)
+
+`Structure_operator` wrote its transfer back as a **uniform depth** across each inlet
+(`Inlet.set_depths()` → `stage = elevation + d̄`). Volume was exact, but on a sloping bed
+that tilts a level water surface onto the bed, disturbing a lake at rest by half the bed
+elevation range across the inlet, every timestep, at zero discharge (3.4e-02 m on a 1/50
+bed) — in every compute mode.
+
+**Two models were tried:**
+
+1. **Surface shift** (`e899973f`, reverted in `f4e2ab11`): move every stage by
+   `new_avg_depth − old_avg_depth`, clamp at the bed. Well balanced, but it removed the
+   smoothing the culvert feedback loop relies on: discharging into an initially **dry**
+   inlet, the shallow-water dynamics inside the inlet build a ridge, the enquiry reading
+   swings, and the discharge oscillates and stalls
+   (`test_pipe_culvert_cpu_gpu_velocity_match` failed on every CI platform; with the
+   momentum write it even collapsed the global timestep).
+
+2. **Stage leveling** (this decision): apply the volume change with the "well-mixed
+   reservoir" model the operators assume — water finds its level. Adding volume raises
+   the *lowest* stages to a common level; removing volume lowers the *highest* stages to
+   a common level, clamping each cell at its bed. Exactly zero transfer is a bit-exact
+   no-op (the lake-at-rest case). On a **flat bed** filling a level or dry inlet
+   reproduces the old uniform-depth write exactly, which is why the flat-bed culvert
+   tests are untouched by construction — the property attempt 1 lacked. This is the same
+   model `Inlet.set_stages_evenly()` already uses for inlet-operator inflow.
+
+**Momentum**: the physics produces ONE momentum per inlet. The old uniform write was
+consistent with uniform depth; over leveled (non-uniform) depths a uniform momentum
+gives a nearly-dry cell an enormous velocity and collapses the timestep. So
+`Inlet.set_average_momenta()` writes it **depth-weighted** (`m·dᵢ/d̄`): the area-weighted
+average momentum is exactly `m`, and the *velocity* field is uniform (`m/d̄`). On uniform
+depth it reduces to the old write.
+
+**Level-finding is bisection** (100 iterations → last bit of a double) on the monotone
+volume(L) function — no sort, so the same loop runs in numpy
+(`level_stages_to_average()`, `anuga/structures/inlet.py`) and inside one GPU team
+(`culvert_level_inlet_surface()`, `gpu_culvert_operator.c`). The two must change
+together. In parallel each rank levels its own share by the same per-area volume change
+(global average passed in); the seam across a partitioned inlet is the same order as the
+old write's.
+
+**Non-idempotence**: the old `stage = bed + depth` write could be applied twice
+harmlessly; leveling cannot. The mode-2 MPI path therefore does not scatter in PHASE 3b —
+the batched PHASE 4 scatter already covers a non-master rank's own inlet.

--- a/claude/KNOWN_ISSUES.md
+++ b/claude/KNOWN_ISSUES.md
@@ -29,9 +29,9 @@ Consequences when writing tests:
 * A well-balancedness test (issue #229) must be kept **short** (~1 s) or use enquiry
   points well clear of the inlets, or the instability grows into the measurement.
 
-Today the effect is largely masked: the inlet write-back sets a uniform depth, which on a
-sloping bed injects a much larger deterministic perturbation that dominates it (that is
-issue #229). Fixing #229 will unmask this, so expect it to matter then.
+With the #229 fix (stage leveling) the old uniform-depth perturbation is gone, so this
+effect is no longer masked — it is now the dominant behaviour of a structure in still
+water, and the constraints above apply to any test touching one.
 
 ---
 

--- a/claude/KNOWN_ISSUES.md
+++ b/claude/KNOWN_ISSUES.md
@@ -5,6 +5,36 @@ or require caution when working in specific areas.
 
 ---
 
+## Structures
+
+### A culvert in still water amplifies roundoff (not a mode-1 vs mode-2 problem)
+
+A Boyd structure whose inlets sit in near-still water is an unstable configuration: the
+operator reads the enquiry cells and writes the inlet cells, and the two are close enough
+to close a feedback loop. With no head across the structure the discharge is decided by
+roundoff, and the perturbation grows exponentially — from 1 ULP to ~1e-2 m of stage in a
+few seconds on a 200 m x 50 m test domain.
+
+**It is not a GPU port problem.** Perturbing a single enquiry cell by 1e-15 in mode 1
+diverges from unperturbed mode 1 exactly as fast as mode 2 does (measured: 5.4e-06 at
+t=0.25 s, 5.3e-03 at t=1 s — the same as |mode1 - mode2| over the same run). A CPU/GPU
+comparison over such a configuration measures the instability, not the port.
+
+Consequences when writing tests:
+
+* A GPU-vs-CPU culvert test needs a **genuine driving head**, so the discharge is
+  deterministic and dominant. `Test_GPU_LargeInlet` in `test_DE_gpu_omp.py` does this
+  (ponded upstream, low downstream) and then agrees to ~1e-14. An earlier version of it
+  used still water and was hostage to this effect.
+* A well-balancedness test (issue #229) must be kept **short** (~1 s) or use enquiry
+  points well clear of the inlets, or the instability grows into the measurement.
+
+Today the effect is largely masked: the inlet write-back sets a uniform depth, which on a
+sloping bed injects a much larger deterministic perturbation that dominates it (that is
+issue #229). Fixing #229 will unmask this, so expect it to matter then.
+
+---
+
 ## Build
 
 ### Building with GPU offloading (NVIDIA HPC SDK / nvc)


### PR DESCRIPTION
Fixes #229. Second attempt — the first (a shape-preserving surface shift, `e899973f`) was reverted after breaking the pipe-culvert test on every CI platform; the diagnosis is on the issue and shaped this design.

## The defect

A structure operator wrote its transfer back as a **uniform depth** across each inlet (`Inlet.set_depths()`: `stage = elevation + average depth`). Volume was exact, but on a sloping bed that tilts a level water surface onto the bed, disturbing a lake at rest by **half the bed elevation range across the inlet**, every timestep, at zero discharge — 3.4e-02 m on a 1/50 bed, in every compute mode, with spurious momentum to match.

## The fix: water finds its level

The write-back applies the volume change with the well-mixed-reservoir model the operators already assume, applied to **stage**:

- adding volume raises the *lowest* stages to a common level (a high cell is never pulled down);
- removing volume lowers the *highest* stages to a common level, clamping each cell at its bed (an over-drained inlet goes dry, no further);
- exactly zero transfer is a **bit-exact no-op** — lake at rest goes 6.8e-02 → 3.7e-09 m on a 1/50 bed.

This is the model `Inlet.set_stages_evenly()` already uses for inlet-operator inflow. Crucially, **on a flat bed, filling a level or dry inlet reproduces the old uniform-depth write exactly** — so the flat-bed culvert tests, including `test_pipe_culvert_cpu_gpu_velocity_match` (the one that killed the shift attempt), are unaffected by construction rather than by luck. The pipe now flows steadily for 15 s (Q 0.229 → 0.092, monotone, volume constant to 1e-6) where the shift stalled it at t=3 s.

**Momentum**: the physics produces one momentum value per inlet. Over leveled (non-uniform) depths the old uniform write gives a nearly-dry cell an enormous velocity — observed 1.7e6 m/s and a "too small timestep" abort. `Inlet.set_average_momenta()` writes it **depth-weighted** (`m·dᵢ/d̄`): area-weighted average momentum is exactly `m`, the velocity field is uniform, and on uniform depth it reduces to the old write.

**Level-finding is bisection** (100 iterations → last bit of a double) on the monotone volume(L) function — no sort, so the identical loop runs in numpy (`level_stages_to_average()`, `anuga/structures/inlet.py`) and inside one GPU team (`culvert_level_inlet_surface()`, `gpu_culvert_operator.c`). The two must change together. Covered paths: pure-Python, C-kernel host, MPI (global average passed in; each rank levels its share by the same per-area change), and the mode-2 device scatter. The mode-2 MPI path no longer scatters in PHASE 3b — leveling, unlike the old idempotent write, must not be applied twice, and PHASE 4's batched scatter already covers a non-master rank's own inlet.

## Tests

- **Kernel unit tests** (`Test_level_stages_to_average`): level surface stays level through fill and drawdown; zero transfer bit-exact; exact volume for any delta; fill raises only the lowest / drawdown lowers only the highest; wet/dry clamp conserves volume; drain-dry; flat-bed fill equals the old uniform-depth result.
- **Well-balancedness**: lake at rest on a sloping bed, host (`Test_Structure_well_balanced`) and mode-2 (`Test_GPU_StructureSurfaceLevel`), both ~1e-9 where the old write gave 6.8e-02.
- **Wet/dry**: draining a shallow sloping inlet until 20 cells go dry, volume drift < 1e-6 m³ in both modes, host and device clamps agreeing to 1e-10.
- **Driven culvert**: `Test_GPU_LargeInlet` (79-triangle inlets, genuine head) mode 1 vs mode 2 to ~1e-14.

Green: full suite exactly as CI runs it (`OMP_NUM_THREADS=1 pytest --pyargs anuga` from sandpit) — **2937 passed, 10 skipped**; all GPU classes under the isolated runner (with its exit-status fix from `8662239c`, so this time the runner's word means something); parallel Boyd box / inlet operator tests; ruff and nvc build clean.

## What changes for users

Results move for any structure whose inlet sits on a **sloping** bed — that is the fix. Flat-bed structures (the common validation configuration) are bit-compatible for the stage write; momentum within an inlet is now depth-weighted rather than uniform, which only differs where depths within an inlet differ.

A related note for reviewers: a structure in **still water** has its discharge decided by roundoff and amplifies it exponentially (pre-existing, not mode-related, documented in `claude/KNOWN_ISSUES.md` and on the issue). With the tilt gone this is now the dominant behaviour of that configuration — validation comparisons should use driven heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)