### PR TITLE
CI: run all five Python versions on Windows in the scheduled build

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -32,6 +32,10 @@ on:
         description: 'JSON list of Python versions to run.'
         type: string
         default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      os_list:
+        description: 'JSON list of runners. Lets a caller cover one OS more deeply than the others.'
+        type: string
+        default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
 
 jobs:
   test_conda:
@@ -40,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ${{ fromJSON(inputs.os_list || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
 
         # 2026/04/05: dropped 3.8 -- numpy>=2.0.0 (required by anuga) requires Python>=3.9
         # 2026/04/06: dropped 3.9 -- X | Y union type syntax requires Python>=3.10

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -33,10 +33,15 @@ permissions:
   contents: read
 
 jobs:
-  # The matrix is deliberately trimmed to the oldest and newest supported
-  # Python, across all three OSes. Both historic breakages were platform- or
-  # toolchain-shaped rather than Python-version-shaped, so OS coverage is what
-  # earns its keep here; push/PR runs still cover every version.
+  # Linux and macOS run the oldest and newest supported Python: their historic
+  # breakages were toolchain-shaped rather than version-shaped, so OS coverage
+  # is what earns its keep and push/PR runs still cover every version.
+  #
+  # Windows runs ALL FIVE. That is not symmetry for its own sake -- on
+  # 2026-08-31 Python 3.11/3.12/3.13 began segfaulting at pytest startup on
+  # Windows while 3.10 and 3.14 stayed green (#255), so this watchdog ran green
+  # through a real breakage. Windows is where version-specific faults actually
+  # appear here, and the trimmed matrix had a hole exactly in the middle.
   main:
     name: main
     uses: ./.github/workflows/conda-setup.yml
@@ -51,12 +56,29 @@ jobs:
       ref: develop
       python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
 
+  # The versions the jobs above skip, on Windows only -- see #255.
+  main-windows:
+    name: main (windows, mid versions)
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: main
+      python_versions: '["3.11", "3.12", "3.13"]'
+      os_list: '["windows-latest"]'
+
+  develop-windows:
+    name: develop (windows, mid versions)
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: develop
+      python_versions: '["3.11", "3.12", "3.13"]'
+      os_list: '["windows-latest"]'
+
   # A red run in the Actions tab is what already failed us — nobody was looking.
   # Turn a failure into an issue, and keep updating that one issue rather than
   # filing a new one every night.
   report:
     name: Report failure
-    needs: [main, develop]
+    needs: [main, develop, main-windows, develop-windows]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
@@ -70,6 +92,8 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MAIN_RESULT: ${{ needs.main.result }}
           DEVELOP_RESULT: ${{ needs.develop.result }}
+          MAIN_WIN_RESULT: ${{ needs['main-windows'].result }}
+          DEVELOP_WIN_RESULT: ${{ needs['develop-windows'].result }}
         run: |
           set -euo pipefail
           TITLE="Scheduled build failing"
@@ -80,6 +104,8 @@ jobs:
             "|---|---|" \
             "| \`main\` | \`${MAIN_RESULT}\` |" \
             "| \`develop\` | \`${DEVELOP_RESULT}\` |" \
+            "| \`main\` (windows 3.11-3.13) | \`${MAIN_WIN_RESULT}\` |" \
+            "| \`develop\` (windows 3.11-3.13) | \`${DEVELOP_WIN_RESULT}\` |" \
             "" \
             "Run: ${RUN_URL}" \
             "" \


### PR DESCRIPTION
Closes the blind spot found by #255.

**The watchdog ran green on the night of 2026-08-30 while Windows was broken.** Its matrix covers Python 3.10 and 3.14; the breakage hits 3.11, 3.12 and 3.13 — exactly the versions it does not test. A watchdog with a hole in the middle of its range is worse than none, because it actively reports green over a red branch.

The original trim wasn't unreasonable: the two breakages known when I wrote it (Cython 3.3.0, the mingw sysroot) were both toolchain-shaped and hit every version, so OS coverage was what earned its keep. #255 is the counterexample — on Windows the faults here are version-specific.

**Change:** Windows runs all five versions; Linux and macOS keep the oldest+newest trim, where the original reasoning still holds and push/PR runs cover the rest.

Implemented by giving `conda-setup.yml` an `os_list` input alongside `python_versions`, so a caller can cover one OS more deeply without a second copy of the build steps — same reason `workflow_call` was used in the first place. Costs two extra jobs per branch: **18 a night rather than 12**.

The failure report now names which of the four legs failed, so a red night tells you whether it is a branch problem or a Windows-version problem without opening the run.

Note this does **not** fix #255 — it makes sure the schedule would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)