### PR TITLE
docker: publish MPI-capable CPU and GPU images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,17 +101,28 @@ jobs:
     steps:
       - name: Free up disk space (NVHPC base is large)
         run: |
+          echo "before:"; df -h / | tail -1
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
-          df -h /
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift /usr/local/share/powershell || true
+          sudo docker image prune --all --force || true
+          echo "after:"; df -h / | tail -1
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history + tags so _git_version.py can describe
 
-      - name: Compute ANUGA version (PEP 440, from git)
+      - name: Compute ANUGA version (PEP 440)
         id: ver
-        run: echo "v=$(python _git_version.py)" >> "$GITHUB_OUTPUT"
+        # Prefer the explicit input: `git describe` on a branch a few commits
+        # past the tag yields 4.0.0.devN+gSHA, which reads as a pre-release even
+        # when the solver source is identical to the tag.
+        run: |
+          v='${{ inputs.anuga_version }}'
+          [ -n "$v" ] || v=$(python _git_version.py)
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "building ANUGA $v"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -126,15 +137,18 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           flavor: |
-            suffix=-gpu,onlatest=false
+            suffix=-gpu,onlatest=true
           tags: |
             # branch name (e.g. develop-gpu) — the pre-release channel
             type=ref,event=branch
             # immutable commit tag (e.g. sha-abc1234-gpu)
             type=sha
-            # release version (e.g. 4.0.0-gpu) and latest-gpu, only on a Release
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # release version (e.g. 4.0.0-gpu) and latest-gpu, both explicit.
+            # These were previously gated on `github.event_name == 'release'`,
+            # which has been permanently false since the release trigger was
+            # removed — so latest-gpu was unreachable.
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
       - name: Build & push GPU image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,10 +36,10 @@ on:
       gpu_dockerfile:
         description: 'Which GPU image to build. slim = multi-stage on a CUDA base (same cc70..cc120 coverage, a fraction of the size); mpi = slim plus CUDA-aware HPC-X for multi-GPU; gpu = the original single-stage devel image.'
         type: choice
-        default: 'docker/Dockerfile.gpu.slim'
+        default: 'docker/Dockerfile.gpu.mpi'
         options:
-          - docker/Dockerfile.gpu.slim
           - docker/Dockerfile.gpu.mpi
+          - docker/Dockerfile.gpu.slim
           - docker/Dockerfile.gpu
       nvhpc_tag:
         description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
@@ -163,7 +163,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.slim' }}
+          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.mpi' }}
           push: true
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,14 @@ on:
         description: 'Also build & push the (large) GPU image'
         type: boolean
         default: false
+      gpu_dockerfile:
+        description: 'Which GPU image to build. slim = multi-stage on a CUDA base (same cc70..cc120 coverage, a fraction of the size); mpi = slim plus CUDA-aware HPC-X for multi-GPU; gpu = the original single-stage devel image.'
+        type: choice
+        default: 'docker/Dockerfile.gpu.slim'
+        options:
+          - docker/Dockerfile.gpu.slim
+          - docker/Dockerfile.gpu.mpi
+          - docker/Dockerfile.gpu
       nvhpc_tag:
         description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
         default: '25.9-devel-cuda_multi-ubuntu24.04'
@@ -151,10 +159,11 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
       - name: Build & push GPU image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile.gpu
+          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.slim' }}
           push: true
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -20,17 +20,26 @@ ENV ANUGA_VERSION=${ANUGA_VERSION}
 # ca-certificates: TLS for pip/aws.
 # libexpat1: fiona's wheel dlopens libexpat.so.1 at import; python:*-slim does
 #   not ship it, so `import fiona` dies with ImportError without this.
