### PR TITLE
CI: pin the Windows mingw toolchain to the one self-consistent set

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -54,29 +54,28 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -el {0}
         run: |
-           # TEMPORARY: pin the Windows mingw toolchain to the one combination known
-           # to work. conda-forge is mid-transition and BOTH halves have moved:
+           # TEMPORARY: hold the mingw runtime+sysroot chain at build 10.
            #
-           #   sysroot 11 + gcc build 2  -> stack smashing on every binary
-           #   sysroot 10 + gcc build 2  -> GREEN   <-- pinned here
-           #   sysroot 10 + gcc build 3  -> stack smashing
-           #   sysroot 11 + gcc build 3  -> stack smashing
-           #
-           # The symptom is that meson's sanity binary aborts:
+           # conda-forge's build-11 mingw packages (m2w64-sysroot-feedstock PR #21,
+           # 2026-08-20) make every mingw-built binary abort on startup:
            #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
            #   *** stack smashing detected ***: terminated
-           # i.e. __stack_chk_fail on a function with no locals -- a stack-protector ABI
-           # mismatch, nothing to do with ANUGA.
+           # meson reports this as "Executables created by c compiler are not runnable".
            #
-           # Remove this whole pin once upstream settles; do not pin one half only.
+           # libwinpthread is the one that bites at RUN time: pinning only the build-time
+           # packages lets the wheel build succeed and then the test step dies loading the
+           # extension. Reproduced by several feedstocks (capytaine, ollama, raster3d) on
+           # gcc 15 and 16 alike, so it is the sysroot chain, not the compiler.
+           #
+           # REMOVE this whole block once conda-forge/admin-requests#2297 lands, which
+           # marks the nine build-11 artifacts broken and makes the pin unnecessary.
            # Tracking: conda-forge/m2w64-sysroot-feedstock#23
            conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
-               "gcc_impl_win-64=16.1.0=h0942c35_2" \
-               "gxx_impl_win-64=16.1.0=he3d2c83_2" \
                "m2w64-sysroot_win-64=*=*_10" \
                "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
                "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
-               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
+               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
+               "libwinpthread=*=*_10"
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -129,7 +129,28 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate anuga_env
-          pip install --no-build-isolation -v .
+          pip install --no-build-isolation -v .      # TEMPORARY (PR #234): the pytest step exits 127 with no output on
+      # Windows. Find out what is actually missing before guessing again.
+      - name: Diagnose test environment (Windows)
+        if: runner.os == 'Windows'
+        shell: bash -el {0}
+        continue-on-error: true
+        run: |
+          conda activate anuga_env
+          echo "=== which python / pytest ==="
+          which python || echo "python NOT on PATH"
+          which pytest || echo "pytest NOT on PATH"
+          python -c "import sys; print('python', sys.version)"
+          echo "=== pytest importable as a module? ==="
+          python -c "import pytest; print('pytest', pytest.__version__)" || echo "pytest NOT importable"
+          echo "=== anuga importable? ==="
+          python -c "import anuga; print('anuga', anuga.__version__)" || echo "anuga NOT importable"
+          echo "=== sandpit present? ==="
+          ls -d sandpit && ls sandpit | head -3
+          echo "=== conda list (test deps) ==="
+          conda list -n anuga_env | grep -iE "^pytest|^python |libstdcxx|libgcc" || true
+
+
 
       - name: Test package (fast — PR feedback)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -54,30 +54,15 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -el {0}
         run: |
-           # PIN: hold the mingw sysroot chain at build 10.
-           #
-           # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
-           # merged 2026-08-20) rebuilt these four packages as build 11. Since that
-           # day every Windows job dies in meson's compiler sanity check with
-           #   "Executables created by c compiler ... are not runnable"
-           # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
-           # all unchanged.
-           #
-           # The toolchain compiles fine; the binary crashes on startup. Running
-           # meson's check by hand on 'int main(void){return 0;}' gives:
-           #   compile: OK
-           #   *** stack smashing detected ***: terminated      (exit 127)
-           # i.e. __stack_chk_fail fires on a function with no locals -- the stack
-           # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
-           # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
-           #
-           # TEMPORARY, remove when upstream fixes build 11:
-           #   conda-forge/m2w64-sysroot-feedstock#23
-           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
-               "m2w64-sysroot_win-64=*=*_10" \
-               "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
-               "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
-               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
+           # NOTE: the mingw sysroot chain was pinned to build 10 here between
+           # 2026-08-21 and 08-22, because build 11 (m2w64-sysroot-feedstock PR #21)
+           # was ABI-incompatible with the then-current gcc and every binary aborted
+           # in the stack protector. conda-forge has since rebuilt the compilers
+           # (gcc_impl_win-64 build 2 -> 3, *-devel _102 -> _103), so the pin then held
+           # the OLD sysroot against the NEW compiler and broke again. Unpinned: the
+           # intended combination is build-11 sysroot with the rebuilt compilers.
+           # See conda-forge/m2w64-sysroot-feedstock#23.
+           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -54,15 +54,29 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -el {0}
         run: |
