### PR TITLE
Active-set stepping: domain.set_use_active_set() skips settled dry cells

### DIFF
--- a/anuga/operators/rate_operators.py
+++ b/anuga/operators/rate_operators.py
@@ -95,6 +95,11 @@ class Rate_operator(Operator):
                 'numpy array; got %s' % type(rate).__name__)
 
         Operator.__init__(self, domain, description, label, logging, verbose)
+        if getattr(domain, 'use_active_set', False):
+            log.warning('Rate operator attached while active-set stepping is '
+                        'enabled: results stay correct (wetted cells activate '
+                        'on the next step), but widespread rain activates the '
+                        'whole mesh and the active-set speedup degrades.')
 
         #-----------------------------------------------------
         # Make sure region is actually an instance of a region

--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -456,6 +456,23 @@ struct gpu_domain {
     int gpu_aware_mpi;           // Runtime flag: 1 if GPU-aware MPI available
     int verbose;                 // 0 = silent (default), 1 = print init/mapping messages
 
+    // Active-set stepping: opt-in wet/dry fast path (domain.set_use_active_set()).
+    // Prepared lazily on the first evolve step: builds the compacted
+    // owned-edge list, switches the flux kernel to scatter mode, and maps the
+    // classification scratch.  Serial (nprocs == 1) only -- silently disabled
+    // with a warning under MPI.  See core_build_active_sets() for the
+    // 2-ring-halo exactness argument.
+    int use_active_set;          // requested from Python
+    int as_prepared;             // lazy init has run
+    int as_ready;                // >=1 full step since mapping (first step runs full)
+    anuga_int *as_wet;           // scratch: wet flags         [n]
+    anuga_int *as_ring1;         // scratch: 1-ring flags      [n]
+    anuga_int *as_cells;         // compacted active cells     [n]
+    anuga_int *as_edges;         // compacted active edges     [num_owned_edges]
+    anuga_int as_counts[2];      // {n_active_cells, n_active_edges} per rebuild
+    double as_cellfrac_sum;      // stats: sum of active fractions
+    long   as_samples;           // stats: number of rebuilds
+
     // Halo exchange info
     struct halo_exchange halo;
 
@@ -513,6 +530,11 @@ struct gpu_domain {
 
 // Initialization and cleanup
 int gpu_domain_init(struct gpu_domain *GD, MPI_Comm comm, int rank, int nprocs);
+// Lazy first-step setup for active-set stepping (no-op unless
+// GD->use_active_set); safe to call every step.
+void gpu_active_set_prepare(struct gpu_domain *GD);
+// Mean active cell fraction since mapping (1.0 if never engaged).
+double gpu_active_set_mean_fraction(struct gpu_domain *GD);
 void gpu_domain_finalize(struct gpu_domain *GD);
 
 // Halo exchange setup - called once after Python domain is partitioned

--- a/anuga/shallow_water/gpu/gpu_kernels.c
+++ b/anuga/shallow_water/gpu/gpu_kernels.c
@@ -382,6 +382,90 @@ void gpu_ader_ck_predictor_edge(struct gpu_domain *GD, double dt) {
 // Full ADER-2 Step
 // ============================================================================
 
+// ============================================================================
+// Active-set stepping (opt-in wet/dry fast path)
+// ============================================================================
+
+void gpu_active_set_prepare(struct gpu_domain *GD) {
+    if (!GD->use_active_set || GD->as_prepared) return;
+    struct domain *D = &GD->D;
+
+    if (GD->nprocs > 1) {
+        if (GD->rank == 0) {
+            fprintf(stderr, "gpu: active-set stepping is serial-only for now; "
+                            "disabled under MPI (np=%d)\n", GD->nprocs);
+        }
+        GD->use_active_set = 0;
+        GD->as_prepared = 1;
+        return;
+    }
+
+    const anuga_int n = D->number_of_elements;
+
+    // Compacted owned-slot list: every boundary slot + the larger-index side
+    // of each interior edge -- one scatter thread per physical edge.  Also
+    // switches the flux kernel to scatter mode (reconstruct_edge_bed = 2),
+    // which the full-set steps use too, so active and full stepping share one
+    // discretization.
+    if (D->owned_edges == NULL) {
+        anuga_int *owned = (anuga_int *)malloc((size_t)(3 * n) * sizeof(anuga_int));
+        anuga_int ne = 0;
+        for (anuga_int p2 = 0; p2 < 3 * n; p2++) {
+            const anuga_int nbr = D->neighbours[p2];
+            if (nbr < 0 || nbr > p2 / 3) owned[ne++] = p2;
+        }
+        D->owned_edges = owned;
+        D->num_owned_edges = ne;
+        #pragma omp target enter data map(to: owned[0:ne])
+    }
+    D->reconstruct_edge_bed = 2;
+
+    GD->as_wet   = (anuga_int *)calloc((size_t)n, sizeof(anuga_int));
+    GD->as_ring1 = (anuga_int *)calloc((size_t)n, sizeof(anuga_int));
+    GD->as_cells = (anuga_int *)calloc((size_t)n, sizeof(anuga_int));
+    GD->as_edges = (anuga_int *)calloc((size_t)D->num_owned_edges, sizeof(anuga_int));
+    {
+        anuga_int *w = GD->as_wet, *r1 = GD->as_ring1;
+        anuga_int *c = GD->as_cells, *e = GD->as_edges;
+        const anuga_int ne = D->num_owned_edges;
+        #pragma omp target enter data map(alloc: w[0:n], r1[0:n], c[0:n], e[0:ne])
+    }
+    GD->as_ready = 0;      // first step runs the full set
+    GD->as_prepared = 1;
+    if (GD->verbose) {
+        printf("gpu: active-set stepping enabled (%lld cells, %lld owned edges)\n",
+               (long long)n, (long long)D->num_owned_edges);
+    }
+}
+
+// Per-step (re)build.  Returns full-set iteration (NULL lists) until the
+// first full step has run -- classification reads centroid stage, which is
+// only well-defined device-side after a complete step in every compute path.
+static void gpu_active_lists(struct gpu_domain *GD,
+                             const anuga_int **cells, anuga_int *ncells,
+                             const anuga_int **edges, anuga_int *nedges) {
+    gpu_active_set_prepare(GD);
+    if (!GD->use_active_set || !GD->as_ready) {
+        *cells = NULL; *ncells = 0;
+        *edges = GD->D.owned_edges; *nedges = GD->D.num_owned_edges;
+        return;
+    }
+    core_build_active_sets(&GD->D, GD->as_wet, GD->as_ring1,
+                           GD->as_cells, GD->as_edges,
+                           GD->D.owned_edges, GD->D.num_owned_edges,
+                           GD->as_counts);
+    *cells = GD->as_cells; *ncells = GD->as_counts[0];
+    *edges = GD->as_edges; *nedges = GD->as_counts[1];
+    GD->as_cellfrac_sum +=
+        (double)GD->as_counts[0] / (double)GD->D.number_of_elements;
+    GD->as_samples++;
+}
+
+double gpu_active_set_mean_fraction(struct gpu_domain *GD) {
+    if (GD->as_samples == 0) return 1.0;
+    return GD->as_cellfrac_sum / (double)GD->as_samples;
+}
+
 double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int apply_forcing, double prev_dt) {
     NVTX_PUSH("gpu_evolve_one_ader2_step");
     // ADER-2 step: extrapolate Q^n → fused edge C-K predictor(prev_dt/2) →
@@ -396,6 +480,9 @@ double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int
 
     double local_timestep, global_timestep, timestep;
 
+    const anuga_int *as_c, *as_e; anuga_int as_nc, as_ne;
+    gpu_active_lists(GD, &as_c, &as_nc, &as_e, &as_ne);
+
     // ========================================
     // Step 1: protect + extrapolate Q^n → edges + evaluate boundaries
     // ========================================
@@ -409,8 +496,14 @@ double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int
     // sequence's first boundary evaluation (before the standalone predictor
     // kernel) was provably dead: the predictor never reads boundary values,
     // and the second evaluation overwrote every value the first produced.
-    gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));
-    gpu_extrapolate_edges(GD, prev_dt > 0.0 ? prev_dt * 0.5 : 0.0);
+    if (as_c) {
+        const double pdt = prev_dt > 0.0 ? prev_dt * 0.5 : 0.0;
+        core_prepare_step_on(&GD->D, 0, gpu_prepare_should_zero_eu(GD), as_c, as_nc);
+        core_extrapolate_edge_pass_on(&GD->D, pdt, as_c, as_nc);
+    } else {
+        gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));
+        gpu_extrapolate_edges(GD, prev_dt > 0.0 ? prev_dt * 0.5 : 0.0);
+    }
 
     gpu_evaluate_reflective_boundary(GD);
     gpu_evaluate_dirichlet_boundary(GD);
