### PR TITLE
CI: TestPyPI publish path for release candidates

### DIFF
--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -21,9 +21,21 @@ on:
         options:
           - none          # build only, upload nothing (default: safe to run anytime)
           - testpypi      # upload to TestPyPI (release candidates)
+      version:
+        description: 'Version for this build, e.g. 4.0.0rc1. Required when publish_to=testpypi. Empty = derive from git describe.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
+
+# Overrides the version that meson derives from `git describe` (see
+# _git_version.py). Empty for push/PR/release events -- `inputs` is null there,
+# so this expands to '' and the normal git-describe path is used. Set only by a
+# manual dispatch, which is how a release candidate gets a real version
+# (4.0.0rc1) without putting an rc tag on develop.
+env:
+  ANUGA_VERSION: ${{ inputs.version }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -279,6 +291,14 @@ jobs:
       id-token: write  # required for trusted publishing (OIDC)
 
     steps:
+      - name: Require an explicit version
+        if: inputs.version == ''
+        run: |
+          echo "publish_to=testpypi needs an explicit 'version' input (e.g. 4.0.0rc1)." >&2
+          echo "Without it the artifacts carry a git-describe dev version such as" >&2
+          echo "3.3.10.dev1004+gabc1234, which is not what you want on TestPyPI." >&2
+          exit 1
+
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -1,5 +1,7 @@
 # Build wheels on every push / PR for early feedback.
 # On a GitHub Release publish, build wheels then upload to PyPI.
+# On manual dispatch with publish_to=testpypi, upload to TestPyPI instead --
+# used for release candidates, which should never touch real PyPI.
 
 name: Build and Publish to PyPI
 
@@ -10,6 +12,15 @@ on:
     branches: [main, develop]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      publish_to:
+        description: 'Where to upload the built distributions'
+        type: choice
+        default: none
+        options:
+          - none          # build only, upload nothing (default: safe to run anytime)
+          - testpypi      # upload to TestPyPI (release candidates)
 
 permissions:
   contents: read
@@ -244,6 +255,54 @@ jobs:
   # Publish to PyPI — only runs when a GitHub Release is published.
   # Requires all wheel builds and the sdist to succeed first.
   # ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
+  # Publish to TestPyPI. Manual only, and only when explicitly asked for:
+  # `gh workflow run python-publish-pypi.yml -f publish_to=testpypi`.
+  #
+  # Deliberately separate from the PyPI job rather than a parameter on it, so no
+  # combination of inputs can send a release candidate to real PyPI. Uses its own
+  # environment (`testpypi`), which must match the trusted publisher configured
+  # at https://test.pypi.org/manage/project/anuga/settings/publishing/ --
+  # owner anuga-community, repo anuga_core, workflow python-publish-pypi.yml.
+  # ---------------------------------------------------------------------------
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build-wheels, build-wheels-osx64, build-sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to == 'testpypi'
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/anuga
+
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: sdist
+          path: dist
+
+      - name: List distributions to upload
+        run: ls -lh dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verify-metadata: false
+          verbose: true
+          packages-dir: dist/
+
   publish:
     name: Publish to PyPI
     needs: [build-wheels, build-wheels-osx64, build-sdist]


### PR DESCRIPTION
Adds a way to publish a release candidate without touching real PyPI, needed for the 4.0.0 RC soak.

## What

* `workflow_dispatch` with two inputs:
  * `publish_to` — `none` (default, build only) or `testpypi`
  * `version` — e.g. `4.0.0rc1`; exported as `ANUGA_VERSION`
* A separate `publish-testpypi` job gated on `workflow_dispatch && publish_to == 'testpypi'`, uploading to `https://test.pypi.org/legacy/` under its own `testpypi` environment.

```bash
gh workflow run python-publish-pypi.yml -f publish_to=testpypi -f version=4.0.0rc1
```

## Safety

The TestPyPI upload is a **separate job**, not a parameter on the existing one. The real-PyPI job still requires `github.event_name == 'release'`, which a manual dispatch cannot satisfy — so no combination of inputs can send an RC to production PyPI. The two jobs use distinct environments (`testpypi` vs `anuga`) so their trusted-publisher configurations stay separate.

Dispatching to TestPyPI without a `version` fails immediately with an explanation, rather than uploading artifacts named `3.3.10.dev1005+g8e2bc22e`.

## No rc tag

The version comes from the existing `ANUGA_VERSION` override in `_git_version.py` (already used for sdists and Docker builds with no `.git`), so an RC needs no tag on `develop`. For push/PR/release events `inputs` is null, the expression expands to `''`, and the normal `git describe` path is untouched — verified both ways locally:

```
ANUGA_VERSION=4.0.0rc1  ->  4.0.0rc1
unset                   ->  3.3.10.dev1005+g8e2bc22e.dirty
```

`4.0.0rc1` is valid PEP 440 and sorts after `3.3.10`, before `4.0.0`, so it is not installed by a plain `pip install anuga`.

## Known follow-up

`workflow_dispatch` is only exposed for workflows present on the **default branch**, and `main`'s copy of this workflow has no such trigger. So after this merges, dispatching against `develop` may still be refused until the trigger also exists on `main`. That is a one-line, CI-only change to `main` if needed — raising it here rather than discovering it at dispatch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)