+# openmpi-bin: mpirun, plus libopenmpi40 as a dependency. The mpi4py wheel does
+#   NOT bundle an MPI -- it dlopens libmpi.so.40 / libmpi.so.12 at import and
+#   fails without a system one, so this is required, not optional.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgomp1 ca-certificates libexpat1 && \
+        libgomp1 ca-certificates libexpat1 openmpi-bin && \
     rm -rf /var/lib/apt/lists/*
 
 # anuga[data] pulls the optional geodata stack (rasterio/fiona/shapely/xarray/
 # pandas/openpyxl) that case-study scripts need — e.g. spatialInputUtil's
 # readListOfRiverWalls, shapefile/raster/polygon-CSV I/O — which otherwise
 # import in a degraded mode and raise AttributeError/ImportError.
+# mpi4py makes anuga.parallel real: without it ANUGA prints "Could not import
+# mpi4py - defining sequential interface" and silently runs one rank. pymetis
+# (the partitioner) already arrives with anuga[data]. Measured cost of MPI in
+# this image: +0.39 GB on disk, ~+0.1 GB on a pull -- small enough that shipping
+# one MPI-capable image beats maintaining two.
 RUN pip install --no-cache-dir -U pip && \
-    pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
+    pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" mpi4py awscli && \
     python -c "import anuga, fiona, rasterio, shapely; print('ANUGA', anuga.__version__, '+ geodata imported OK')" && \
+    python -c "from mpi4py import MPI; print('MPI', MPI.get_vendor(), 'OK')" && \
     python -c "import os,sys,anuga; w=os.environ.get('ANUGA_VERSION','') or None; \
 sys.exit(0) if (w is None or anuga.__version__==w) else sys.exit('PINNED %s but installed %s' % (w, anuga.__version__))"
 

--- a/docker/Dockerfile.gpu.mpi
+++ b/docker/Dockerfile.gpu.mpi
@@ -6,11 +6,24 @@
 #     buffers, no host staging),
 #   * the HPC-X OpenMPI + UCX runtime copied into the runtime stage.
 #
-# Kept SEPARATE from anuga:gpu-slim on purpose.  The MPI runtime adds several
-# hundred MB (ompi ~235 MB + ucx ~285 MB before trimming) and the slim image
-# exists to keep AWS cold-start pulls fast.  Single-GPU instances (g4dn.xlarge,
-# g6.xlarge) cannot use multi-rank GPU anyway — mode 2 requires one rank per
-# GPU — so use gpu-slim there and this image on multi-GPU nodes.
+# This is the PUBLISHED GPU image (ghcr.io …:<version>-gpu).
+#
+# It was originally kept separate from anuga:gpu-slim because the MPI runtime
+# "adds several hundred MB" — ompi ~235 MB + ucx ~285 MB *before* the trimming
+# below.  Measured after trimming, on a full multi-arch build (2026-08-30):
+#
+#     gpu.slim   0.46 GB compressed / 2.12 GB on disk
+#     gpu.mpi    0.60 GB compressed / 2.66 GB on disk
+#
+# i.e. MPI costs 0.14 GB on a pull, against 15.94 GB for the old single-stage
+# devel image.  At that price the split is not worth its complexity: MPI-capable
+# is a superset, nothing about it degrades single-GPU use, and one image is
+# simpler to build, publish and document.  gpu.slim remains for anyone who wants
+# the smallest possible pull for a large single-GPU fleet.
+#
+# Note single-GPU instances (g4dn.xlarge, g6.xlarge) still cannot use multi-rank
+# GPU — mode 2 requires one rank per GPU — they simply run this image as one
+# rank.
 #
 # MPI comes from the NVHPC base's bundled HPC-X, which is built CUDA-aware
 # (ompi_info: mpi_built_with_cuda_support:value:true).  There is one HPC-X per


### PR DESCRIPTION
Started as a fix to the GPU job's tagging; the measurements turned it into a change of what we publish.

## Measured, not estimated

Full multi-arch builds on fork CI, then run on an RTX 5070:

| image | pull (compressed) | on disk | build |
|---|---|---|---|
| `Dockerfile.gpu` (what CI published) | **15.94 GB** | ~50 GB | 21 min |
| `Dockerfile.gpu.slim` | 0.46 GB | 2.12 GB | 13 min |
| `Dockerfile.gpu.mpi` | **0.60 GB** | 2.66 GB | 15 min |
| `Dockerfile.cpu` without mpi | 0.29 GB | 1.33 GB | ~1 min |
| `Dockerfile.cpu` with mpi | — | **1.72 GB** | ~1 min |

## Two things the numbers settle

**The published GPU image was the worst of the three.** `Dockerfile.gpu` ships the entire NVHPC devel SDK — two layers of 9.2 GB and 6.2 GB, against 0.25 GB of actual ANUGA. The slim multi-stage build has *identical* `cc70..cc120` coverage (same `GPU_ARCH` default), is 35× smaller to pull, and builds **faster** because it never pushes those layers.

**MPI is cheap.** `gpu.mpi`'s own header argued for keeping MPI separate because it "adds several hundred MB" — but that figure was ompi+ucx *before* the trimming it then performs. Measured after trimming: **0.14 GB compressed**. On CPU, +0.39 GB on disk. At that price two image lines aren't worth maintaining: MPI-capable is a superset and nothing about it degrades single-rank use. Header corrected in-place with the measured figures.

## Changes

* GPU job defaults to `Dockerfile.gpu.mpi`; a `gpu_dockerfile` input can select slim or the original for comparison.
* `Dockerfile.cpu` gains `openmpi-bin` + `mpi4py`. The mpi4py wheel does **not** bundle an MPI — it dlopens `libmpi.so.40`/`.12` and fails without a system one — so the apt package is required, not optional. `pymetis` already arrived via `anuga[data]`.
* Fixes the tagging faults that made a release GPU image impossible: version from `git describe` (`4.0.0.devN+gSHA`), `type=ref,event=tag` producing nothing on a branch dispatch, and `latest` gated on `github.event_name == 'release'` — permanently false since #249 removed that trigger.

## Verified on hardware, not just built

```
gpu.slim   mode 'unified', arrays mapped to device 0, offload evolve correct
gpu.mpi    gpu_has_mpi True; mpirun -np 2 -> rank 0 of 2, rank 1 of 2
cpu+mpi    Open MPI 5.0.7; mpirun -np 2 -> both ranks; sequential unchanged
```

**Before this, `anuga.parallel` in the CPU image silently ran a single rank** — `mpi4py` was absent, so ANUGA fell back to its sequential interface without an error.

The GPU job had also never once run in CI; every GPU image so far was hand-built. Proof it works on a free runner: https://github.com/stoiver/anuga_core/actions/runs/33305477765

## Follow-up

`docker/README.md` still says CI lacks a big enough runner and tells people to hand-build. #252 is already touching that file, so the correction belongs there or after — not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)