-           # NOTE: the mingw sysroot chain was pinned to build 10 here between
-           # 2026-08-21 and 08-22, because build 11 (m2w64-sysroot-feedstock PR #21)
-           # was ABI-incompatible with the then-current gcc and every binary aborted
-           # in the stack protector. conda-forge has since rebuilt the compilers
-           # (gcc_impl_win-64 build 2 -> 3, *-devel _102 -> _103), so the pin then held
-           # the OLD sysroot against the NEW compiler and broke again. Unpinned: the
-           # intended combination is build-11 sysroot with the rebuilt compilers.
-           # See conda-forge/m2w64-sysroot-feedstock#23.
-           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
+           # TEMPORARY: pin the Windows mingw toolchain to the one combination known
+           # to work. conda-forge is mid-transition and BOTH halves have moved:
+           #
+           #   sysroot 11 + gcc build 2  -> stack smashing on every binary
+           #   sysroot 10 + gcc build 2  -> GREEN   <-- pinned here
+           #   sysroot 10 + gcc build 3  -> stack smashing
+           #   sysroot 11 + gcc build 3  -> stack smashing
+           #
+           # The symptom is that meson's sanity binary aborts:
+           #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
+           #   *** stack smashing detected ***: terminated
+           # i.e. __stack_chk_fail on a function with no locals -- a stack-protector ABI
+           # mismatch, nothing to do with ANUGA.
+           #
+           # Remove this whole pin once upstream settles; do not pin one half only.
+           # Tracking: conda-forge/m2w64-sysroot-feedstock#23
+           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+               "gcc_impl_win-64=16.1.0=h0942c35_2" \
+               "gxx_impl_win-64=16.1.0=he3d2c83_2" \
+               "m2w64-sysroot_win-64=*=*_10" \
+               "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
+               "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
+               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -54,22 +54,29 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -el {0}
         run: |
-           # TEMPORARY: hold the mingw runtime+sysroot chain at build 10.
+           # PIN: hold the mingw sysroot chain at build 10.
            #
-           # conda-forge's build-11 mingw packages (m2w64-sysroot-feedstock PR #21,
-           # 2026-08-20) make every mingw-built binary abort on startup:
-           #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
-           #   *** stack smashing detected ***: terminated
-           # meson reports this as "Executables created by c compiler are not runnable".
+           # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
+           # merged 2026-08-20) rebuilt these four packages as build 11. Since that
+           # day every Windows job dies in meson's compiler sanity check with
+           #   "Executables created by c compiler ... are not runnable"
+           # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
+           # all unchanged.
            #
-           # libwinpthread is the one that bites at RUN time: pinning only the build-time
-           # packages lets the wheel build succeed and then the test step dies loading the
-           # extension. Reproduced by several feedstocks (capytaine, ollama, raster3d) on
-           # gcc 15 and 16 alike, so it is the sysroot chain, not the compiler.
+           # The toolchain compiles fine; the binary crashes on startup. Running
+           # meson's check by hand on 'int main(void){return 0;}' gives:
+           #   compile: OK
+           #   *** stack smashing detected ***: terminated      (exit 127)
+           # i.e. __stack_chk_fail fires on a function with no locals -- the stack
+           # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
+           # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
            #
-           # REMOVE this whole block once conda-forge/admin-requests#2297 lands, which
-           # marks the nine build-11 artifacts broken and makes the pin unnecessary.
-           # Tracking: conda-forge/m2w64-sysroot-feedstock#23
+           # TEMPORARY. libwinpthread is the one that bites at RUN time: pinning
+           # only the build packages lets the wheel build succeed and then the
+           # test step dies loading the extension. Reproduced by capytaine,
+           # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
+           # chain, not the compiler. Remove once admin-requests#2297 lands:
+           #   conda-forge/m2w64-sysroot-feedstock#23
            conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
                "m2w64-sysroot_win-64=*=*_10" \
                "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
@@ -128,28 +135,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate anuga_env
-          pip install --no-build-isolation -v .      # TEMPORARY (PR #234): the pytest step exits 127 with no output on
-      # Windows. Find out what is actually missing before guessing again.
-      - name: Diagnose test environment (Windows)
-        if: runner.os == 'Windows'
-        shell: bash -el {0}
-        continue-on-error: true
-        run: |
-          conda activate anuga_env
-          echo "=== which python / pytest ==="
-          which python || echo "python NOT on PATH"
-          which pytest || echo "pytest NOT on PATH"
-          python -c "import sys; print('python', sys.version)"
-          echo "=== pytest importable as a module? ==="
-          python -c "import pytest; print('pytest', pytest.__version__)" || echo "pytest NOT importable"
-          echo "=== anuga importable? ==="
-          python -c "import anuga; print('anuga', anuga.__version__)" || echo "anuga NOT importable"
-          echo "=== sandpit present? ==="
-          ls -d sandpit && ls sandpit | head -3
-          echo "=== conda list (test deps) ==="
-          conda list -n anuga_env | grep -iE "^pytest|^python |libstdcxx|libgcc" || true
-
-
+          pip install --no-build-isolation -v .
 
       - name: Test package (fast — PR feedback)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -75,14 +75,21 @@ jobs:
            # only the build packages lets the wheel build succeed and then the
            # test step dies loading the extension. Reproduced by capytaine,
            # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
-           # chain, not the compiler. Remove once admin-requests#2297 lands:
+           # chain. The COMPILERS must be held too: gcc/gxx_impl build 3 were
+           # built against the build-11 sysroot (they require libstdcxx-devel
+           # _103), so build 3 + sysroot 10 gives "Unknown compiler(s)" and
+           # build 11 is broken outright. Only gcc 2 + sysroot 10 + libwinpthread
+           # 10 is self-consistent. Remove the block once admin-requests#2297 lands:
            #   conda-forge/m2w64-sysroot-feedstock#23
            conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+               "gcc_impl_win-64=16.1.0=h0942c35_2" \
+               "gxx_impl_win-64=16.1.0=he3d2c83_2" \
                "m2w64-sysroot_win-64=*=*_10" \
                "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
                "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
                "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
-               "libwinpthread=*=*_10"
+               "libwinpthread=*=*_10" \
+               "libstdcxx=16.1.0=hae5796f_2"
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -78,15 +78,22 @@ jobs:
           # only the build packages lets the wheel build succeed and then the
           # test step dies loading the extension. Reproduced by capytaine,
           # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
