### PR TITLE
CI: nightly scheduled build of main and develop

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -19,6 +19,20 @@ on:
       - jorge/unify_again
       - feat/sc26
 
+  # Callable so the scheduled watchdog (scheduled-build.yml) reuses this exact
+  # recipe instead of keeping a second copy of the build steps. The Windows
+  # toolchain pin already lives in two workflows; a third copy would drift.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to check out. Empty = the triggering ref.'
+        type: string
+        default: ''
+      python_versions:
+        description: 'JSON list of Python versions to run.'
+        type: string
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+
 jobs:
   test_conda:
     name: Example (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -30,12 +44,13 @@ jobs:
 
         # 2026/04/05: dropped 3.8 -- numpy>=2.0.0 (required by anuga) requires Python>=3.9
         # 2026/04/06: dropped 3.9 -- X | Y union type syntax requires Python>=3.10
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # fetch full history so git describe can find tags
+          ref: ${{ inputs.ref }}   # empty outside workflow_call = triggering ref
       - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest      # Installs Miniforge instead of Miniconda
@@ -153,8 +168,8 @@ jobs:
           export OMP_NUM_THREADS=1
           pytest -rs --pyargs anuga --run-fast
 
-      - name: Test package (full suite — push to main/develop)
-        if: github.event_name == 'push'
+      - name: Test package (full suite — push to main/develop, and scheduled)
+        if: github.event_name != 'pull_request'
         shell: bash -el {0}
         run: |
           conda activate anuga_env

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,0 +1,98 @@
+# Scheduled watchdog for the release branches.
+#
+# Why this exists: between 2026-08-23 and 2026-08-30 `main` could not be built
+# on any platform, and nobody noticed for a week. Two upstream changes broke it
+# — Cython 3.3.0 (dict views can no longer be assigned to a `cdef list`) and a
+# conda-forge mingw sysroot rebuild — and both had already been fixed on
+# `develop`. Nothing reported it because `main` had had no push since 28 July
+# and CI only ran on push/PR, so the branch was never rebuilt against a moving
+# toolchain. It surfaced by accident, via a mirror-sync PR.
+#
+# Neither break was in ANUGA's code. That is the point: the things most likely
+# to break a quiet release branch come from outside it, so the branch has to be
+# rebuilt on a clock rather than on our commits.
+#
+# This reuses conda-setup.yml via workflow_call rather than copying its build
+# steps, so there is one recipe to maintain.
+
+name: Scheduled build
+
+on:
+  schedule:
+    # 20:00 UTC daily = 06:00 next day in Sydney, so a failure is waiting at the
+    # start of the working day rather than discovered a week later.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+    inputs:
+      python_versions:
+        description: 'JSON list of Python versions (default: oldest + newest)'
+        type: string
+        default: '["3.10", "3.14"]'
+
+permissions:
+  contents: read
+
+jobs:
+  # The matrix is deliberately trimmed to the oldest and newest supported
+  # Python, across all three OSes. Both historic breakages were platform- or
+  # toolchain-shaped rather than Python-version-shaped, so OS coverage is what
+  # earns its keep here; push/PR runs still cover every version.
+  main:
+    name: main
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: main
+      python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
+
+  develop:
+    name: develop
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: develop
+      python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
+
+  # A red run in the Actions tab is what already failed us — nobody was looking.
+  # Turn a failure into an issue, and keep updating that one issue rather than
+  # filing a new one every night.
+  report:
+    name: Report failure
+    needs: [main, develop]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAIN_RESULT: ${{ needs.main.result }}
+          DEVELOP_RESULT: ${{ needs.develop.result }}
+        run: |
+          set -euo pipefail
+          TITLE="Scheduled build failing"
+          BODY=$(printf '%s\n' \
+            "The nightly build failed." \
+            "" \
+            "| branch | result |" \
+            "|---|---|" \
+            "| \`main\` | \`${MAIN_RESULT}\` |" \
+            "| \`develop\` | \`${DEVELOP_RESULT}\` |" \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "A failure here usually means something outside ANUGA moved — a new" \
+            "Cython, a rebuilt conda-forge toolchain, a runner image change —" \
+            "rather than a commit of ours, since these branches may have had no" \
+            "pushes at all. Check the build step before the test step.")
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+                       --search "\"$TITLE\" in:title" --json number \
+                       --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+            echo "commented on #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+          fi


### PR DESCRIPTION
Closes the R1/R2 gap that this week demonstrated at our own expense: `main` was
unbuildable on every platform for seven days and nothing noticed, because CI
only runs on push/PR and `main` had had no push since 28 July.

Both breakages — Cython 3.3.0, and the conda-forge mingw sysroot rebuild — came
from **outside** ANUGA, and both were already fixed on `develop`. That is the
argument for a clock-based build: what breaks a quiet release branch does not
arrive with our commits. The released 3.3.10 tag still carries both defects.

### What it does

Nightly at 20:00 UTC (06:00 Sydney, so a failure is waiting at the start of the
day) it builds and runs the full suite on **`main` and `develop`**, across
Linux/macOS/Windows on the oldest and newest supported Python.

The trimmed matrix is deliberate: both historic breakages were platform- or
toolchain-shaped, not Python-version-shaped, so OS coverage is what earns its
keep. Push and PR runs still cover all five versions. `workflow_dispatch` takes
a `python_versions` input if you want a wider sweep on demand.

### No second copy of the build steps

`conda-setup.yml` gains `workflow_call` with `ref` and `python_versions` inputs,
and the scheduler calls it. The Windows toolchain pin already lives in two
workflows; a third copy would drift — which is the same class of problem this PR
exists to catch. Both inputs are empty/defaulted outside `workflow_call`, so
push and PR behaviour is unchanged.

### One real bug found while wiring it up

The full-suite step was gated on `github.event_name == 'push'`. A scheduled run
would have built the code and then run **no tests at all** — passing green and
proving nothing. It is now `!= 'pull_request'`, so push and schedule both run
the full suite and PRs keep the fast one.

### Failure is made visible

A red run in the Actions tab is exactly what already failed us. On failure the
workflow opens a tracking issue, or comments on the existing one, so it does not
file a fresh issue every night.

### To actually take effect

Scheduled workflows only run from the **default branch**, and `uses: ./…`
resolves against the caller's ref — so both files must reach `main` before the
schedule does anything. After this merges to `develop` it needs cherry-picking
to `main` (same as the Cython fix), or it sits dormant until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
