### PR TITLE
Fix the build on main (Cython 3.3.0 + Windows mingw toolchain)

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -50,7 +50,45 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash -el {0}
         run: |
-           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
+           # PIN: hold the mingw sysroot chain at build 10.
+           #
+           # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
+           # merged 2026-08-20) rebuilt these four packages as build 11. Since that
+           # day every Windows job dies in meson's compiler sanity check with
+           #   "Executables created by c compiler ... are not runnable"
+           # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
+           # all unchanged.
+           #
+           # The toolchain compiles fine; the binary crashes on startup. Running
+           # meson's check by hand on 'int main(void){return 0;}' gives:
+           #   compile: OK
+           #   *** stack smashing detected ***: terminated      (exit 127)
+           # i.e. __stack_chk_fail fires on a function with no locals -- the stack
+           # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
+           # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
+           #
+           # TEMPORARY. libwinpthread is the one that bites at RUN time: pinning
+           # only the build packages lets the wheel build succeed and then the
+           # test step dies loading the extension. Reproduced by capytaine,
+           # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
+           # chain. The COMPILERS must be held too: gcc/gxx_impl build 3 were
+           # built against the build-11 sysroot (they require libstdcxx-devel
+           # _103), so build 3 + sysroot 10 gives "Unknown compiler(s)" and
+           # build 11 is broken outright. Only gcc 2 + sysroot 10 + libwinpthread
+           # 10 is self-consistent. Remove the block once admin-requests#2297 lands:
+           #   conda-forge/m2w64-sysroot-feedstock#23
+           conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+               "gcc_impl_win-64=16.1.0=h0942c35_2" \
+               "gxx_impl_win-64=16.1.0=he3d2c83_2" \
+               "m2w64-sysroot_win-64=*=*_10" \
+               "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
+               "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
+               "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
+               "libwinpthread=*=*_10" \
+               "libstdcxx=16.1.0=hae5796f_2"
+           # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
+           # mpi.h under Library/include and is picked up by meson.build automatically.
+           conda install -c conda-forge -n anuga_env msmpi mpi4py
 
            # conda install -c conda-forge -n anuga_env compilers
            # The compilers package on windows which uses clang. We run into

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -58,7 +58,43 @@ jobs:
       - name: Install compilers (Windows)
         if: runner.os == 'Windows'
         shell: bash -el {0}
-        run: conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64
+        # PIN: hold the mingw sysroot chain at build 10.
+        #
+        # conda-forge's m2w64-sysroot-feedstock PR #21 ("finish v1 transition",
+        # merged 2026-08-20) rebuilt these four packages as build 11. Since that
+        # day every Windows job dies in meson's compiler sanity check with
+        #   "Executables created by c compiler ... are not runnable"
+        # while gcc_win-64 (16.1.0), binutils (2.46.1) and the runner image are
+        # all unchanged.
+        #
+        # The toolchain compiles fine; the binary crashes on startup. Running
+        # meson's check by hand on 'int main(void){return 0;}' gives:
+        #   compile: OK
+        #   *** stack smashing detected ***: terminated      (exit 127)
+        # i.e. __stack_chk_fail fires on a function with no locals -- the stack
+        # protector ABI between gcc 16.1.0 and the build-11 CRT does not line up.
+        # (Installing libwinpthread explicitly does NOT help; tried and ruled out.)
+        #
+        # TEMPORARY. libwinpthread is the one that bites at RUN time: pinning
+          # only the build packages lets the wheel build succeed and then the
+          # test step dies loading the extension. Reproduced by capytaine,
+          # ollama and raster3d on gcc 15 and 16 alike, so it is the sysroot
+          # chain. The COMPILERS must be held too: gcc/gxx_impl build 3 were
+          # built against the build-11 sysroot (they require libstdcxx-devel
+          # _103), so build 3 + sysroot 10 gives "Unknown compiler(s)" and
+          # build 11 is broken outright. Only gcc 2 + sysroot 10 + libwinpthread
+          # 10 is self-consistent. Remove the block once admin-requests#2297 lands:
+        #   conda-forge/m2w64-sysroot-feedstock#23
+        run: |
+          conda install -c conda-forge -n anuga_env libpython gcc_win-64 gxx_win-64 \
+              "gcc_impl_win-64=16.1.0=h0942c35_2" \
+              "gxx_impl_win-64=16.1.0=he3d2c83_2" \
+              "m2w64-sysroot_win-64=*=*_10" \
+              "mingw-w64-ucrt-x86_64-crt-git=*=*_10" \
+              "mingw-w64-ucrt-x86_64-headers-git=*=*_10" \
+              "mingw-w64-ucrt-x86_64-winpthreads-git=*=*_10" \
+              "libwinpthread=*=*_10" \
+              "libstdcxx=16.1.0=hae5796f_2"
 
       - name: Install compilers (macOS)
         if: runner.os == 'macOS'