@@ -426,7 +519,8 @@ double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int
     // Step 3: single flux call from Q^{n+1/2} edges (or Q^n on bootstrap step)
     // ========================================
 
-    local_timestep = gpu_flux_phase(GD, 0, 1);
+    local_timestep = as_c ? core_compute_fluxes_scatter_on(&GD->D, 0, 1, as_e, as_ne)
+                          : gpu_flux_phase(GD, 0, 1);
 
     // ========================================
     // Step 4: Allreduce for global min CFL timestep + clip to max_timestep
@@ -464,7 +558,9 @@ double gpu_evolve_one_ader2_step(struct gpu_domain *GD, double max_timestep, int
     // so evaluating it here, after the reduction, is bit-identical to the old
     // pre-reduction call -- it only accumulates into the semi-implicit terms
     // that the update consumes).
-    gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
+    if (as_c) core_forcing_and_update_on(&GD->D, timestep, apply_forcing, 0, 0.0, 0.0, as_c, as_nc);
+    else      gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
+    GD->as_ready = 1;
 
     NVTX_POP();  // gpu_evolve_one_ader2_step
     return timestep;
@@ -479,10 +575,18 @@ double gpu_evolve_one_euler_step(struct gpu_domain *GD, double max_timestep, int
 
     double local_timestep, global_timestep, timestep;
 
+    const anuga_int *as_c, *as_e; anuga_int as_nc, as_ne;
+    gpu_active_lists(GD, &as_c, &as_nc, &as_e, &as_ne);
+
     // Fused protect + extrapolate centroid pass, then the edge pass --
     // same launch structure as the fused RK2/ADER2 steps.
-    gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));
-    gpu_extrapolate_edges(GD, 0.0);
+    if (as_c) {
+        core_prepare_step_on(&GD->D, 0, gpu_prepare_should_zero_eu(GD), as_c, as_nc);
+        core_extrapolate_edge_pass_on(&GD->D, 0.0, as_c, as_nc);
+    } else {
+        gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));
+        gpu_extrapolate_edges(GD, 0.0);
+    }
 
     gpu_evaluate_reflective_boundary(GD);
     gpu_evaluate_dirichlet_boundary(GD);
