### PR TITLE
Session 57 notes and aws_run_gpu spot fallback (pre-4.0.0 tidy)

### DIFF
--- a/claude/RELEASE_PLAN_4.0.0.md
+++ b/claude/RELEASE_PLAN_4.0.0.md
@@ -158,13 +158,20 @@ receives in a wheel. Remove it when upstream fixes build 11.
       Linux/macOS arm64+x86_64/Windows, plus sdist), built via the
       `ANUGA_VERSION` override with no rc tag. Dispatch:
       `gh workflow run python-publish-pypi.yml -f publish_to=testpypi -f version=4.0.0rc1`
-- [ ] **Send the announcement** — draft ready at
-      `claude/RELEASE_4.0.0rc1_ANNOUNCEMENT.md`, addressed to Ole, Rudy, Petar
-      and Jorge, with a specific ask for each. Then 3–4 days of soak.
+- [x] **Send the announcement** — draft at
+      `claude/RELEASE_4.0.0rc1_ANNOUNCEMENT.md`, addressed to Ole, Rudy, Petar,
+      David and Jorge, with a specific ask for each. Then 3–4 days of soak.
       **Wait for Petar on Towradgi before Phase 3**: it is his case study, it is
       the evidence behind the #229 numbers in the release notes, and if he says
       the changed result looks wrong for that catchment the physics decision
       reopens rather than the wording.
+- [x] **PETAR'S VERDICT — 2026-08-30: the culvert stage reconstruction on slopes
+      is OK.** This was the Phase-3 gate. The #229 physics decision stands, the
+      release-notes delta table stands as written, and the soak is closed.
+      During the review he asked for the Collins St culvert logs and the
+      upstream approach flow; the peak was extracted from the existing 24 h run
+      (RUN_20260810_195336) as 32.4 m³/s at t=38 700 s, harness preserved in
+      `sandpit/culvert_issue/`.
 
 ### Commits after 4.0.0rc1
 
@@ -175,10 +182,24 @@ discovered at tag time:
 | commit | change | in the RC? |
 |---|---|---|
 | `32577739` | #237 — explain the missing `anuga/_version.py` instead of a bare ModuleNotFoundError | no |
+| `9c5d1215` | release-plan bookkeeping (this table) | no |
+| `13195657` | `claude/PPA_FEASIBILITY.md` for issue #25 — notes only | no |
+| `64f53a6a` | **Fix the build under Cython 3.3.0** (dict views are not lists) | **no** |
+| `9dc87f0f` | Towradgi reproduction recipe from the soak — notes only | no |
 
-Judgement: an import-time error message, no solver or API change, so it does
-not invalidate the soak. If anything else lands that *could* change results,
-rebuild the RC rather than adding a row here.
+Judgement: no solver or API change among them, so the soak stands.
+
+`64f53a6a` is the one that matters and it is worth stating plainly: Cython 3.3.0
+landed on conda-forge on 23 Aug, a few hours *after* the RC wheels were built.
+**The RC on TestPyPI therefore cannot be built from its sdist today** — the same
+defect that left `main` unbuildable 23–30 Aug and that the released 3.3.10 tag
+still carries. 4.0.0 fixes it. The difference between the soaked artifact and
+the tag is in the safe direction (broken → fixed), and it is a build-time fix
+that cannot move a simulation result, so this is a row rather than an RC rebuild.
+
+Before cutting the release PR, confirm `origin/develop` is current: as of
+2026-08-30 the local branch was 2 commits ahead (`bdbc9d8f` session notes,
+`db7230c4` aws_run_gpu.sh) and unpushed.
 
 ## Phase 3 — Ship (Day 10–12)
 

--- a/claude/SESSION_GUIDE.md
+++ b/claude/SESSION_GUIDE.md
@@ -449,7 +449,95 @@ Findings:
 
 ---
 
