### PR TITLE
Bring the scheduled build and Docker fixes to main

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -19,6 +19,20 @@ on:
       - jorge/unify_again
       - feat/sc26
 
+  # Callable so the scheduled watchdog (scheduled-build.yml) reuses this exact
+  # recipe instead of keeping a second copy of the build steps. The Windows
+  # toolchain pin already lives in two workflows; a third copy would drift.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to check out. Empty = the triggering ref.'
+        type: string
+        default: ''
+      python_versions:
+        description: 'JSON list of Python versions to run.'
+        type: string
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+
 jobs:
   test_conda:
     name: Example (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -30,12 +44,13 @@ jobs:
 
         # 2026/04/05: dropped 3.8 -- numpy>=2.0.0 (required by anuga) requires Python>=3.9
         # 2026/04/06: dropped 3.9 -- X | Y union type syntax requires Python>=3.10
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # fetch full history so git describe can find tags
+          ref: ${{ inputs.ref }}   # empty outside workflow_call = triggering ref
       - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest      # Installs Miniforge instead of Miniconda
@@ -153,8 +168,8 @@ jobs:
           export OMP_NUM_THREADS=1
           pytest -rs --pyargs anuga --run-fast
 
-      - name: Test package (full suite — push to main/develop)
-        if: github.event_name == 'push'
+      - name: Test package (full suite — push to main/develop, and scheduled)
+        if: github.event_name != 'pull_request'
         shell: bash -el {0}
         run: |
           conda activate anuga_env

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,19 +1,34 @@
 # Build and publish ANUGA container images to GitHub Container Registry (GHCR).
 #
-# - CPU image: built + pushed automatically on a GitHub Release (and on demand).
-# - GPU image: opt-in only (workflow_dispatch with build_gpu=true), because the
-#   NVHPC base is ~15 GB and the multi-arch build is heavy for free runners —
-#   it may need disk cleanup and/or a larger runner. It is never in the release
-#   critical path.
+# BOTH images are manual (workflow_dispatch). The CPU image used to build
+# automatically on a GitHub Release, but that races the PyPI upload: both fire
+# on `release: published`, and the CPU image installs ANUGA *from PyPI*, so the
+# new version is not there yet. On the 4.0.0 release this produced an image
+# tagged 4.0.0-cpu containing anuga 3.3.10; only an unrelated build failure
+# stopped it being pushed. Run this workflow after PyPI has the release, and
+# pass anuga_version so the pin is explicit and verified inside the build.
+#
+# - GPU image: additionally opt-in via build_gpu=true, because the NVHPC base
+#   is ~15 GB and the multi-arch build is heavy for free runners.
+#
+# See issue #248.
 #
 # Images: ghcr.io/<owner>/anuga:<tag>-cpu  and  ...:<tag>-gpu
 name: Build and Publish Docker images
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
+      anuga_version:
+        description: 'ANUGA version to install from PyPI, e.g. 4.0.0. Empty = whatever PyPI serves as latest (not recommended for a release).'
+        default: ''
+      image_tag:
+        description: 'Tag for the image, e.g. 4.0.0. Empty = derive from the ref.'
+        default: ''
+      mark_latest:
+        description: 'Also tag this image as latest'
+        type: boolean
+        default: false
       build_gpu:
         description: 'Also build & push the (large) GPU image'
         type: boolean
@@ -55,7 +70,18 @@ jobs:
             suffix=-cpu,onlatest=true
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.mark_latest }}
+
+      - name: Refuse to build a release image before PyPI has that version
+        if: inputs.anuga_version != ''
+        run: |
+          v='${{ inputs.anuga_version }}'
+          if ! curl -sf "https://pypi.org/pypi/anuga/$v/json" > /dev/null; then
+            echo "::error::anuga $v is not on PyPI yet - wait for the publish workflow to finish."
+            exit 1
+          fi
+          echo "anuga $v is on PyPI, proceeding."
 
       - name: Build & push CPU image
         uses: docker/build-push-action@v6
@@ -63,12 +89,14 @@ jobs:
           context: .
           file: docker/Dockerfile.cpu
           push: true