--- a/anuga/utilities/sparse_matrix_ext.pyx
+++ b/anuga/utilities/sparse_matrix_ext.pyx
@@ -66,15 +66,15 @@ cdef int64_t _deserialise(sparse_dok* dok, dict serial_dok):
 
 	cdef int64_t num_entries, k, i, j
 	cdef double val
-	cdef list items
 	cdef list keys
 	cdef edge_key_t key
 
-	items = serial_dok.items()
-	keys = serial_dok.keys()
+	# list(...) is required: dict.keys() returns a view, and since Cython 3.3.0
+	# a dict_keys object can no longer be assigned to a `cdef list`.
+	keys = list(serial_dok.keys())
 	num_entries = len(serial_dok)
 
-	for k in xrange(num_entries):
+	for k in range(num_entries):
 
 		val = serial_dok[keys[k]]
 


### PR DESCRIPTION
`main` has not built since 23 August. Cython 3.3.0 landed on conda-forge that
day and no longer permits assigning a dict view to a `cdef list`, so every
wheel build and every `Example` job fails at:

    anuga/utilities/sparse_matrix_ext.pyx:73:25:
        Cannot assign type 'dict_items object' to 'list object'

Nothing in ANUGA changed. The breakage went unnoticed because nothing has been
pushed to `main` since 28 July, so CI had not run against it since before
Cython 3.3.0 existed. It surfaced when a sync PR against
GeoscienceAustralia/anuga_core triggered the first build of main's content in
over a month.

This matters beyond CI: the build workflows install unpinned `cython`, so
**anyone doing a source build of 3.3.10 today hits this too**.

### The fix

Cherry-pick of 64f53a6a from `develop`, where this was fixed on 23 August. In
`_deserialise()`:

* `items = serial_dok.items()` was assigned and never used — deleted rather
  than fixed.
* `keys = serial_dok.keys()` needs an explicit `list()`.
* `xrange` → `range` while here; it is a Python 2 builtin.

### Verification

Compiled the file with Cython 3.3.0 directly, before and after:

* before: two errors — line 73 `dict_items`, line 74 `dict_keys`. (CI only ever
  reported the first, since the build stops at the first error.)
* after: clean, 539 KB of C generated.

The identical change has been on `develop` since 23 August, where the full
suite is green (2728 passed) and it also builds under Cython 3.2.5, so the fix
is not version-specific.

Only this file is affected — the other `.pyx` uses of `.items()` iterate rather
than assign, which remains legal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit: the Windows toolchain

With the Cython fix alone, Linux and macOS went green but **all five Windows
jobs still failed**, now in meson's compiler sanity check:

    ld.exe: cannot find crt2.o: No such file or directory
    ld.exe: cannot find default-manifest.o: No such file or directory
    ERROR: Compiler x86_64-w64-mingw32-cc cannot compile programs.

Same root cause as #233 on develop: conda-forge's m2w64-sysroot rebuild (build
11, 2026-08-20) is not self-consistent with the compilers an unpinned install
now resolves to. `main` is unpinned, so it picked up gcc **16.2.0** against a
sysroot lacking the matching CRT objects — missing `crt2.o`, rather than
develop's "not runnable"/stack-smashing signature. Two views of one
incompatibility.

The second commit lifts develop's pin block verbatim into both workflows:
gcc/gxx 16.1.0 build 2, sysroot chain and libwinpthread at build 10, libstdcxx
16.1.0. **Only** the Windows compiler-install steps were taken — develop's
`workflow_dispatch`/TestPyPI machinery is deliberately left behind as
release-candidate tooling that does not belong on main. Both files were checked
to still parse as YAML and confirmed free of that machinery.

TEMPORARY, as on develop: remove once conda-forge admin-requests#2297 lands.

### Why this is two commits and not two PRs

`main` needs both to build at all; splitting them means merging a PR that leaves
CI red. They are separable commits for review.