-## Recent session summaries (sessions 21–56)
+## Recent session summaries (sessions 21–57)
+
+**Session 57 (2026-08-21/23):** **4.0.0 release engineering** — Phases 1 and 2
+complete, RC published, and three separate upstream breakages absorbed along the
+way. None of the four defects found were in ANUGA's solver.
+
+- **Review + release plan.** An engineering review of the whole repo (published
+  as an Artifact) produced `claude/RELEASE_PLAN_4.0.0.md`: go straight to 4.0.0,
+  no 3.4 bridge, because `main` and `develop` already share the packaging
+  foundation and develop still defaults to `legacy` compute mode — so there is
+  no behavioural cliff. The scary parts of "v4" (mode-2 default flip, forcing
+  removal) are explicitly deferred to 4.1.
+- **Phase 1: nine verification gates, all green.** Full suite both builds
+  (2937 / 2948), unified-mode one-process (2947), GPU isolated runners on TWO
+  architectures (local RTX 5070 cc120 and cloud g6.xlarge Ada L4 — identical
+  counts), validation suite (120 passed), Towradgi mode-1 vs mode-2, MPI,
+  wheels, fresh conda 3.10/3.14, docs.
+- **Phase 2: notes, guide, citation, RC.** `RELEASE_NOTES.md` and
+  `UPGRADING_TO_4.0.md` written and approved; `CITATION.cff` was stale at
+  version 3.1.9 / 2022-06-26 with a 2022 commit pin. `4.0.0rc1` published to
+  **TestPyPI** — 21 artifacts, cp310–cp314, Linux/macOS(arm64+x86_64)/Windows —
+  built via the `ANUGA_VERSION` override so **no rc tag** was needed on develop.
+  Verified installable in a clean venv by the exact command the announcement
+  gives people.
+
+**Four defects found, none in the solver:**
+
+1. **`run_gpu_tests_isolated.sh` swallowed failures** — `rc=$?` after a pipeline
+   read `tail`'s status, so every failing class reported "ok" and the script
+   exited 0. This is why several "all GPU classes green" claims earlier were
+   worthless.
+2. **`anuga_run_isolated_tests` crashed against an installed anuga** — all 106
+   tests CRASH in a container. pytest emits node ids relative to ITS rootdir
+   (the common ancestor of the targets); the runner resolved them against its
+   own cwd-derived ROOTDIR. In a checkout the two coincide, which is why it was
+   invisible locally. Now resolves against target-derived base dirs and **fails
+   loudly** when an id resolves to no file.
+3. **gcc/nvc disagree on line-region triangle selection** (#231) — a culvert
+   exchange line lying exactly on mesh edges selected 32 vs 54 triangles for the
+   same script. Test made geometry-robust.
+4. **Concurrent writes to one SWW silently interleave** (#232) — `domain_name`
+   is hardcoded in the case-study scripts, so two runs corrupt each other's
+   output with a non-monotonic time axis and plausible-looking numbers. Cost a
+   full invalid gate-5 result. Found via the frame-index pattern (writer A at
+   0,2,4-8; B at 1,3).
+
+**Three upstream breakages, none our doing:**
+
+- **conda-forge mingw build 11** broke every Windows job for two days: binaries
+  compile and then abort in the stack protector (`__stack_chk_fail` on an empty
+  `main`). Took five CI cycles to converge because the ground kept moving — the
+  compilers were rebuilt mid-investigation, so a sysroot-only pin worked for a
+  day and then failed. **Only one self-consistent set exists**: gcc/gxx_impl
+  build 2 + sysroot chain build 10 + `libwinpthread` build 10 + `libstdcxx`
+  build 2. Pinning one half looks like it works (wheels build) and then every
+  test process dies silently at exit 127, because libwinpthread bites at RUN
+  time. Removal tracked in **#235**; upstream is
+  conda-forge/m2w64-sysroot-feedstock#23, where our reproduction is cited.
+- **Cython 3.3.0** broke all 20 wheel builds: `dict.items()` can no longer be
+  assigned to a `cdef list`. `sparse_matrix_ext.pyx` had one such assignment
+  that was **never used**, plus a second on the next line that would have failed
+  next. Local builds stayed green on Cython 3.2.5.
+- **Branch protection** turned out to be enforced by *rulesets*, not classic
+  protection — removing the classic setting did nothing, which only surfaced
+  when a merge was refused.
+
+**Also:** #237 (bare `ModuleNotFoundError` from an unbuilt tree) fixed;
+#238 filed (make the meshpy import lazy — Triangle's licence makes it a hard
+non-free dependency at import time); `claude/PPA_FEASIBILITY.md` written for
+#25 (Ubuntu has every dependency except meshpy and pymetis; recommend against a
+PPA since pip wheels, conda-forge and Docker now cover the original ask).
+
+**RESUME STATE (as of 2026-08-23):**
+- `develop` == `origin/develop` == `stoiver/develop` at `743b6369`. All CI green.
+- **Waiting on**: RC soak feedback from Ole, Rudy, Petar, David and Jorge; and
+  conda-forge/admin-requests#2297 landing so the Windows pin (#235) can go.
+- **Petar's verdict on Towradgi can reopen the #229 physics decision**, not just
+  the wording — it is his case study and it is the evidence behind the release
+  notes' numbers. Reproduction recipe kept in
+  `claude/RELEASE_4.0.0rc1_REPLY_PETAR.md`.
+- **RC drift** (commits after 4.0.0rc1, tracked in the release plan): #237's
+  import message and the Cython 3.3.0 fix. Both build/import level; neither can
+  change results, so the soak stands. Anything that COULD change results means
+  rebuilding the RC, not adding a row.
+- Phase 3 is short and scripted in `claude/RELEASE_PLAN_4.0.0.md`: release PR to
+  `main`, set `date-released` in CITATION.cff, annotated bare-version tag, then
+  the GitHub Release triggers PyPI / Docker / the conda-forge bot.
+- Open from this session: #231, #232, #235, #238. Closed: #189, #214, #224,
+  #225, #229, #237.
 
 **Session 56 (2026-08-20/21):** **Issue triage sweep → five issues closed**, one
 of them the long-standing well-balancedness defect in every structure operator.
