### PR TITLE
CI: capture the solved conda environment on Windows (#255)

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -159,6 +159,30 @@ jobs:
           conda activate anuga_env
           pip install --no-build-isolation -v .
 
+      # Diagnostics for #255: Windows 3.11-3.13 segfault at pytest startup while
+      # 3.10 and 3.14 pass, with no identifiable change in code, mpi4py, msmpi
+      # or the runner image. Comparing a green run against a red one needs the
+      # SOLVED environment, not just the handful of packages the install steps
+      # happen to echo -- that gap is what stalled diagnosis. Runs on Windows
+      # only, and always(), so a red job still uploads its environment.
+      - name: Record the solved environment (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        shell: bash -el {0}
+        run: |
+          conda activate anuga_env
+          conda list --explicit > "conda-explicit-py${{ matrix.python-version }}.txt" || true
+          conda list                > "conda-list-py${{ matrix.python-version }}.txt"     || true
+          echo "=== solved env: $(wc -l < "conda-explicit-py${{ matrix.python-version }}.txt") lines ==="
+
+      - name: Upload the solved environment (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda-env-windows-py${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: conda-*-py${{ matrix.python-version }}.txt
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Test package (fast — PR feedback)
         if: github.event_name == 'pull_request'
         shell: bash -el {0}


### PR DESCRIPTION
Unblocks the #255 investigation, which stalled on missing evidence rather than missing ideas.

Everything obvious was already ruled out — mpi4py, msmpi, runner image and runner version were **byte-identical** between the last green run and the first red one, the solver source was untouched, and removing mpi4py entirely did not stop the segfault.

What could **not** be compared is the *solved* environment. The install steps echo only the packages they explicitly name, so a transitive dependency that moved overnight is invisible — and that is the leading (still unproven) hypothesis.

This uploads `conda list --explicit` and `conda list` as artifacts, 30-day retention, **Windows only** (that is where the fault is, and artifacts are per-job).

`always()` matters here: a job that segfaults must still upload the environment that produced it. That is precisely the case we need.

**This does not fix #255.** It makes the next green-vs-red diff possible at all — right now such a diff cannot be performed even in principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)