### PR TITLE
[EXPERIMENT, do not merge] #255 arm A: no mpi4py on Windows

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -107,7 +107,9 @@ jobs:
                "libstdcxx=16.1.0=hae5796f_2"
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
-           conda install -c conda-forge -n anuga_env msmpi mpi4py
+           # EXPERIMENT (#255): mpi4py removed on Windows to test whether it is
+           # implicated in the pytest-startup segfault on 3.11-3.13. Not for merge.
+           echo "EXPERIMENT: skipping msmpi/mpi4py install on Windows" 
 
            # conda install -c conda-forge -n anuga_env compilers
            # The compilers package on windows which uses clang. We run into

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -151,9 +151,9 @@ jobs:
           echo "=== mpi.h search under CONDA_PREFIX ==="
           find "$CONDA_PREFIX/include" "$CONDA_PREFIX/Library/include" -name "mpi.h" 2>/dev/null || echo "mpi.h not found under $CONDA_PREFIX/include or Library/include"
           echo "=== mpi4py config ==="
-          python -c "import mpi4py; print('get_include:', mpi4py.get_include()); import json; print('get_config:', mpi4py.get_config())"
+          python -c "import mpi4py; print('get_include:', mpi4py.get_include()); import json; print('get_config:', mpi4py.get_config())" || echo "mpi4py not installed (EXPERIMENT arm A)"
           echo "=== mpi4py location ==="
-          python -c "import mpi4py, os; print(os.path.dirname(mpi4py.__file__))"
+          python -c "import mpi4py, os; print(os.path.dirname(mpi4py.__file__))" || echo "mpi4py not installed (EXPERIMENT arm A)"
 
       - name: Install anuga package
         shell: bash -el {0}


### PR DESCRIPTION
Diagnostic for #255 — **not for merge**, will be closed once CI reports.

Removes the msmpi/mpi4py install from the Windows job. Tests whether mpi4py is implicated **at all** in the pytest-startup segfault on Windows 3.11–3.13.

Read the result as:
* **3.11–3.13 pass** → mpi4py is in the causal chain; arm B (#pending) says whether it is version-specific.
* **3.11–3.13 still segfault** → mpi4py is not the cause, and the hypothesis carried over from the Python 3.9 workaround is wrong.

Paired with arm B, which keeps mpi4py but pins it to 4.0.3.