+          build-args: |
+            ANUGA_VERSION=${{ inputs.anuga_version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
   gpu:
     name: GPU image (opt-in)
-    if: github.event_name == 'workflow_dispatch' && inputs.build_gpu
+    if: inputs.build_gpu
     runs-on: ubuntu-latest
     steps:
       - name: Free up disk space (NVHPC base is large)

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,0 +1,98 @@
+# Scheduled watchdog for the release branches.
+#
+# Why this exists: between 2026-08-23 and 2026-08-30 `main` could not be built
+# on any platform, and nobody noticed for a week. Two upstream changes broke it
+# — Cython 3.3.0 (dict views can no longer be assigned to a `cdef list`) and a
+# conda-forge mingw sysroot rebuild — and both had already been fixed on
+# `develop`. Nothing reported it because `main` had had no push since 28 July
+# and CI only ran on push/PR, so the branch was never rebuilt against a moving
+# toolchain. It surfaced by accident, via a mirror-sync PR.
+#
+# Neither break was in ANUGA's code. That is the point: the things most likely
+# to break a quiet release branch come from outside it, so the branch has to be
+# rebuilt on a clock rather than on our commits.
+#
+# This reuses conda-setup.yml via workflow_call rather than copying its build
+# steps, so there is one recipe to maintain.
+
+name: Scheduled build
+
+on:
+  schedule:
+    # 20:00 UTC daily = 06:00 next day in Sydney, so a failure is waiting at the
+    # start of the working day rather than discovered a week later.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+    inputs:
+      python_versions:
+        description: 'JSON list of Python versions (default: oldest + newest)'
+        type: string
+        default: '["3.10", "3.14"]'
+
+permissions:
+  contents: read
+
+jobs:
+  # The matrix is deliberately trimmed to the oldest and newest supported
+  # Python, across all three OSes. Both historic breakages were platform- or
+  # toolchain-shaped rather than Python-version-shaped, so OS coverage is what
+  # earns its keep here; push/PR runs still cover every version.
+  main:
+    name: main
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: main
+      python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
+
+  develop:
+    name: develop
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: develop
+      python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
+
+  # A red run in the Actions tab is what already failed us — nobody was looking.
+  # Turn a failure into an issue, and keep updating that one issue rather than
+  # filing a new one every night.
+  report:
+    name: Report failure
+    needs: [main, develop]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAIN_RESULT: ${{ needs.main.result }}
+          DEVELOP_RESULT: ${{ needs.develop.result }}
+        run: |
+          set -euo pipefail
+          TITLE="Scheduled build failing"
+          BODY=$(printf '%s\n' \
+            "The nightly build failed." \
+            "" \
+            "| branch | result |" \
+            "|---|---|" \
+            "| \`main\` | \`${MAIN_RESULT}\` |" \
+            "| \`develop\` | \`${DEVELOP_RESULT}\` |" \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "A failure here usually means something outside ANUGA moved — a new" \
+            "Cython, a rebuilt conda-forge toolchain, a runner image change —" \
+            "rather than a commit of ours, since these branches may have had no" \
+            "pushes at all. Check the build step before the test step.")
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+                       --search "\"$TITLE\" in:title" --json number \
+                       --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+            echo "commented on #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY"
+          fi

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -14,11 +14,14 @@ FROM python:3.12-slim
 
 # Empty = latest release; pin with e.g. --build-arg ANUGA_VERSION=3.3.10
 ARG ANUGA_VERSION=
+ENV ANUGA_VERSION=${ANUGA_VERSION}
 
 # libgomp1: OpenMP runtime the manylinux extension links against.
 # ca-certificates: TLS for pip/aws.
+# libexpat1: fiona's wheel dlopens libexpat.so.1 at import; python:*-slim does
+#   not ship it, so `import fiona` dies with ImportError without this.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgomp1 ca-certificates && \
+        libgomp1 ca-certificates libexpat1 && \
     rm -rf /var/lib/apt/lists/*
 
 # anuga[data] pulls the optional geodata stack (rasterio/fiona/shapely/xarray/
@@ -27,7 +30,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # import in a degraded mode and raise AttributeError/ImportError.
 RUN pip install --no-cache-dir -U pip && \
     pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
-    python -c "import anuga, fiona, rasterio, shapely; print('ANUGA', anuga.__version__, '+ geodata imported OK')"
+    python -c "import anuga, fiona, rasterio, shapely; print('ANUGA', anuga.__version__, '+ geodata imported OK')" && \
+    python -c "import os,sys,anuga; w=os.environ.get('ANUGA_VERSION','') or None; \
+sys.exit(0) if (w is None or anuga.__version__==w) else sys.exit('PINNED %s but installed %s' % (w, anuga.__version__))"
 
 COPY docker/anuga-entrypoint.sh /usr/local/bin/anuga-entrypoint
 RUN chmod +x /usr/local/bin/anuga-entrypoint


### PR DESCRIPTION
Brings the two post-4.0.0 fixes to `main`. `develop` is ahead of `main` by
exactly these two PRs and nothing else, so this is a straight merge rather than
cherry-picks. A test merge is clean.

| PR | change |
|---|---|
| #250 | nightly scheduled build of `main` and `develop` (issue: the week-long silent breakage) |
| #249 | Docker CPU image: pin the version, stop racing the PyPI upload, add `libexpat1` (#248) |

### Why these need to be on `main` specifically, not just `develop`

**Both are inert until they land here.**

* Scheduled workflows only run from the **default branch**, and #250's
  `uses: ./.github/workflows/conda-setup.yml` resolves against the caller's
  ref. Until `scheduled-build.yml` *and* the `workflow_call` version of
  `conda-setup.yml` are both on `main`, the nightly build does not exist. That
  is precisely the window it is meant to protect: `main` is now a released
  branch that nothing watches.
* `workflow_dispatch` also resolves from the default branch, so #249's new
  `anuga_version` / `image_tag` / `mark_latest` inputs are not selectable until
  they are here either — which blocks building the 4.0.0 CPU image at all.

### Verification

A test merge into `main` is conflict-free and the merged tree keeps all of:
`CITATION.cff` at `version: 4.0.0` / `date-released: '2026-08-30'`,
`scheduled-build.yml`, `workflow_call` in `conda-setup.yml`, and `libexpat1` in
`docker/Dockerfile.cpu`.

### Note

`main` still holds five commits `develop` does not — the CITATION release
commit, the #244 pair (Cython + mingw pin, made directly on `main` while it was
broken), and the two release merges. Worth merging `main` back into `develop`
at some point so the two lines do not keep diverging; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
