### PR TITLE
[EXPERIMENT, do not merge] #255 arm B: mpi4py pinned to 4.0.3 on Windows

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -107,7 +107,10 @@ jobs:
                "libstdcxx=16.1.0=hae5796f_2"
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
-           conda install -c conda-forge -n anuga_env msmpi mpi4py
+           # EXPERIMENT (#255): mpi4py pinned to 4.0.3 -- the version the Python 3.9
+           # workaround used -- to test whether 4.1.2 specifically is implicated
+           # in the pytest-startup segfault on 3.11-3.13. Not for merge.
+           conda install -c conda-forge -n anuga_env msmpi "mpi4py=4.0.3"
 
            # conda install -c conda-forge -n anuga_env compilers
            # The compilers package on windows which uses clang. We run into


### PR DESCRIPTION
Diagnostic for #255 — **not for merge**, will be closed once CI reports.

Keeps mpi4py but pins it to **4.0.3**, the version the existing Python 3.9 workaround in `conda-setup.yml` settled on. Tests whether **4.1.2 specifically** is implicated in the pytest-startup segfault on Windows 3.11–3.13.

Read the result as:
* **3.11–3.13 pass** → 4.1.2 is the trigger, and a pin is the fix (better than dropping MPI, which would silence the parallel tests).
* **3.11–3.13 still segfault** → not version-specific to 4.1.2; arm A says whether mpi4py is involved at all.

Paired with arm A, which removes mpi4py entirely.