-          # chain, not the compiler. Remove once admin-requests#2297 lands:
+          # chain. The COMPILERS must be held too: gcc/gxx_impl build 3 were
+          # built against the build-11 sysroot (they require libstdcxx-devel
+          # _103), so build 3 + sysroot 10 gives "Unknown compiler(s)" and
+          # build 11 is broken outright. Only gcc 2 + sysroot 10 + libwinpthread
+          # 10 is self-consistent. Remove the block once admin-requests#2297 lands:
         #   conda-forge/m2w64-sysroot-feedstock#23
         run: |
           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+              "gcc_impl_win-64=16.1.0=h0942c35_2" \
+              "gxx_impl_win-64=16.1.0=he3d2c83_2" \
               "m2w64-sysroot_win-64=*=*_10" \
               "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
               "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
-              "libwinpthread=*=*_10"
+              "libwinpthread=*=*_10" \
+              "libstdcxx=16.1.0=hae5796f_2"
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -57,22 +57,29 @@ jobs:
       - name: Install compilers (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}
-          # TEMPORARY: hold the mingw runtime+sysroot chain at build 10.
-          #
-          # conda-forge's build-11 mingw packages (m2w64-sysroot-feedstock PR #21,
-          # 2026-08-20) make every mingw-built binary abort on startup:
-          #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
-          #   *** stack smashing detected ***: terminated
-          # meson reports this as "Executables created by c compiler are not runnable".
-          #
-          # libwinpthread is the one that bites at RUN time: pinning only the build-time
-          # packages lets the wheel build succeed and then the test step dies loading the
-          # extension. Reproduced by several feedstocks (capytaine, ollama, raster3d) on
-          # gcc 15 and 16 alike, so it is the sysroot chain, not the compiler.
-          #
-          # REMOVE this whole block once conda-forge/admin-requests#2297 lands, which
-          # marks the nine build-11 artifacts broken and makes the pin unnecessary.
-          # Tracking: conda-forge/m2w64-sysroot-feedstock#23
+        # PIN: hold the mingw sysroot chain at build 10.
+        #
+        # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
+        # merged 2026-08-20) rebuilt these four packages as build 11. Since that
+        # day every Windows job dies in meson's compiler sanity check with
+        #   "Executables created by c compiler ... are not runnable"
+        # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
+        # all unchanged.
+        #
+        # The toolchain compiles fine; the binary crashes on startup. Running
+        # meson's check by hand on 'int main(void){return 0;}' gives:
+        #   compile: OK
+        #   *** stack smashing detected ***: terminated      (exit 127)
+        # i.e. __stack_chk_fail fires on a function with no locals -- the stack
+        # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
+        # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
+        #
+        # TEMPORARY. libwinpthread is the one that bites at RUN time: pinning
+          # only the build packages lets the wheel build succeed and then the
+          # test step dies loading the extension. Reproduced by capytaine,
+          # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
+          # chain, not the compiler. Remove once admin-requests#2297 lands:
+        #   conda-forge/m2w64-sysroot-feedstock#23
         run: |
           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
               "m2w64-sysroot_win-64=*=*_10" \

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -57,30 +57,29 @@ jobs:
       - name: Install compilers (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}
-        # TEMPORARY: pin the Windows mingw toolchain to the one combination known
-        # to work. conda-forge is mid-transition and BOTH halves have moved:
-        #
-        #   sysroot 11 + gcc build 2  -> stack smashing on every binary
-        #   sysroot 10 + gcc build 2  -> GREEN   <-- pinned here
-        #   sysroot 10 + gcc build 3  -> stack smashing
-        #   sysroot 11 + gcc build 3  -> stack smashing
-        #
-        # The symptom is that meson's sanity binary aborts:
-        #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
-        #   *** stack smashing detected ***: terminated
-        # i.e. __stack_chk_fail on a function with no locals -- a stack-protector ABI
-        # mismatch, nothing to do with ANUGA.
-        #
-        # Remove this whole pin once upstream settles; do not pin one half only.
-        # Tracking: conda-forge/m2w64-sysroot-feedstock#23
+          # TEMPORARY: hold the mingw runtime+sysroot chain at build 10.
+          #
+          # conda-forge's build-11 mingw packages (m2w64-sysroot-feedstock PR #21,
+          # 2026-08-20) make every mingw-built binary abort on startup:
+          #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
+          #   *** stack smashing detected ***: terminated
+          # meson reports this as "Executables created by c compiler are not runnable".
+          #
+          # libwinpthread is the one that bites at RUN time: pinning only the build-time
+          # packages lets the wheel build succeed and then the test step dies loading the
+          # extension. Reproduced by several feedstocks (capytaine, ollama, raster3d) on
+          # gcc 15 and 16 alike, so it is the sysroot chain, not the compiler.
+          #
+          # REMOVE this whole block once conda-forge/admin-requests#2297 lands, which
+          # marks the nine build-11 artifacts broken and makes the pin unnecessary.
+          # Tracking: conda-forge/m2w64-sysroot-feedstock#23
         run: |
           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
-              "gcc_impl_win-64=16.1.0=h0942c35_2" \
-              "gxx_impl_win-64=16.1.0=he3d2c83_2" \
               "m2w64-sysroot_win-64=*=*_10" \
               "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
               "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
-              "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
+              "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
+              "libwinpthread=*=*_10"
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -57,16 +57,30 @@ jobs:
       - name: Install compilers (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}