@@ -494,7 +598,8 @@ double gpu_evolve_one_euler_step(struct gpu_domain *GD, double max_timestep, int
     gpu_evaluate_characteristic_wave_boundary(GD);
     gpu_evaluate_flather_boundary(GD);
 
-    local_timestep = gpu_flux_phase(GD, 0, 1);
+    local_timestep = as_c ? core_compute_fluxes_scatter_on(&GD->D, 0, 1, as_e, as_ne)
+                          : gpu_flux_phase(GD, 0, 1);
 
     static int fixed_ts_printed_euler = 0;
     if (GD->fixed_flux_timestep > 0.0) {
@@ -520,7 +625,9 @@ double gpu_evolve_one_euler_step(struct gpu_domain *GD, double max_timestep, int
     }
 
     // Manning + update fused (edge-based modes: also the flux gather)
-    gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
+    if (as_c) core_forcing_and_update_on(&GD->D, timestep, apply_forcing, 0, 0.0, 0.0, as_c, as_nc);
+    else      gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
+    GD->as_ready = 1;
 
     NVTX_POP();  // gpu_evolve_one_euler_step
     return timestep;
@@ -550,6 +657,9 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
 
     double local_timestep, global_timestep, timestep;
 
+    const anuga_int *as_c, *as_e; anuga_int as_nc, as_ne;
+    gpu_active_lists(GD, &as_c, &as_nc, &as_e, &as_ne);
+
     // ========================================
     // First Euler step
     // ========================================
@@ -557,8 +667,13 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
     // RK2 backup + protect + extrapolate centroid pass, fused into one
     // cell-local launch; the edge pass (which reads neighbour centroids)
     // follows as its own launch.
-    gpu_prepare_step(GD, 1, gpu_prepare_should_zero_eu(GD));
-    gpu_extrapolate_edges(GD, 0.0);
+    if (as_c) {
+        core_prepare_step_on(&GD->D, 1, gpu_prepare_should_zero_eu(GD), as_c, as_nc);
+        core_extrapolate_edge_pass_on(&GD->D, 0.0, as_c, as_nc);
+    } else {
+        gpu_prepare_step(GD, 1, gpu_prepare_should_zero_eu(GD));
+        gpu_extrapolate_edges(GD, 0.0);
+    }
 
     // Evaluate all GPU-supported boundary conditions
     gpu_evaluate_reflective_boundary(GD);
@@ -572,7 +687,8 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
     gpu_evaluate_flather_boundary(GD);
 
     // Compute fluxes - returns local minimum timestep
-    local_timestep = gpu_flux_phase(GD, 0, 2);
+    local_timestep = as_c ? core_compute_fluxes_scatter_on(&GD->D, 0, 2, as_e, as_ne)
+                          : gpu_flux_phase(GD, 0, 2);
 
     // Compute global timestep
     static int fixed_ts_printed = 0;
@@ -608,7 +724,8 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
 
     // Forcing + update, fused into one launch (edge-based: also the flux
     // gather itself -- see gpu_apply_phase)
-    gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
+    if (as_c) core_forcing_and_update_on(&GD->D, timestep, apply_forcing, 0, 0.0, 0.0, as_c, as_nc);
+    else      gpu_apply_phase(GD, timestep, apply_forcing, 0, 0.0, 0.0, 0);
 
     // Ghost exchange (MPI) - sync ghost cells between processes
     if (GD->nprocs > 1) {
@@ -619,8 +736,13 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
     // Second Euler step
     // ========================================
 
-    gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));   // no backup on the second substep
-    gpu_extrapolate_edges(GD, 0.0);
+    if (as_c) {   // no backup on the second substep
+        core_prepare_step_on(&GD->D, 0, gpu_prepare_should_zero_eu(GD), as_c, as_nc);
+        core_extrapolate_edge_pass_on(&GD->D, 0.0, as_c, as_nc);
+    } else {
+        gpu_prepare_step(GD, 0, gpu_prepare_should_zero_eu(GD));
+        gpu_extrapolate_edges(GD, 0.0);
+    }
 
     // Evaluate boundary conditions (same as first step)
     gpu_evaluate_reflective_boundary(GD);
@@ -634,12 +756,15 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
     gpu_evaluate_flather_boundary(GD);
 
     // Compute fluxes (ignore timestep from second step)
-    gpu_flux_phase(GD, 1, 2);
+    if (as_c) core_compute_fluxes_scatter_on(&GD->D, 1, 2, as_e, as_ne);
+    else      gpu_flux_phase(GD, 1, 2);
 
     // Forcing + update + the RK2 average (Q_final = 0.5*Q_backup + 0.5*Q),
     // all three fused into one launch.  The timestep is the one the first
     // substep already computed, so nothing here waits on a reduction.
-    gpu_apply_phase(GD, timestep, apply_forcing, 1, 0.5, 0.5, 1);
+    if (as_c) core_forcing_and_update_on(&GD->D, timestep, apply_forcing, 1, 0.5, 0.5, as_c, as_nc);
+    else      gpu_apply_phase(GD, timestep, apply_forcing, 1, 0.5, 0.5, 1);
+    GD->as_ready = 1;
 
     NVTX_POP();  // gpu_evolve_one_rk2_step
     return timestep;
@@ -651,6 +776,14 @@ double gpu_evolve_one_rk2_step(struct gpu_domain *GD, double max_timestep, int a
 
 double gpu_evolve_one_rk3_step(struct gpu_domain *GD, double max_timestep, int apply_forcing) {
     NVTX_PUSH("gpu_evolve_one_rk3_step");
+    if (GD->use_active_set) {
+        static int rk3_as_notice = 0;
+        if (!rk3_as_notice) {
+            fprintf(stderr, "gpu: active-set stepping is not implemented for "
+                            "rk3 (DE2); running full steps\n");
+            rk3_as_notice = 1;
+        }
+    }
     // Full SSP-RK3 step orchestrated entirely in C.
     //
     // Algorithm (Shu-Osher, 3rd-order strong-stability-preserving):

--- a/anuga/shallow_water/gpu/gpu_kernels.c
+++ b/anuga/shallow_water/gpu/gpu_kernels.c
@@ -400,6 +400,34 @@ void gpu_active_set_prepare(struct gpu_domain *GD) {
         return;
     }
 
+    // The active path drives the scatter flux kernel DIRECTLY (it is the only
+    // flux kernel with an edge-list variant), bypassing gpu_flux_mode.  So
+    // everything gpu_flux_mode would route to the cell-based kernel has to
+    // disable the mode here instead, or the active steps would silently use a
+    // kernel that cannot represent the physics: riverwalls (one-sided weir
+    // corrections), sloped Manning (separate kernels), and passive tracers --
+    // sediment classes are tracers -- which only the cell-based kernel
+    // advects.  Full stepping stays correct; only the speedup is lost.
+    // number_of_tracers cannot change while the interface is mapped
+    // (add_tracer tears it down), so a one-time check here is sufficient.
+    const char *why = NULL;
+    if (D->number_of_tracers > 0)
+        why = "passive tracers / sediment classes are registered (only the "
+              "cell-based flux kernel advects them)";
+    else if (D->number_of_riverwall_edges != 0)
+        why = "riverwalls are present (their weir corrections are one-sided)";
+    else if (GD->use_sloped_mannings)
+        why = "sloped Manning friction is selected";
+    if (why != NULL) {
+        if (GD->rank == 0) {
+            fprintf(stderr, "gpu: active-set stepping disabled: %s; "
+                            "running full steps\n", why);
+        }
+        GD->use_active_set = 0;
+        GD->as_prepared = 1;
+        return;
+    }
+
     const anuga_int n = D->number_of_elements;
 
     // Compacted owned-slot list: every boundary slot + the larger-index side

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -3563,6 +3563,63 @@ A grain size is a tracer -- so it is transported by the machinery of
             self.use_sloped_mannings = False
 
 
+
+    def set_use_active_set(self, flag: bool = True) -> None:
+        """Enable active-set stepping: skip cells that are provably
+        unchangeable this step (dry, with an all-dry 2-ring neighbourhood).
+
+        Only the GPU/unified compute path honours the flag (rk2/DE1,
+        ader2/DE_ader2 and euler/DE0 stepping; DE2/rk3 runs full steps with a
+        notice).  It also switches the flux kernel to single-solve scatter
+        mode, whose results differ from the default cell-based kernel only at
+        floating-point roundoff.  Serial domains only for now -- under MPI
+        the flag is ignored with a warning.
+
+        On mostly-dry flood domains (dam break, levee breach, storm surge)
+        this is the largest single speedup measured for the GPU path.  Water
+        added by rate operators (rainfall) is never lost -- newly wetted
+        cells activate on the next step -- but widespread rain activates the
+        whole mesh and the speedup degrades toward zero, hence the warning
+        when both are in play.
+        """
+        self.use_active_set = bool(flag)
+        gi = getattr(self, 'gpu_interface', None)
+        if gi is not None and getattr(gi, 'gpu_dom', None) is not None:
+            try:
+                from anuga.shallow_water.sw_domain_gpu_ext import set_use_active_set_gpu
+                set_use_active_set_gpu(gi.gpu_dom, 1 if flag else 0)
+            except ImportError:
+                pass
+        if flag:
+            rate_like = [type(op).__name__ for op in
+                         getattr(self, 'fractional_step_operators', [])
+                         if 'rate' in type(op).__name__.lower()]
+            if rate_like:
+                log.warning('active-set stepping enabled with rate operators '
+                            'attached (%s): results stay correct, but rained '
+                            'regions activate and the speedup degrades under '
+                            'widespread rain.' % ', '.join(rate_like))
+
+    def get_use_active_set(self) -> bool:
+        """Whether active-set stepping is requested (see set_use_active_set)."""
+        return bool(getattr(self, 'use_active_set', False))
+
+    def get_active_set_stats(self):
+        """Return (mean_active_fraction, n_rebuilds) once evolution has run.
+
+        mean_active_fraction is 1.0 whenever the active set never engaged
+        (flag off, non-GPU compute mode, MPI fallback, or before the first
+        rebuild).
+        """
+        gi = getattr(self, 'gpu_interface', None)
+        if gi is not None and getattr(gi, 'gpu_dom', None) is not None:
+            try:
+                from anuga.shallow_water.sw_domain_gpu_ext import active_set_stats_gpu
+                return active_set_stats_gpu(gi.gpu_dom)
+            except (ImportError, AttributeError):
+                pass
+        return (1.0, 0)
+
     def set_compute_fluxes_method(self, flag: str = 'original') -> None:
         """Set method for computing fluxes.
 

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -3570,7 +3570,10 @@ A grain size is a tracer -- so it is transported by the machinery of
 
         Only the GPU/unified compute path honours the flag (rk2/DE1,
         ader2/DE_ader2 and euler/DE0 stepping; DE2/rk3 runs full steps with a
-        notice).  It also switches the flux kernel to single-solve scatter
+        notice).  It is also ignored, with a notice, on domains with passive
+        tracers or sediment classes, riverwalls, or sloped Manning friction:
+        the active path uses the single-solve scatter flux kernel, which
+        carries none of those.  It also switches the flux kernel to single-solve scatter
         mode, whose results differ from the default cell-based kernel only at
         floating-point roundoff.  Serial domains only for now -- under MPI
         the flag is ignored with a warning.
@@ -3591,6 +3594,11 @@ A grain size is a tracer -- so it is transported by the machinery of
             except ImportError:
                 pass
         if flag:
+            if getattr(self, 'number_of_tracers', 0) > 0:
+                log.warning('active-set stepping requested on a domain with '
+                            'passive tracers / sediment classes: only the '
+                            'cell-based flux kernel advects tracers, so the '
+                            'GPU path will run full steps (flag ignored).')
             rate_like = [type(op).__name__ for op in
                          getattr(self, 'fractional_step_operators', [])
                          if 'rate' in type(op).__name__.lower()]

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -222,6 +222,8 @@ cdef extern from "gpu_domain.h" nogil:
         double fixed_flux_timestep
         double recorded_flux_timestep
         int use_sloped_mannings
+        int use_active_set
+        long as_samples
 
     # Function declarations - initialization and cleanup
     int gpu_domain_init(gpu_domain *GD, MPI_Comm comm, int rank, int nprocs)
@@ -325,6 +327,7 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_saxpy3_conserved_quantities(gpu_domain *GD, double a, double b, double c)
     double gpu_protect(gpu_domain *GD)
     double gpu_compute_water_volume(gpu_domain *GD)
+    double gpu_active_set_mean_fraction(gpu_domain *GD)
     void gpu_manning_friction(gpu_domain *GD)
 
     # ADER-2 Cauchy-Kovalewski predictor — centroid variant
@@ -705,6 +708,7 @@ cdef void get_domain_pointers(gpu_domain *GD, object domain_object):
     fft = getattr(domain_object, 'fixed_flux_timestep', None)
     GD.fixed_flux_timestep = fft if fft is not None else -1.0
     GD.use_sloped_mannings = 1 if getattr(domain_object, 'use_sloped_mannings', False) else 0
+    GD.use_active_set = 1 if getattr(domain_object, 'use_active_set', False) else 0
     D.low_froude = domain_object.low_froude
     # Explicit even though GPUDomain's memory is zero-initialized: bed-edge
     # reconstruction in compute_fluxes is opt-in and stays off for ANUGA.
@@ -2311,6 +2315,21 @@ def compute_water_volume_gpu(GPUDomain gpu_dom):
         Local water volume (m^3)
     """
     return gpu_compute_water_volume(&gpu_dom.GD)
+
+
+def set_use_active_set_gpu(GPUDomain gpu_dom, int flag):
+    """Push the active-set flag into an already-initialized GPU domain."""
+    gpu_dom.GD.use_active_set = flag
+
+
+def active_set_stats_gpu(GPUDomain gpu_dom):
+    """Return (mean_active_fraction, n_rebuilds) for active-set stepping.
+
+    mean_active_fraction is 1.0 when the active set never engaged (disabled,
+    MPI fallback, or no rebuild has run yet).
+    """
+    return (gpu_active_set_mean_fraction(&gpu_dom.GD),
+            int(gpu_dom.GD.as_samples))
 
 
 def manning_friction_gpu(GPUDomain gpu_dom):

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -14,6 +14,7 @@ python_sources = [
 'test_data_manager.py',
 'test_sw_domain_openmp.py',
 'test_DE_gpu_omp.py',
+'test_active_set.py',
 'test_compute_mode.py',
 'test_tracers.py',
 'test_tracers_boundary.py',

--- a/anuga/shallow_water/tests/test_active_set.py
+++ b/anuga/shallow_water/tests/test_active_set.py
@@ -1,0 +1,138 @@
+"""Tests for active-set stepping (domain.set_use_active_set).
+
+Active-set stepping skips cells that are provably unchangeable this step
+(dry, with an all-dry 2-ring neighbourhood).  These tests verify it against
+plain full stepping on a mostly-dry domain, that its statistics report real
+engagement, and that water added by a rate operator (rain) on inactive cells
+is never lost.
+"""
+
+import os
+import tempfile
+import unittest
+import warnings
+
+import numpy as np
+import pytest
+
+import anuga
+from anuga import Reflective_boundary, rectangular_cross_domain
+
+
+_gpu_error = None
+_gpu_avail = None
+
+
+def gpu_available():
+    global _gpu_error, _gpu_avail
+    if _gpu_avail is not None:
+        return _gpu_avail
+    try:
+        from anuga.shallow_water.sw_domain_gpu_ext import init_gpu_domain  # noqa: F401
+        _gpu_avail = True
+    except Exception as e:
+        _gpu_avail = False
+        _gpu_error = f"{type(e).__name__}: {e}"
+    return _gpu_avail
+
+
+# Same per-process isolation rule as test_DE_gpu_omp.py: on a GPU-offload
+# build the NVHPC runtime aborts after many mode-2 domains in one process, so
+# this file only runs in-process on CPU builds or under the isolated runner.
+if (gpu_available() and anuga.gpu_offload_supported()
+        and not os.environ.get('ANUGA_GPU_TESTS_ISOLATED')):
+    _skip_reason = (
+        "GPU-offload build: run active-set tests via "
+        "anuga/shallow_water/tests/run_gpu_tests_isolated.sh")
+    warnings.warn(_skip_reason, stacklevel=1)
+    pytest.skip(_skip_reason, allow_module_level=True)
+
+
+def _make_domain(name):
+    """A mostly-dry sloped domain: wet pool in the low corner, dry upslope."""
+    domain = rectangular_cross_domain(16, 16, len1=100., len2=100.)
+    domain.set_flow_algorithm('DE1')
+    domain.set_low_froude(0)
+    domain.set_name(name)
+    domain.set_datadir(tempfile.mkdtemp())
+    domain.store = False
+    domain.set_quantity('elevation', lambda x, y: x / 10.0)   # 0..10 m
+    domain.set_quantity('friction', 0.0)
+    domain.set_quantity('stage', 2.0)                         # wet only x < 20
+    Br = Reflective_boundary(domain)
+    domain.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+    return domain
+
+
+@pytest.mark.skipif(not gpu_available(),
+                    reason=_gpu_error or "GPU OpenMP interface not available")
+class Test_active_set(unittest.TestCase):
+
+    def _evolve(self, domain, finaltime=3.0):
+        for _ in domain.evolve(yieldstep=1.0, finaltime=finaltime):
+            pass
+
+    def test_active_matches_full_stepping(self):
+        """Active-set evolution matches plain mode-2 evolution.
+
+        The active-set domain uses scatter fluxes (single Riemann solve per
+        edge), which agree with the default cell-based kernel only to
+        floating-point roundoff, hence the tolerance.
+        """
+        ref = _make_domain('as_ref')
+        ref.set_multiprocessor_mode(2)
+        self._evolve(ref)
+
+        act = _make_domain('as_act')
+        act.set_multiprocessor_mode(2)
+        act.set_use_active_set(True)
+        self._evolve(act)
+
+        for q in ('stage', 'xmomentum', 'ymomentum'):
+            a = act.quantities[q].centroid_values
+            r = ref.quantities[q].centroid_values
+            assert np.allclose(a, r, atol=1e-8, rtol=1e-6), \
+                f'{q}: max diff {np.abs(a - r).max()}'
+
+        frac, samples = act.get_active_set_stats()
+        assert samples > 0, 'active set never engaged'
+        assert frac < 0.9, f'active fraction {frac} suspiciously high'
+        # the reference never engaged it
+        assert ref.get_active_set_stats() == (1.0, 0)
+
+    def test_rain_on_inactive_cells_is_not_lost(self):
+        """A rate operator wetting dry (inactive) cells conserves volume."""
+        from anuga.operators.rate_operators import Rate_operator
+
+        domain = _make_domain('as_rain')
+        domain.set_multiprocessor_mode(2)
+        domain.set_use_active_set(True)
+
+        # Rain on a dry upslope region only (x in [60, 90]) -- cells the
+        # active set is guaranteed to be skipping.
+        region = [[60., 5.], [90., 5.], [90., 95.], [60., 95.]]
+        rate = 0.01  # m/s over the polygon
+        op = Rate_operator(domain, rate=rate, polygon=region)
+
+        v0 = domain.get_water_volume()
+        t_end = 2.0
+        for _ in domain.evolve(yieldstep=1.0, finaltime=t_end):
+            pass
+        v1 = domain.get_water_volume()
+
+        added = v1 - v0
+        # The operator rains on cells whose centroids lie in the polygon, so
+        # the covered area is the sum of those cell areas, not the polygon's.
+        covered = float(np.sum(domain.areas[op.indices]))
+        expected = rate * covered * t_end
+        assert added > 0.5 * expected, \
+            f'rain lost: added {added}, expected ~{expected}'
+        assert abs(added - expected) < 1e-6 * expected, \
+            f'rain volume off: added {added}, expected {expected}'
+
+        frac, samples = domain.get_active_set_stats()
+        assert samples > 0
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/anuga/shallow_water/tests/test_active_set.py
+++ b/anuga/shallow_water/tests/test_active_set.py
@@ -133,6 +133,47 @@ class Test_active_set(unittest.TestCase):
         frac, samples = domain.get_active_set_stats()
         assert samples > 0
 
+    def test_tracers_disable_the_active_set(self):
+        """With a passive tracer registered the flag is ignored, not honoured
+        with a kernel that cannot advect the tracer.
+
+        The active path drives the scatter flux kernel directly, and only the
+        cell-based kernel carries the tracer flux.  So the run must (a) never
+        engage the active set and (b) reproduce the plain mode-2 run exactly
+        -- same kernels, same launch order, hence bit-identical -- for the
+        hydrodynamics AND the tracer.
+        """
+        def build(name):
+            d = _make_domain(name)
+            # A step in the pool so there is flow to carry the tracer (the
+            # base pool is at rest).
+            d.set_quantity('stage', lambda x, y: np.where(x < 10.0, 2.5, 2.0))
+            d.add_tracer('c', beta=1.0)
+            x = d.centroid_coordinates[:, 0]
+            d.set_tracer('c', np.where(x < 10.0, 1.0, 0.0))
+            d.set_multiprocessor_mode(2)
+            return d
+
+        ref = build('as_tr_ref')
+        self._evolve(ref)
+
+        act = build('as_tr_act')
+        act.set_use_active_set(True)
+        self._evolve(act)
+
+        assert act.get_active_set_stats() == (1.0, 0), \
+            'active set engaged on a domain with tracers'
+        for q in ('stage', 'xmomentum', 'ymomentum'):
+            a = act.quantities[q].centroid_values
+            r = ref.quantities[q].centroid_values
+            assert np.array_equal(a, r), f'{q}: max diff {np.abs(a - r).max()}'
+        a = act.get_tracer('c')
+        r = ref.get_tracer('c')
+        assert np.array_equal(a, r), f'tracer: max diff {np.abs(a - r).max()}'
+        # and the tracer actually moved, so the comparison is not vacuous
+        initial = np.where(act.centroid_coordinates[:, 0] < 10.0, 1.0, 0.0)
+        assert np.abs(a - initial).max() > 1e-3
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/parallel/use_gpu_offloading.rst
+++ b/docs/source/parallel/use_gpu_offloading.rst
@@ -286,6 +286,73 @@ Performance tips
    a 1M-triangle domain), so yieldstep granularity has minimal impact on
    throughput.
 
+6. **Active-set stepping, on mostly-dry domains.**  See below.
+
+
+Active-set stepping
+-------------------
+
+A mostly-dry domain spends most of its time integrating cells that cannot
+change: dry, and surrounded by dry.  Active-set stepping skips them.
+
+.. code-block:: python
+
+   domain.set_use_active_set(True)     # off by default
+
+On mostly-dry flood problems -- a dam break, a levee breach, a storm surge
+over dry land -- this is the largest single speedup measured for the GPU path.
+It costs nothing in accuracy: a cell is skipped only when it is dry and its
+whole two-ring neighbourhood is dry, so there is nothing to integrate.  Water
+added by rate operators is never lost either; a newly wetted cell activates on
+the next step.
+
+.. warning::
+
+   **The flag is a request, not a guarantee.**  Several configurations turn it
+   off again, and they do so with a log notice rather than an error -- so a run
+   that quietly gets no speedup looks exactly like one that does.  Check the
+   log, or ask the domain:
+
+   .. code-block:: python
+
+      frac, rebuilds = domain.get_active_set_stats()
+      # frac == 1.0 means the active set never engaged
+
+   ``get_active_set_stats()`` returns the mean active fraction and the number
+   of rebuilds, and reports ``1.0`` whenever the active set did not engage.
+
+The flag is ignored, with a notice, when:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Condition
+     - Why
+   * - compute mode is ``'legacy'``
+     - only the unified (GPU) path implements it
+   * - flow algorithm is ``DE2`` (rk3)
+     - implemented for ``DE0``/euler, ``DE1``/rk2 and ``DE_ader2``
+   * - passive tracers or sediment are registered
+     - the active path uses the single-solve scatter flux kernel, which does
+       not advect tracers; only the cell-based kernel does
+   * - the domain has riverwalls
+     - the scatter kernel does not carry them
+   * - Manning friction varies across a cell
+     - likewise
+   * - running under MPI
+     - serial domains only for now
+
+Enabling it alongside **rate operators** is allowed and correct, but widespread
+rainfall wets the whole mesh, which activates every cell and erodes the speedup
+toward zero.  That combination also logs a notice.
+
+.. note::
+
+   Active-set stepping switches the flux kernel to single-solve scatter mode.
+   Results differ from the default cell-based kernel only at floating-point
+   roundoff.
+
 
 Troubleshooting
 ----------------


### PR DESCRIPTION
Production wiring for the largest single speedup measured in the GPU optimization campaign (7.9x sustained on a mostly-dry flood event): each step classifies wet cells (stage - bed > 1e-12), grows a 2-ring halo -- the cells a step's two flux rounds can influence -- and iterates only that set through prepare, reconstruction, flux, and update.  Cells outside it are provably unchanged this step.

domain.set_use_active_set(True) requests it; the GPU/unified compute path honours it for rk2 (DE1), ader2 (DE_ader2) and euler (DE0) stepping, prepared lazily on the first evolve step: the compacted owned-edge list is built, the flux kernel switches to single-solve scatter mode (both full and active steps, so one discretization), and the classification scratch is mapped.  Serial domains only -- under MPI the flag disables itself with a warning.  rk3 (DE2) runs full steps with a notice.  The flag can be set before or after the GPU interface exists; a live GPU domain is updated in place.

Rain interplay, the part that needs to be said precisely: rate operators apply on their own index lists outside the gated step, and the next rebuild classifies on post-rain stage, so water landing on inactive cells is NEVER lost -- the new test asserts the rained volume arrives to machine precision on a domain whose rain polygon lies entirely in the inactive region.  What widespread rain does cost is the speedup (everything activates), so attaching a rate operator with the flag on -- or enabling the flag with one attached -- logs a warning saying exactly that.

domain.get_active_set_stats() returns (mean active fraction, rebuild count).  Tests: active evolution matches full mode-2 stepping (scatter vs cell-kernel roundoff tolerance), stats prove engagement, rain conservation as above.  Full fast suite green (2726 passed).