@@ -502,6 +590,8 @@ of them the long-standing well-balancedness defect in every structure operator.
   comparisons need a driven head; well-balancedness tests stay short.
 - **Process:** merges to `develop` don't fire `Fixes #N` (default branch is
   `main`) — #189/#224/#225/#229 all closed by hand with commit citations.
+
+*(superseded by session 57's resume state above)*
 
 **RESUME STATE (as of 2026-08-21):**
 - `develop` == `origin/develop` == `stoiver/develop` at `7f98999a` (merge of
@@ -561,7 +651,8 @@ and hardening the installers so neither can happen quietly again.
   stages every halo through host memory in *both* paths (UCX `uct_mm` SIGSEGVs
   on device pointers). Measure halo cost before implementing real GPUDirect.
 
-*(Session 55's resume state below is superseded by session 56's above — PR #222
+*(Session 56's resume state below is superseded by session 57's above; and
+session 55's by session 56's — PR #222
 merged, and the issue landscape has moved.)*
 
 **RESUME STATE (as of 2026-08-13):**

--- a/docker/README.md
+++ b/docker/README.md
@@ -164,6 +164,18 @@ docker/aws_run_gpu.sh --region ap-southeast-2 \
   --output s3://my-bucket/anuga/out --command "python run.py" --dry-run
 ```
 
+**Use `--spot` for anything repeatable.** It tries the spot market first across
+every instance type and AZ, then falls back to on-demand automatically, so the
+worst case is the price you would have paid anyway. Spot is roughly a third of
+on-demand. The launch output labels each attempt `[spot]` or `[on-demand]` and
+the success line says which market you actually got.
+
+Note what "safe to interrupt" does and does not mean here: the entrypoint
+uploads results to S3 **after the command finishes**, so a spot reclaim loses
+that run entirely — there is no checkpointing. That is fine for short jobs
+(10–40 min) where re-running is cheap, and a bad trade for a long production
+run unless your own script checkpoints.
+
 Defaults to `g5.2xlarge` (1× A10G / cc86, 8 vCPU, 32 GB — a good balance since
 mesh-gen + DEM fitting are CPU-bound). Flags: `--dry-run`, `--instance`, `--spot`,
 `--keep` (don't self-terminate, for debugging), `--ami`, `--instance-profile`,

--- a/docker/aws_run_gpu.sh
+++ b/docker/aws_run_gpu.sh
@@ -238,11 +238,16 @@ if [ "$DRY" = "1" ]; then
   echo "================= DRY RUN — nothing launched, nothing charged ================="
   echo "-- identity --"
   aws sts get-caller-identity --output text 2>&1 | sed 's/^/  /' || echo "  (could not verify creds — is the CLI configured?)"
-  echo "-- GPU on-demand vCPU quota (needs >= this instance's vCPUs) --"
-  q=$("${AWS[@]}" service-quotas get-service-quota --service-code ec2 --quota-code L-DB2E81BA \
-        --query 'Quota.Value' --output text 2>/dev/null) \
-    && echo "  current 'Running On-Demand G and P instances' = ${q} vCPUs" \
-    || echo "  (could not read quota — check Service Quotas; new accounts start at 0, see AWS_SETUP.md step 6)"
+  echo "-- GPU vCPU quotas (each needs >= this instance's vCPUs) --"
+  for qq in "L-DB2E81BA:G/VT on-demand" "L-417A185B:P on-demand" \
+            "L-3819A6DF:G/VT spot" "L-7212CCBC:P spot"; do
+    qcode=${qq%%:*}; qname=${qq##*:}
+    q=$("${AWS[@]}" service-quotas get-service-quota --service-code ec2 --quota-code "$qcode" \
+          --query 'Quota.Value' --output text 2>/dev/null) \
+      && printf '  %-16s %s vCPUs\n' "$qname" "$q" \
+      || printf '  %-16s (could not read — see AWS_SETUP.md step 6)\n' "$qname"
+  done
+  [ "$SPOT" = "1" ] && echo "  (--spot: tries the spot quota first, then falls back to on-demand)"
   echo "-- plan --"
   printf '  %-16s %s\n' image "$IMAGE" instances "$INSTANCE_TYPES (spot=$SPOT, disk=${DISK_GB}GB)" \
     region "$REGION" ami "$AMI" profile "$INSTANCE_PROFILE" subnets "${SUBNETS[*]}" \
@@ -261,26 +266,40 @@ if [ "$DRY" = "1" ]; then
   exit 0
 fi
 
-echo ">> launching (types: $INSTANCE_TYPES; ${#SUBNETS[@]} AZ subnet(s))..."
-IID="" ; USED_TYPE="" ; USED_SUBNET=""
-for itype in ${INSTANCE_TYPES//,/ }; do
-  for subnet in "${SUBNETS[@]}"; do
-    ATTEMPT=( "${RUN_ARGS[@]}" --instance-type "$itype" )
-    [ "$subnet" != "<none>" ] && ATTEMPT+=( --subnet-id "$subnet" )
-    if out=$("${AWS[@]}" ec2 run-instances "${ATTEMPT[@]}" \
-               --query 'Instances[0].InstanceId' --output text 2>&1); then
-      IID="$out" ; USED_TYPE="$itype" ; USED_SUBNET="$subnet" ; break 2
-    elif echo "$out" | grep -qE "InsufficientInstanceCapacity|Unsupported|InvalidParameterValue"; then
-      echo "   $itype${subnet:+ / $subnet}: unavailable — trying next"
-      continue
-    else
-      die "run-instances failed: $out"
-    fi
-  done
-done
-[ -z "$IID" ] && die "no capacity for any of [$INSTANCE_TYPES] across ${#SUBNETS[@]} AZ(s); try --spot, --instance <other type>, another --region, or retry later"
+# With --spot we try the spot market first and fall back to on-demand, rather
+# than failing outright: spot is much cheaper but its capacity pools are
+# separate and often empty, and for these short jobs an on-demand run is far
+# better than no run. Without --spot only on-demand is attempted.
+MARKETS=("on-demand")
+[ "$SPOT" = "1" ] && MARKETS=("spot" "on-demand")
 
-SPOT_LABEL="" ; [ "$SPOT" = "1" ] && SPOT_LABEL=", spot"   # ${SPOT:+} misfires: "0" is non-empty
+echo ">> launching (types: $INSTANCE_TYPES; ${#SUBNETS[@]} AZ subnet(s); markets: ${MARKETS[*]})..."
+IID="" ; USED_TYPE="" ; USED_SUBNET="" ; USED_MARKET=""
+for market in "${MARKETS[@]}"; do
+  MARKET_ARGS=()
+  [ "$market" = "spot" ] && MARKET_ARGS=(--instance-market-options "MarketType=spot")
+  for itype in ${INSTANCE_TYPES//,/ }; do
+    for subnet in "${SUBNETS[@]}"; do
+      ATTEMPT=( "${RUN_ARGS[@]}" "${MARKET_ARGS[@]}" --instance-type "$itype" )
+      [ "$subnet" != "<none>" ] && ATTEMPT+=( --subnet-id "$subnet" )
+      if out=$("${AWS[@]}" ec2 run-instances "${ATTEMPT[@]}" \
+                 --query 'Instances[0].InstanceId' --output text 2>&1); then
+        IID="$out" ; USED_TYPE="$itype" ; USED_SUBNET="$subnet" ; USED_MARKET="$market" ; break 3
+      elif echo "$out" | grep -qE "InsufficientInstanceCapacity|Unsupported|InvalidParameterValue|MaxSpotInstanceCountExceeded"; then
+        echo "   $itype${subnet:+ / $subnet} [$market]: unavailable — trying next"
+        continue
+      else
+        die "run-instances failed: $out"
+      fi
+    done
+  done
+  [ "$market" = "spot" ] && echo ">> no spot capacity/quota — falling back to on-demand"
+done
+[ -z "$IID" ] && die "no capacity for any of [$INSTANCE_TYPES] across ${#SUBNETS[@]} AZ(s) in ${MARKETS[*]}; try --instance <other type>, another --region, or retry later"
+
+# Report the market we ACTUALLY got, not the one requested: with --spot the
+# launch may have fallen back to on-demand, and the price difference matters.
+SPOT_LABEL="" ; [ "$USED_MARKET" = "spot" ] && SPOT_LABEL=", spot"
 echo ">> instance $IID launched ($USED_TYPE${SPOT_LABEL}${USED_SUBNET:+, $USED_SUBNET})."
 echo ">> it will run: ${COMMAND}"
 echo ">> results ->   ${OUTPUT_S3}    (+ anuga-run.log with timing)"


### PR DESCRIPTION
Two commits that were sitting on the fork unpushed to `develop`, both
documentation or tooling — no solver or API change. Clearing them so the
4.0.0 release PR is cut from a current `develop`.

| commit | change |
|---|---|
| `bdbc9d8f` | Session 57 notes: 4.0.0 phases 1–2, RC published, three upstream breakages |
| `db7230c4` | `aws_run_gpu.sh`: `--spot` now falls back to on-demand |

Files: `claude/SESSION_GUIDE.md`, `docker/README.md`, `docker/aws_run_gpu.sh`.

Context: this is step 1 of Phase 3 in `claude/RELEASE_PLAN_4.0.0.md`. The soak
closed on 2026-08-30 — Petar confirmed the culvert stage reconstruction on
slopes is correct, which was the stated Phase-3 gate. A test merge of
`develop` into `main` is clean (no conflicts), including across the two
workflow files and `sparse_matrix_ext.pyx`, where `main` carries a cherry-pick
of the same Cython fix under a different SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