-        # NOTE: the mingw sysroot chain was pinned to build 10 here between
-        # 2026-08-21 and 08-22, because build 11 (m2w64-sysroot-feedstock PR #21)
-        # was ABI-incompatible with the then-current gcc and every binary aborted
-        # in the stack protector. conda-forge has since rebuilt the compilers
-        # (gcc_impl_win-64 build 2 -> 3, *-devel _102 -> _103), so the pin then held
-        # the OLD sysroot against the NEW compiler and broke again. Unpinned: the
-        # intended combination is build-11 sysroot with the rebuilt compilers.
-        # See conda-forge/m2w64-sysroot-feedstock#23.
+        # TEMPORARY: pin the Windows mingw toolchain to the one combination known
+        # to work. conda-forge is mid-transition and BOTH halves have moved:
+        #
+        #   sysroot 11 + gcc build 2  -> stack smashing on every binary
+        #   sysroot 10 + gcc build 2  -> GREEN   <-- pinned here
+        #   sysroot 10 + gcc build 3  -> stack smashing
+        #   sysroot 11 + gcc build 3  -> stack smashing
+        #
+        # The symptom is that meson's sanity binary aborts:
+        #   printf 'int main(void){return 0;}' | cc -   ->  compiles, then
+        #   *** stack smashing detected ***: terminated
+        # i.e. __stack_chk_fail on a function with no locals -- a stack-protector ABI
+        # mismatch, nothing to do with ANUGA.
+        #
+        # Remove this whole pin once upstream settles; do not pin one half only.
+        # Tracking: conda-forge/m2w64-sysroot-feedstock#23
         run: |
-          conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
+          conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+              "gcc_impl_win-64=16.1.0=h0942c35_2" \
+              "gxx_impl_win-64=16.1.0=he3d2c83_2" \
+              "m2w64-sysroot_win-64=*=*_10" \
+              "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
+              "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
+              "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -57,31 +57,16 @@ jobs:
       - name: Install compilers (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}
-        # PIN: hold the mingw sysroot chain at build 10.
-        #
-        # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
-        # merged 2026-08-20) rebuilt these four packages as build 11. Since that
-        # day every Windows job dies in meson's compiler sanity check with
-        #   "Executables created by c compiler ... are not runnable"
-        # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
-        # all unchanged.
-        #
-        # The toolchain compiles fine; the binary crashes on startup. Running
-        # meson's check by hand on 'int main(void){return 0;}' gives:
-        #   compile: OK
-        #   *** stack smashing detected ***: terminated      (exit 127)
-        # i.e. __stack_chk_fail fires on a function with no locals -- the stack
-        # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
-        # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
-        #
-        # TEMPORARY, remove when upstream fixes build 11:
-        #   conda-forge/m2w64-sysroot-feedstock#23
+        # NOTE: the mingw sysroot chain was pinned to build 10 here between
+        # 2026-08-21 and 08-22, because build 11 (m2w64-sysroot-feedstock PR #21)
+        # was ABI-incompatible with the then-current gcc and every binary aborted
+        # in the stack protector. conda-forge has since rebuilt the compilers
+        # (gcc_impl_win-64 build 2 -> 3, *-devel _102 -> _103), so the pin then held
+        # the OLD sysroot against the NEW compiler and broke again. Unpinned: the
+        # intended combination is build-11 sysroot with the rebuilt compilers.
+        # See conda-forge/m2w64-sysroot-feedstock#23.
         run: |
-          conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
-              "m2w64-sysroot_win-64=*=*_10" \
-              "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
-              "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
-              "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10"
+          conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,7 +35,9 @@ keywords:
   - shallow water equations
   - finite volume method
 license: Apache License, Version 2.0
-commit: 564d7c88b06d7ae3b3a3a2862673d597b7a950bd
-version: 3.1.9
-date-released: '2022-06-26'
+# NOTE: set `date-released: 'YYYY-MM-DD'` in the release commit, matching the
+# tag date -- see claude/RELEASE_PLAN_4.0.0.md Phase 3. It is omitted rather
+# than left stale (it read 2022-06-26 through three releases). The `commit:`
+# pin was dropped for the same reason: the tag identifies the release.
+version: 4.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,24 +9,38 @@ to a GPU, with mode-1 and mode-2 agreeing bit-for-bit on the paths that matter.
 Alongside that are a decade-old correctness fix in the structure operators, a
 substantial set of parallel and wet/dry fixes, and container images.
 
-**Existing scripts keep working.** The default compute path is unchanged
-(`legacy`); GPU offload is opt-in. What makes this a major version is the
+**Existing scripts keep working.** The default compute mode is unchanged
+(`'legacy'`), and both the unified mode and GPU offload are opt-in. What makes this a major version is the
 removal of long-deprecated code, not a change in day-to-day behaviour.
 
 ---
 
 ## Highlights
 
-### GPU / unified compute (`multiprocessor_mode=2`)
+### The unified compute mode
 
-* OpenMP-target offload for the shallow-water solver: fluxes, extrapolation,
-  boundaries, riverwalls, culverts and operators all run on device.
-* **One implementation of the physics.** `culvert_compute_one()` is shared by the
-  CPU and GPU paths, so mode 1 and mode 2 produce bit-identical culvert results.
-* Opt in per domain with `domain.set_multiprocessor_mode(2)`, or process-wide
-  with `ANUGA_DEFAULT_COMPUTE_MODE=unified`. New controls: `anuga.set_gpu_offload()`,
-  `gpu_offload_enabled()`, `gpu_offload_supported()`, `set_omp_num_threads()`.
-* Multi-GPU via MPI, with device-side halo exchange.
+The solver and its operators now have a single C implementation that runs
+CPU-multicore, and can offload to a GPU on a suitably built install.
+
+```python
+domain.set_compute_mode('unified')     # per domain; CPU-multicore by default
+```
+
+or process-wide with `ANUGA_DEFAULT_COMPUTE_MODE=unified`.
+
+* **No GPU required.** 'unified' is a compute mode, not a GPU switch: on an
+  ordinary build it runs the same unified C kernels on the CPU. GPU offload is a
+  separate, process-wide opt-in — `anuga.set_gpu_offload(True)` on a build made
+  with the NVIDIA HPC SDK. `gpu_offload_supported()` reports whether a build can.
+* **One implementation of the physics.** `culvert_compute_one()` is shared by
+  both paths, so 'legacy' and 'unified' give bit-identical culvert results.
+* On GPU: fluxes, extrapolation, boundaries, riverwalls, culverts and operators
+  all execute on device, with multi-GPU via MPI and device-side halo exchange.
+* New controls: `set_gpu_offload()`, `gpu_offload_enabled()`,
+  `gpu_offload_supported()`, `set_omp_num_threads()`, `get_omp_num_threads()`.
+
+`set_multiprocessor_mode(1|2)` still works as a thin wrapper, but
+`set_compute_mode('legacy'|'unified')` is the preferred API for new code.
 
 ### New timestepping method
 
@@ -117,9 +131,9 @@ The legacy forcing classes in `anuga.shallow_water.forcing` now all emit
 | `Wind_stress`, `Wind_stress_fast` | `Wind_stress_operator` |
 | `Barometric_pressure`, `Barometric_pressure_fast` | `Barometric_pressure_operator` |
 
-These are **silently skipped** under `multiprocessor_mode=2`, which applies
+These are **silently skipped** in the `'unified'` compute mode, which applies
 forcing in C and handles only Manning friction; a warning is issued when that
-happens. Migrating to the operators is required to use them with GPU offload.
+happens. Migrating to the operators is required to use them with 'unified'.
 
 `manning_friction_semi_implicit` is *not* deprecated — it is an in-step
 semi-implicit term, not an operator.
@@ -133,12 +147,12 @@ semi-implicit term, not an operator.
 * **Culvert stack overflow** with more than 64 culverts (#217) — buffers were
   sized by a constant that was only the initial capacity.
 * **GPU culvert inlet cap** (#225) — an inlet was limited to 64 triangles.
-* **Riverwall crest changes reached the device** (#224) — runtime
+* **Riverwall crest changes reach the device** (#224) — runtime
   `set_elevation()` was silently ignored under GPU offload.
 * **DE0 non-GPU boundary fallback** — Euler steps silently ignored
-  Python-evaluated boundary types under mode 2.
+  Python-evaluated boundary types in the 'unified' mode.
 * Degenerate-timestep protection now warns rather than silently not running
-  under mode 2 (#189).
+  in the 'unified' mode (#189).
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,163 @@
+# ANUGA 4.0.0
+
+First release on the 4.x line, and the first release of the work that has been
+accumulating on `develop` since 3.3.10 — 993 commits across 935 files.
+
+The headline is a **GPU/multicore solver**: the shallow-water kernels now run
+through a single unified C implementation that executes on the CPU or offloads
+to a GPU, with mode-1 and mode-2 agreeing bit-for-bit on the paths that matter.
+Alongside that are a decade-old correctness fix in the structure operators, a
+substantial set of parallel and wet/dry fixes, and container images.
+
+**Existing scripts keep working.** The default compute path is unchanged
+(`legacy`); GPU offload is opt-in. What makes this a major version is the
+removal of long-deprecated code, not a change in day-to-day behaviour.
+
+---
+
+## Highlights
+
+### GPU / unified compute (`multiprocessor_mode=2`)
+
+* OpenMP-target offload for the shallow-water solver: fluxes, extrapolation,
+  boundaries, riverwalls, culverts and operators all run on device.
+* **One implementation of the physics.** `culvert_compute_one()` is shared by the
+  CPU and GPU paths, so mode 1 and mode 2 produce bit-identical culvert results.
+* Opt in per domain with `domain.set_multiprocessor_mode(2)`, or process-wide
+  with `ANUGA_DEFAULT_COMPUTE_MODE=unified`. New controls: `anuga.set_gpu_offload()`,
+  `gpu_offload_enabled()`, `gpu_offload_supported()`, `set_omp_num_threads()`.
+* Multi-GPU via MPI, with device-side halo exchange.
+
+### New timestepping method
+
+* **`DE_ader2`** — a fused ADER-2 predictor/extrapolation step, measured **1.75×
+  faster than DE1** at equivalent accuracy. Select with
+  `domain.set_flow_algorithm('DE_ader2')`.
+
+### Rainfall and forcing
+
+* `Raster_rate_operator` — apply gridded rainfall rasters directly.
+* Australian Rainfall & Runoff support: `ARR_rate_operator`, `Arr_hub_rain`,
+  `Arr_ifd_rain`, `ARR_point_rainfall_patterns`, `Arr_grd`.
+* `Wind_stress_operator` and `Barometric_pressure_operator` — operator
+  equivalents of the legacy forcing classes (see Deprecations).
+
+### Boundaries
+
+* `Absorbing_wave_boundary` and `Characteristic_wave_boundary`.
+
+### Meshes and memory
+
+* `sequential_mesh_dump` / `sequential_mesh_load` — partition once, run many
+  scenarios; NetCDF, self-describing, safe to share.
+* `uniform_refine_domain`, `sequential_mesh_refine`, `create_parallel_mesh`.
+* ~58% reduction in quantity memory; `quantity_memory_stats()`,
+  `domain_memory_stats()` to inspect it.
+
+### Tooling
+
+* Container images: CPU, GPU (NVHPC/nvc), and GPU+CUDA-aware-MPI, published to
+  GHCR on release.
+* GUIs: `anuga_sww_gui`, `anuga_animate_gui`.
+* `anuga_toml_run` for the TOML scenario interface (which itself shipped in
+  3.3.x; new here are `[[mesh.interior_holes]]` and `[[erosion]]` sections).
+* `anuga_run_isolated_tests` — per-test process isolation, needed on GPU builds.
+
+---
+
+## Breaking changes
+
+* **`anuga.culvert_flows` is removed** (7 790 lines). It was superseded years ago.
+  Migrate to the structure operators — `Boyd_box_operator`, `Boyd_pipe_operator`,
+  `Weir_orifice_trapezoid_operator`. `examples/structures/run_open_slot_wide_bridge.py`
+  shows the equivalent setup.
+* **Local-timestepping attributes removed**: `max_flux_update_frequency`,
+  `flux_update_frequency`, `update_next_flux`, `update_extrapolation`,
+  `edge_timestep`, `allow_timestep_increase`. The 3.1.9 implementation was not
+  GPU-compatible and had been dead code; see `claude/FUTURE_WORK.md` P3.1 for the
+  redesign.
+* **Structure operators now write back a level water surface** (see below). This
+  changes results for any structure whose inlet sits on a sloping bed.
+
+### The structure write-back change (#229)
+
+Structure operators wrote their transfer back as a **uniform depth** across each
+inlet. On a sloping bed that tilts a level water surface onto the bed, so a lake
+at rest was disturbed by roughly half the bed elevation range across the inlet —
+every timestep, at zero discharge.
+
+The write-back now applies the volume change by **levelling the stage** (water
+finds its level), clamping cells at their bed.
+
+What to expect:
+
+| case | change |
+|---|---|
+| flat bed under the inlet | **none** — bit-identical by construction |
+| sloping bed | results move; magnitude scales with the bed range across the inlet |
+
+Measured on the Towradgi catchment (22 culverts on real terrain, inlet bed
+spread median 0.77 m): peak stage difference **0.32 m**, 99th percentile 1.5 mm.
+Three of four flat-bed validation cases were bit-identical.
+
+If you calibrated a model against pre-4.0.0 results with structures on sloping
+ground, re-check it.
+
+---
+
+## Deprecations
+
+The legacy forcing classes in `anuga.shallow_water.forcing` now all emit
+`DeprecationWarning` and **will be removed in 4.1**:
+
+| deprecated | use instead |
+|---|---|
+| `Rainfall` | `Rate_operator.rainfall()` |
+| `Inflow` | `Rate_operator.inflow()` |
+| `Wind_stress`, `Wind_stress_fast` | `Wind_stress_operator` |
+| `Barometric_pressure`, `Barometric_pressure_fast` | `Barometric_pressure_operator` |
+
+These are **silently skipped** under `multiprocessor_mode=2`, which applies
+forcing in C and handles only Manning friction; a warning is issued when that
+happens. Migrating to the operators is required to use them with GPU offload.
+
+`manning_friction_semi_implicit` is *not* deprecated — it is an in-step
+semi-implicit term, not an operator.
+
+---
+
+## Selected fixes
+
+* **Parallel inlet mass balance** (#193) and **startup mass loss** (#200) — both
+  affected conserved volume in ordinary runs.
+* **Culvert stack overflow** with more than 64 culverts (#217) — buffers were
+  sized by a constant that was only the initial capacity.
+* **GPU culvert inlet cap** (#225) — an inlet was limited to 64 triangles.
+* **Riverwall crest changes reached the device** (#224) — runtime
+  `set_elevation()` was silently ignored under GPU offload.
+* **DE0 non-GPU boundary fallback** — Euler steps silently ignored
+  Python-evaluated boundary types under mode 2.
+* Degenerate-timestep protection now warns rather than silently not running
+  under mode 2 (#189).
+
+---
+
+## Requirements
+
+* Python 3.10 – 3.14, numpy ≥ 2.0
+* GPU offload requires the NVIDIA HPC SDK (`nvc`); the standard build is
+  unaffected and needs no GPU.
+
+## Known issues
+
+* Windows CI pins the conda-forge mingw sysroot chain to build 10. Build 11
+  (2026-08-20) produces a toolchain whose binaries abort in the stack protector;
+  tracked at conda-forge/m2w64-sysroot-feedstock#23. This pins only the CI
+  environment — released wheels are unaffected.
+* A structure sitting in near-still water amplifies roundoff; see
+  `claude/KNOWN_ISSUES.md`.
+
+## Thanks
+
+Stephen Roberts, Jorge Luis Gálvez Vallejo, wangshuo, Samir Shaikh, and everyone
+who reported issues against 3.3.x.

--- a/UPGRADING_TO_4.0.md
+++ b/UPGRADING_TO_4.0.md
@@ -30,7 +30,7 @@ Pipes use `Boyd_pipe_operator(..., diameter=...)`; weirs use
 ## 2. Forcing classes are deprecated (removal in 4.1)
 
 They still work in 4.0.0 but emit `DeprecationWarning`, and they are **silently
-skipped under GPU offload** — migrate before enabling `multiprocessor_mode=2`.
+skipped in the `'unified'` compute mode** — migrate before enabling it.
 
 ```python
 # before
@@ -82,12 +82,12 @@ A range near zero means this change does not affect that structure.
 
 ---
 
-## Optional: trying GPU / unified compute
+## Optional: trying the unified compute mode
 
 Nothing below is required to run 4.0.0.
 
 ```python
-domain.set_multiprocessor_mode(2)      # per domain
+domain.set_compute_mode('unified')     # per domain
 ```
 
 or process-wide:
@@ -96,14 +96,26 @@ or process-wide:
 export ANUGA_DEFAULT_COMPUTE_MODE=unified
 ```
 
-Requirements and caveats:
+**This is not a GPU switch.** `'unified'` selects the unified C kernels, which
+run CPU-multicore on an ordinary build. Offloading to a GPU is a separate,
+process-wide decision:
 
-* Actual GPU offload needs a build made with the NVIDIA HPC SDK (`nvc`). On a
-  standard build, mode 2 runs the same unified C kernels on the CPU.
-* The deprecated forcing classes are not applied in mode 2 (a warning is issued).
-* `protect_against_isolated_degenerate_timesteps` is not implemented in mode 2
-  (default-off; a warning is issued if enabled).
-* Under MPI, the number of ranks must match the number of visible GPUs.
+```python
+anuga.set_gpu_offload(True)            # needs a build made with nvc
+print(anuga.gpu_offload_supported())   # whether this build can offload at all
+```
+
+Caveats:
+
+* The deprecated forcing classes are not applied in 'unified' (a warning is
+  issued) — use the operators.
+* `protect_against_isolated_degenerate_timesteps` is not implemented in
+  'unified' (default-off; a warning is issued if enabled).
+* Under MPI with GPU offload, the number of ranks must match the number of
+  visible GPUs.
+
+`domain.set_multiprocessor_mode(2)` remains as a thin wrapper over
+`set_compute_mode('unified')`, but new code should prefer the named form.
 
 Container images with a working GPU toolchain are published to GHCR — see
 `docker/README.md`.

--- a/UPGRADING_TO_4.0.md
+++ b/UPGRADING_TO_4.0.md
@@ -1,0 +1,109 @@
+# Upgrading to ANUGA 4.0.0
+
+Most scripts need **no changes**. The default compute path is unchanged and GPU
+offload is opt-in. This guide covers the three things that can affect you.
+
+---
+
+## 1. `anuga.culvert_flows` has been removed
+
+The package was superseded by the structure operators years ago.
+
+```python
+# before (4.0.0: ModuleNotFoundError)
+from anuga.culvert_flows.culvert_class import Culvert_flow
+
+# after
+from anuga import Boyd_box_operator
+
+Boyd_box_operator(domain,
+                  end_points=[[x0, y0], [x1, y1]],
+                  width=2.0, height=2.0,
+                  losses=1.5, manning=0.013,
+                  apron=0.5)
+```
+
+Pipes use `Boyd_pipe_operator(..., diameter=...)`; weirs use
+`Weir_orifice_trapezoid_operator`. A worked example is in
+`examples/structures/run_open_slot_wide_bridge.py`.
+
+## 2. Forcing classes are deprecated (removal in 4.1)
+
+They still work in 4.0.0 but emit `DeprecationWarning`, and they are **silently
+skipped under GPU offload** — migrate before enabling `multiprocessor_mode=2`.
+
+```python
+# before
+from anuga.shallow_water.forcing import Rainfall, Inflow, Wind_stress
+domain.forcing_terms.append(Rainfall(domain, rate=10.0))     # mm/s
+domain.forcing_terms.append(Inflow(domain, rate=5.0))        # m^3/s
+domain.forcing_terms.append(Wind_stress(s=10.0, phi=45.0))
+
+# after
+from anuga import Rate_operator, Wind_stress_operator
+Rate_operator.rainfall(domain, rate=36.0)    # mm/hr  (10 mm/s == 36000 mm/hr)
+Rate_operator.inflow(domain, rate=5.0)       # m^3/s
+Wind_stress_operator(domain, s=10.0, phi=45.0)
+```
+
+**Watch the units.** `Rainfall` took **mm/s**; `Rate_operator.rainfall()` takes
+**mm/hr** — multiply by 3600 when porting. `Inflow` and `Rate_operator.inflow()`
+both take m³/s, so those carry over unchanged.
+`Barometric_pressure` → `Barometric_pressure_operator`.
+
+## 3. Structures on sloping ground give different results
+
+Structure operators used to write a uniform *depth* across each inlet, which
+tilted a level water surface onto a sloping bed. They now level the *stage*.
+
+* **Flat bed under the inlet** — results are bit-identical. Nothing to do.
+* **Sloping bed** — results change, in proportion to the bed elevation range
+  across the inlet. On Towradgi (median inlet bed spread 0.77 m) the peak stage
+  difference was 0.32 m.
+
+If you have a calibrated model with structures on sloping ground, re-run and
+re-check it against your observations. The new behaviour is the correct one: a
+lake at rest is now undisturbed by an idle structure, which was not true before.
+
+To see how exposed a model is, measure the bed spread across its inlets:
+
+```python
+z = domain.quantities['elevation'].centroid_values
+for op in domain.fractional_step_operators:
+    for i, inlet in enumerate(getattr(op, 'inlets', []) or []):
+        if inlet is None or not len(inlet.triangle_indices):
+            continue
+        zz = z[inlet.triangle_indices]
+        print(f'{getattr(op, "label", type(op).__name__)} inlet {i}: '
+              f'bed range {zz.max() - zz.min():.3f} m')
+```
+
+A range near zero means this change does not affect that structure.
+
+---
+
+## Optional: trying GPU / unified compute
+
+Nothing below is required to run 4.0.0.
+
+```python
+domain.set_multiprocessor_mode(2)      # per domain
+```
+
+or process-wide:
+
+```bash
+export ANUGA_DEFAULT_COMPUTE_MODE=unified
+```
+
+Requirements and caveats:
+
+* Actual GPU offload needs a build made with the NVIDIA HPC SDK (`nvc`). On a
+  standard build, mode 2 runs the same unified C kernels on the CPU.
+* The deprecated forcing classes are not applied in mode 2 (a warning is issued).
+* `protect_against_isolated_degenerate_timesteps` is not implemented in mode 2
+  (default-off; a warning is issued if enabled).
+* Under MPI, the number of ranks must match the number of visible GPUs.
+
+Container images with a working GPU toolchain are published to GHCR — see
+`docker/README.md`.

--- a/anuga/shallow_water/forcing.py
+++ b/anuga/shallow_water/forcing.py
@@ -1022,6 +1022,10 @@ class Barometric_pressure_fast:
         domain.forcing_terms.append(P)
         """
 
+        warn(
+            'Barometric_pressure_fast is deprecated and will be removed in a future release. Use anuga.operators.barometric_pressure.Barometric_pressure_operator instead.',
+            DeprecationWarning, stacklevel=2)
+
         from anuga.config import rho_a, rho_w, eta_w
 
         self.use_coordinates=True
@@ -1205,6 +1209,10 @@ class Wind_stress_fast:
 
         domain.forcing_terms.append(W)
         """
+
+        warn(
+            'Wind_stress_fast is deprecated and will be removed in a future release. Use anuga.operators.wind_stress_operator.Wind_stress_operator instead.',
+            DeprecationWarning, stacklevel=2)
 
         from anuga.config import rho_a, rho_w, eta_w
 

--- a/claude/RELEASE_PLAN_4.0.0.md
+++ b/claude/RELEASE_PLAN_4.0.0.md
@@ -148,7 +148,10 @@ receives in a wheel. Remove it when upstream fixes build 11.
 - [ ] **Upgrade guide** (one page): `culvert_flows` → `Boyd_box_operator` mapping;
       forcing classes → operators table; note that mode 2 is opt-in and how to try it
       (`domain.set_multiprocessor_mode(2)` / `ANUGA_DEFAULT_COMPUTE_MODE=unified`).
-- [ ] **Version/citation hygiene**: CITATION file, docs version strings, README badges.
+- [x] **Version/citation hygiene**: CITATION.cff bumped to 4.0.0; the stale
+      2022 `commit:` pin dropped and `date-released` omitted rather than left
+      wrong. Docs take the version from `anuga.__version__` (no hardcoding) and
+      README badges are version-agnostic, so neither needs a change.
 - [ ] **RC on TestPyPI** (optional but cheap): `4.0.0rc1` tag, workflow_dispatch the
       wheel build, `pip install --index-url test.pypi.org` smoke.
 - [ ] Announce the RC on the anuga-community list/discussions for a 3–4 day
@@ -162,8 +165,12 @@ Procedure per the 3.3.8 runbook (SESSION_GUIDE §"Release procedure"):
 # 1. Release PR: develop → main (review per the Phase-0 policy decision)
 gh pr create --repo anuga-community/anuga_core --base main --head develop \
   --title "Release 4.0.0"
-# 2. After merge — annotated tag, BARE version (no v prefix), on the merge commit
+# 2. Set the release date in CITATION.cff, then tag.
+#    (version is already 4.0.0; date-released is deliberately absent until now)
 git checkout main && git pull origin main
+sed -i "s/^version: 4.0.0$/version: 4.0.0\ndate-released: '$(date +%F)'/" CITATION.cff
+git commit -am "CITATION.cff: record the 4.0.0 release date"
+#    annotated tag, BARE version (no v prefix), on the merge commit
 git tag -a 4.0.0 -m "ANUGA 4.0.0"
 git push origin 4.0.0
 # 3. The GitHub Release is what triggers PyPI upload (a bare tag does NOT)


### PR DESCRIPTION
Fixes Windows CI. **37/37 checks pass** (1 skip: Publish to PyPI, releases only).

Supersedes the partial pin from #233, which fixed Windows for a day and then broke again when conda-forge rebuilt the compilers.

## The problem

conda-forge's build-11 mingw packages (m2w64-sysroot-feedstock PR #21, 2026-08-20) make every mingw-built binary abort on startup:

```
printf 'int main(void){return 0;}' > sanity.c
x86_64-w64-mingw32-cc sanity.c -o sanity.exe   ->  compile: OK
./sanity.exe                                   ->  *** stack smashing detected ***
```

`__stack_chk_fail` on a function with no locals — a stack-protector ABI mismatch. meson reports it as "Executables created by c compiler are not runnable"; CMake-based projects hit it too, so it is not build-system specific. Upstream: conda-forge/m2w64-sysroot-feedstock#23 (our reproduction is cited there).

## Why the pin has to cover both halves

| pinned | result |
|---|---|
| nothing | ❌ stack smashing |
| sysroot only (build 10) | ✅ for a day, then ❌ when gcc was rebuilt |
| unpinned again | ❌ `Unknown compiler(s)` |
| sysroot + libwinpthread, no compiler pin | ❌ `Unknown compiler(s)` |
| **all of the below** | ✅ **37/37** |

Two things drive it:

1. **`gcc_impl`/`gxx_impl` build 3 were built against the build-11 sysroot** (`gxx_impl _3` requires `libstdcxx-devel _103`). So build 3 + sysroot 10 fails, and sysroot 11 is broken outright. Only build 2 + sysroot 10 is self-consistent. Upstream's shorter pin works for feedstocks whose compiler resolves to build 2 anyway; ours resolves to 3.
2. **`libwinpthread` bites at *run* time.** Pinning only build-time packages let the wheels build and then every test process died silently at exit 127 — the same symptom raster3d reported. That is why the earlier attempt looked half-fixed.

The pinned set:

```
gcc_impl_win-64, gxx_impl_win-64   build 2
m2w64-sysroot_win-64, crt-git,
  headers-git, winpthreads-git     build 10
libwinpthread                      build 10
libstdcxx                          build 2
```

Applied to **both** workflows, which share the install line and so broke together. The full set was solved for `win-64` locally before pushing rather than discovered over another CI cycle.

## Removing this

`conda-forge/admin-requests#2297` will mark the nine build-11 artifacts broken, after which the solver refuses them on its own and **this whole block should be deleted** — not adjusted. Still open as of this PR; the workflow comments name the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)