### PR TITLE
Bring the MPI-capable container images to main

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -178,6 +178,24 @@ jobs:
           conda list                > "conda-list-py${{ matrix.python-version }}.txt"     || true
           echo "=== solved env: $(wc -l < "conda-explicit-py${{ matrix.python-version }}.txt") lines ==="
 
+      # Decisive isolation test for #255. The segfault's stack is
+      #   test_sww2vtu.py -> sww2vtu.py -> netCDF4/__init__.py:11 -> create_module
+      # i.e. it dies loading _netCDF4.pyd. If importing netCDF4 on its own also
+      # segfaults, then ANUGA and pytest are irrelevant and this is purely a bad
+      # netCDF4/hdf5/libnetcdf combination -- a known netCDF4 failure mode on
+      # win-64, where the DLL bundling is the fragile part.
+      # continue-on-error so this reports without masking the real test result.
+      - name: Probe netCDF4 in isolation (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        continue-on-error: true
+        shell: bash -el {0}
+        run: |
+          conda activate anuga_env
+          echo "--- versions (segfault here => purely environmental) ---"
+          python -c "import netCDF4; print('netCDF4', netCDF4.__version__, '| hdf5', netCDF4.__hdf5libversion__, '| libnetcdf', netCDF4.__netcdf4libversion__)"
+          echo "--- import of the module that triggers it ---"
+          python -c "import anuga.file_conversion.sww2vtu as m; print('sww2vtu imported OK')"
+
       - name: Upload the solved environment (Windows, #255)
         if: always() && runner.os == 'Windows'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -159,6 +159,30 @@ jobs:
           conda activate anuga_env
           pip install --no-build-isolation -v .
 
+      # Diagnostics for #255: Windows 3.11-3.13 segfault at pytest startup while
+      # 3.10 and 3.14 pass, with no identifiable change in code, mpi4py, msmpi
+      # or the runner image. Comparing a green run against a red one needs the
+      # SOLVED environment, not just the handful of packages the install steps
+      # happen to echo -- that gap is what stalled diagnosis. Runs on Windows
+      # only, and always(), so a red job still uploads its environment.
+      - name: Record the solved environment (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        shell: bash -el {0}
+        run: |
+          conda activate anuga_env
+          conda list --explicit > "conda-explicit-py${{ matrix.python-version }}.txt" || true
+          conda list                > "conda-list-py${{ matrix.python-version }}.txt"     || true
+          echo "=== solved env: $(wc -l < "conda-explicit-py${{ matrix.python-version }}.txt") lines ==="
+
+      - name: Upload the solved environment (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda-env-windows-py${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: conda-*-py${{ matrix.python-version }}.txt
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Test package (fast — PR feedback)
         if: github.event_name == 'pull_request'
         shell: bash -el {0}

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -32,6 +32,10 @@ on:
         description: 'JSON list of Python versions to run.'
         type: string
         default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      os_list:
+        description: 'JSON list of runners. Lets a caller cover one OS more deeply than the others.'
+        type: string
+        default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
 
 jobs:
   test_conda:
@@ -40,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ${{ fromJSON(inputs.os_list || '["ubuntu-latest", "macos-latest", "windows-latest"]') }}
 
         # 2026/04/05: dropped 3.8 -- numpy>=2.0.0 (required by anuga) requires Python>=3.9
         # 2026/04/06: dropped 3.9 -- X | Y union type syntax requires Python>=3.10

--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -112,6 +112,23 @@ jobs:
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py
+           # PIN (#255): hold netcdf4 at the _104 build series on Windows.
+           #
+           # conda-forge stopped building py312/py313 variants of netcdf4 1.7.4
+           # after _104 -- the _105.._109 series exists only for py311 and py314.
+           # The solver therefore resolves the **py311** build into py312/py313
+           # environments, and loading that _netCDF4.pyd segfaults the
+           # interpreter: `python -c "import netCDF4"` alone dies with exit 139,
+           # no ANUGA and no pytest involved.
+           #
+           # _104 has a matching build for every Python we test, and pulls the
+           # coherent older stack (hdf5 1.14.6 / libnetcdf 4.10.0) that Python
+           # 3.10 has been passing on throughout.
+           #
+           # TEMPORARY. Remove once conda-forge publishes py312/py313 builds of
+           # the current series, or fixes the constraints so a mismatched build
+           # cannot be selected.
+           conda install -c conda-forge -n anuga_env "netcdf4=1.7.4=*_104"
 
            # conda install -c conda-forge -n anuga_env compilers
            # The compilers package on windows which uses clang. We run into

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,17 +101,28 @@ jobs:
     steps:
       - name: Free up disk space (NVHPC base is large)
         run: |
+          echo "before:"; df -h / | tail -1
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
-          df -h /
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+                      /usr/share/swift /usr/local/share/powershell || true
+          sudo docker image prune --all --force || true
+          echo "after:"; df -h / | tail -1
 
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history + tags so _git_version.py can describe
 
-      - name: Compute ANUGA version (PEP 440, from git)
+      - name: Compute ANUGA version (PEP 440)
         id: ver
-        run: echo "v=$(python _git_version.py)" >> "$GITHUB_OUTPUT"
+        # Prefer the explicit input: `git describe` on a branch a few commits
+        # past the tag yields 4.0.0.devN+gSHA, which reads as a pre-release even
+        # when the solver source is identical to the tag.
+        run: |
+          v='${{ inputs.anuga_version }}'
+          [ -n "$v" ] || v=$(python _git_version.py)
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "building ANUGA $v"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -126,15 +137,18 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           flavor: |
-            suffix=-gpu,onlatest=false
+            suffix=-gpu,onlatest=true
           tags: |
             # branch name (e.g. develop-gpu) — the pre-release channel
             type=ref,event=branch
             # immutable commit tag (e.g. sha-abc1234-gpu)
             type=sha
-            # release version (e.g. 4.0.0-gpu) and latest-gpu, only on a Release
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # release version (e.g. 4.0.0-gpu) and latest-gpu, both explicit.
+            # These were previously gated on `github.event_name == 'release'`,
+            # which has been permanently false since the release trigger was
+            # removed — so latest-gpu was unreachable.
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
       - name: Build & push GPU image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,10 +36,10 @@ on:
       gpu_dockerfile:
         description: 'Which GPU image to build. slim = multi-stage on a CUDA base (same cc70..cc120 coverage, a fraction of the size); mpi = slim plus CUDA-aware HPC-X for multi-GPU; gpu = the original single-stage devel image.'
         type: choice
-        default: 'docker/Dockerfile.gpu.slim'
+        default: 'docker/Dockerfile.gpu.mpi'
         options:
-          - docker/Dockerfile.gpu.slim
           - docker/Dockerfile.gpu.mpi
+          - docker/Dockerfile.gpu.slim
           - docker/Dockerfile.gpu
       nvhpc_tag:
         description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
@@ -163,7 +163,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.slim' }}
+          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.mpi' }}
           push: true
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,14 @@ on:
         description: 'Also build & push the (large) GPU image'
         type: boolean
         default: false
+      gpu_dockerfile:
+        description: 'Which GPU image to build. slim = multi-stage on a CUDA base (same cc70..cc120 coverage, a fraction of the size); mpi = slim plus CUDA-aware HPC-X for multi-GPU; gpu = the original single-stage devel image.'
+        type: choice
+        default: 'docker/Dockerfile.gpu.slim'
+        options:
+          - docker/Dockerfile.gpu.slim
+          - docker/Dockerfile.gpu.mpi
+          - docker/Dockerfile.gpu
       nvhpc_tag:
         description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
         default: '25.9-devel-cuda_multi-ubuntu24.04'
@@ -151,10 +159,11 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
       - name: Build & push GPU image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile.gpu
+          file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.slim' }}
           push: true
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -33,10 +33,15 @@ permissions:
   contents: read
 
 jobs:
-  # The matrix is deliberately trimmed to the oldest and newest supported
-  # Python, across all three OSes. Both historic breakages were platform- or
-  # toolchain-shaped rather than Python-version-shaped, so OS coverage is what
-  # earns its keep here; push/PR runs still cover every version.
+  # Linux and macOS run the oldest and newest supported Python: their historic
+  # breakages were toolchain-shaped rather than version-shaped, so OS coverage
+  # is what earns its keep and push/PR runs still cover every version.
+  #
+  # Windows runs ALL FIVE. That is not symmetry for its own sake -- on
+  # 2026-08-31 Python 3.11/3.12/3.13 began segfaulting at pytest startup on
+  # Windows while 3.10 and 3.14 stayed green (#255), so this watchdog ran green
+  # through a real breakage. Windows is where version-specific faults actually
+  # appear here, and the trimmed matrix had a hole exactly in the middle.
   main:
     name: main
     uses: ./.github/workflows/conda-setup.yml
@@ -51,12 +56,29 @@ jobs:
       ref: develop
       python_versions: ${{ inputs.python_versions || '["3.10", "3.14"]' }}
 
+  # The versions the jobs above skip, on Windows only -- see #255.
+  main-windows:
+    name: main (windows, mid versions)
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: main
+      python_versions: '["3.11", "3.12", "3.13"]'
+      os_list: '["windows-latest"]'
+
+  develop-windows:
+    name: develop (windows, mid versions)
+    uses: ./.github/workflows/conda-setup.yml
+    with:
+      ref: develop
+      python_versions: '["3.11", "3.12", "3.13"]'
+      os_list: '["windows-latest"]'
+
   # A red run in the Actions tab is what already failed us — nobody was looking.
   # Turn a failure into an issue, and keep updating that one issue rather than
   # filing a new one every night.
   report:
     name: Report failure
-    needs: [main, develop]
+    needs: [main, develop, main-windows, develop-windows]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
@@ -70,6 +92,8 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MAIN_RESULT: ${{ needs.main.result }}
           DEVELOP_RESULT: ${{ needs.develop.result }}
+          MAIN_WIN_RESULT: ${{ needs['main-windows'].result }}
+          DEVELOP_WIN_RESULT: ${{ needs['develop-windows'].result }}
         run: |
           set -euo pipefail
           TITLE="Scheduled build failing"
@@ -80,6 +104,8 @@ jobs:
             "|---|---|" \
             "| \`main\` | \`${MAIN_RESULT}\` |" \
             "| \`develop\` | \`${DEVELOP_RESULT}\` |" \
+            "| \`main\` (windows 3.11-3.13) | \`${MAIN_WIN_RESULT}\` |" \
+            "| \`develop\` (windows 3.11-3.13) | \`${DEVELOP_WIN_RESULT}\` |" \
             "" \
             "Run: ${RUN_URL}" \
             "" \

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -20,17 +20,26 @@ ENV ANUGA_VERSION=${ANUGA_VERSION}
 # ca-certificates: TLS for pip/aws.
 # libexpat1: fiona's wheel dlopens libexpat.so.1 at import; python:*-slim does
 #   not ship it, so `import fiona` dies with ImportError without this.
+# openmpi-bin: mpirun, plus libopenmpi40 as a dependency. The mpi4py wheel does
+#   NOT bundle an MPI -- it dlopens libmpi.so.40 / libmpi.so.12 at import and
+#   fails without a system one, so this is required, not optional.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libgomp1 ca-certificates libexpat1 && \
+        libgomp1 ca-certificates libexpat1 openmpi-bin && \
     rm -rf /var/lib/apt/lists/*
 
 # anuga[data] pulls the optional geodata stack (rasterio/fiona/shapely/xarray/
 # pandas/openpyxl) that case-study scripts need — e.g. spatialInputUtil's
 # readListOfRiverWalls, shapefile/raster/polygon-CSV I/O — which otherwise
 # import in a degraded mode and raise AttributeError/ImportError.
+# mpi4py makes anuga.parallel real: without it ANUGA prints "Could not import
+# mpi4py - defining sequential interface" and silently runs one rank. pymetis
+# (the partitioner) already arrives with anuga[data]. Measured cost of MPI in
+# this image: +0.39 GB on disk, ~+0.1 GB on a pull -- small enough that shipping
+# one MPI-capable image beats maintaining two.
 RUN pip install --no-cache-dir -U pip && \
-    pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" awscli && \
+    pip install --no-cache-dir "anuga[data]${ANUGA_VERSION:+==${ANUGA_VERSION}}" mpi4py awscli && \
     python -c "import anuga, fiona, rasterio, shapely; print('ANUGA', anuga.__version__, '+ geodata imported OK')" && \
+    python -c "from mpi4py import MPI; print('MPI', MPI.get_vendor(), 'OK')" && \
     python -c "import os,sys,anuga; w=os.environ.get('ANUGA_VERSION','') or None; \
 sys.exit(0) if (w is None or anuga.__version__==w) else sys.exit('PINNED %s but installed %s' % (w, anuga.__version__))"
 

--- a/docker/Dockerfile.gpu.mpi
+++ b/docker/Dockerfile.gpu.mpi
@@ -6,11 +6,24 @@
 #     buffers, no host staging),
 #   * the HPC-X OpenMPI + UCX runtime copied into the runtime stage.
 #
-# Kept SEPARATE from anuga:gpu-slim on purpose.  The MPI runtime adds several
-# hundred MB (ompi ~235 MB + ucx ~285 MB before trimming) and the slim image
-# exists to keep AWS cold-start pulls fast.  Single-GPU instances (g4dn.xlarge,
-# g6.xlarge) cannot use multi-rank GPU anyway — mode 2 requires one rank per
-# GPU — so use gpu-slim there and this image on multi-GPU nodes.
+# This is the PUBLISHED GPU image (ghcr.io …:<version>-gpu).
+#
+# It was originally kept separate from anuga:gpu-slim because the MPI runtime
+# "adds several hundred MB" — ompi ~235 MB + ucx ~285 MB *before* the trimming
+# below.  Measured after trimming, on a full multi-arch build (2026-08-30):
+#
+#     gpu.slim   0.46 GB compressed / 2.12 GB on disk
+#     gpu.mpi    0.60 GB compressed / 2.66 GB on disk
+#
+# i.e. MPI costs 0.14 GB on a pull, against 15.94 GB for the old single-stage
+# devel image.  At that price the split is not worth its complexity: MPI-capable
+# is a superset, nothing about it degrades single-GPU use, and one image is
+# simpler to build, publish and document.  gpu.slim remains for anyone who wants
+# the smallest possible pull for a large single-GPU fleet.
+#
+# Note single-GPU instances (g4dn.xlarge, g6.xlarge) still cannot use multi-rank
+# GPU — mode 2 requires one rank per GPU — they simply run this image as one
+# rank.
 #
 # MPI comes from the NVHPC base's bundled HPC-X, which is built CUDA-aware
 # (ompi_info: mpi_built_with_cuda_support:value:true).  There is one HPC-X per

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,10 +2,14 @@
 
 Two images:
 
-| Image | Base | ANUGA source | Use |
-|-------|------|--------------|-----|
-| `anuga:cpu` | `python:3.12-slim` | PyPI wheel | CPU runs; small, fast; CPU AWS Batch |
-| `anuga:gpu` | `nvcr.io/nvidia/nvhpc:*-devel` | built from this checkout with `nvc` | GPU offload; local Blackwell laptop **and** AWS GPU instances |
+| Image | Base | ANUGA source | Pull / disk | Use |
+|-------|------|--------------|-------------|-----|
+| `anuga:cpu` | `python:3.12-slim` | PyPI wheel | 0.3 / 1.7 GB | CPU runs; CPU AWS Batch |
+| `anuga:gpu` | `nvidia/cuda:*-base` (multi-stage; built under `nvhpc:*-devel`) | built from this checkout with `nvc` | 0.6 / 2.7 GB | GPU offload; local Blackwell laptop **and** AWS GPU instances |
+
+Both are **MPI-capable** (`mpirun` + `mpi4py`), so `anuga.parallel` works in
+either. Sizes measured 2026-08-30; the GPU figure is the published
+`Dockerfile.gpu.mpi`, with full `cc70..cc120` coverage.
 
 Both share `anuga-entrypoint.sh`: a headless entrypoint that optionally syncs
 input from S3, runs the command you pass, and syncs `output/` back to S3 —
@@ -91,12 +95,29 @@ docker pull ghcr.io/anuga-community/anuga:develop-gpu     # branch channel
 
 Publishing a container from develop is fine — it's an artifact, not a source
 release. The `docker-publish.yml` workflow (manual `workflow_dispatch`,
-`build_gpu=true`) tags `develop-gpu` + `sha-<short>-gpu`. Until CI has a big
-enough runner for the ~15 GB NVHPC base, the reliable path is to **build locally
-and push**:
+`build_gpu=true`) tags `develop-gpu` + `sha-<short>-gpu`.
+
+**CI builds the GPU image fine** — this used to say a free runner was too small
+for the ~15 GB NVHPC base, and that is no longer true. Measured 2026-08-30 on a
+standard `ubuntu-latest`: the published (multi-stage) image builds and pushes in
+**13–15 minutes** against a 6 h limit, with **118 GB** free after the cleanup
+step. The old figure came from the single-stage `Dockerfile.gpu`, which shipped
+the whole devel SDK; the published image no longer does. So prefer the workflow:
 
 ```bash
-docker build -f docker/Dockerfile.gpu \
+gh workflow run docker-publish.yml --ref main \
+  -f build_gpu=true -f anuga_version=4.0.0 -f image_tag=4.0.0 -f mark_latest=true
+```
+
+`gpu_dockerfile` selects the variant — `Dockerfile.gpu.mpi` (the default, and
+what is published), `Dockerfile.gpu.slim` (same GPU coverage, ~0.14 GB smaller,
+no MPI) or `Dockerfile.gpu` (the original single-stage devel image, ~35× larger;
+keep for debugging, do not publish).
+
+To build locally anyway — for a quick iteration, or an ECR push:
+
+```bash
+docker build -f docker/Dockerfile.gpu.mpi \
   --build-arg ANUGA_VERSION="$(python _git_version.py)" \
   -t ghcr.io/anuga-community/anuga:develop-gpu .
 echo "$GHCR_PAT" | docker login ghcr.io -u <user> --password-stdin
@@ -234,9 +255,10 @@ Each user runs this in **their own AWS account and pays for their own usage**.
 
 **Image source:** by default it pulls the public GHCR image
 (`ghcr.io/anuga-community/anuga:develop-gpu`). Add **`--ecr`** to use the private
-in-region ECR image `…dkr.ecr.<region>.amazonaws.com/anuga:gpu-slim` instead —
-the ~459 MB slim build, so the instance's cold-start pull drops from ~16.7 GB to
-~0.5 GB. The script builds the URI from your account + region, grants the
+in-region ECR image `…dkr.ecr.<region>.amazonaws.com/anuga:gpu-slim` instead.
+Note the size argument for this has largely gone: the public GHCR image is now
+the multi-stage build at ~0.6 GB, not the ~16.7 GB devel image, so ECR now buys
+in-region pull latency and egress rather than a 30x size saving. The script builds the URI from your account + region, grants the
 instance role `AmazonEC2ContainerRegistryReadOnly`, and logs the instance in to
 ECR before pulling. Override the repo:tag with `--ecr-repo anuga:<tag>`, or pass
 a full ECR URI via `--image …` (auto-detected). Push the image first (below).
@@ -311,16 +333,21 @@ docker push "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/anuga:gpu-slim"
   ```
   (The images set `HOME=/tmp` so `--user` runs have a writable config dir. With
   compose, `export UID GID` first — see the header of docker-compose.yml.)
-- **Image size:** the devel-based GPU image (`Dockerfile.gpu`) is ~50 GB
-  (~16.7 GB compressed to pull). `Dockerfile.gpu.slim` is a multi-stage build
-  (CUDA **-base** image + copied NVHPC redistributable libs + the venv) that is
-  **~2.15 GB (459 MB compressed)** — ~37x smaller to pull, slashing storage and
-  AWS cold-start time. Validated on the cc120 laptop: `import anuga` and a real
-  GPU-offload evolve both work. OpenMP-target offload needs only `libnvomp`
-  (from the redist copy) plus the host driver (`--gpus`), not `libcudart`, so
-  the CUDA `-base` image is enough. Build with
-  `docker build -f docker/Dockerfile.gpu.slim -t anuga:gpu-slim .`. Further
-  shrink is possible by trimming the redist libs to the `ldd` set.
+- **Image size:** measured 2026-08-30, full multi-arch (`cc70..cc120`) builds:
+
+  | Dockerfile | pull | on disk | published? |
+  |---|---|---|---|
+  | `Dockerfile.gpu.mpi` | 0.60 GB | 2.66 GB | **yes — this is `:*-gpu`** |
+  | `Dockerfile.gpu.slim` | 0.46 GB | 2.12 GB | no (same GPU coverage, no MPI) |
+  | `Dockerfile.gpu` | 15.94 GB | ~50 GB | no — debugging only |
+
+  The single-stage `Dockerfile.gpu` ships the entire NVHPC devel SDK: two layers
+  of 9.2 GB and 6.2 GB against 0.25 GB of actual ANUGA. The multi-stage builds
+  copy only the venv plus the NVHPC redistributable libs onto a CUDA **-base**
+  image — OpenMP-target offload needs `libnvomp` and the host driver (`--gpus`),
+  not `libcudart`. MPI costs 0.14 GB over slim, which is why it is simply
+  included rather than kept as a separate image. Further shrink is possible by
+  trimming the redist libs to the `ldd` set.
 - **Version string:** `.git` is excluded from the build context, so a
   source-built GPU image reports `0.0.0+unknown` for `anuga.__version__`
   (cosmetic; the code is the checkout's).

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,11 +56,33 @@ docker build -f docker/Dockerfile.gpu \
   --build-arg ANUGA_VERSION="$(python _git_version.py)" -t anuga:gpu .
 ```
 
-### Published (pre-release) image
+### Published images
+
+Both images are published by `docker-publish.yml`, which is **manual
+(`workflow_dispatch`) only**. It used to build the CPU image automatically on a
+GitHub Release, but that races the PyPI upload — both fire on the same event,
+and the CPU image installs ANUGA *from PyPI*, so the new version isn't there
+yet. Run it after PyPI has the release, passing `anuga_version`:
+
+```bash
+gh workflow run docker-publish.yml --ref main \
+  -f anuga_version=4.0.0 -f image_tag=4.0.0 -f mark_latest=true
+```
+
+The workflow refuses to build if that version isn't on PyPI, and the image
+asserts the installed version matches the pin, so a mislabelled image can't be
+produced silently (see issue #248).
+
+```bash
+docker pull ghcr.io/anuga-community/anuga:4.0.0-cpu     # released CPU image
+docker pull ghcr.io/anuga-community/anuga:latest-cpu    # newest CPU image
+```
+
+Every tag carries a `-cpu` / `-gpu` suffix — there is deliberately no bare
+`latest`, so a pull is never ambiguous about which variant it gets.
 
 The GPU image is built from the **develop** branch (v4.0 line), which isn't
-released yet — so it's published to GHCR under a **pre-release** tag, not
-`latest`:
+released yet — so it's published to GHCR under a **pre-release** tag:
 
 ```bash
 docker pull ghcr.io/anuga-community/anuga:develop-gpu     # branch channel
@@ -69,9 +91,9 @@ docker pull ghcr.io/anuga-community/anuga:develop-gpu     # branch channel
 
 Publishing a container from develop is fine — it's an artifact, not a source
 release. The `docker-publish.yml` workflow (manual `workflow_dispatch`,
-`build_gpu=true`) tags `develop-gpu` + `sha-<short>-gpu`; version tags + `latest`
-only appear on a GitHub Release. Until CI has a big enough runner for the ~15 GB
-NVHPC base, the reliable path is to **build locally and push**:
+`build_gpu=true`) tags `develop-gpu` + `sha-<short>-gpu`. Until CI has a big
+enough runner for the ~15 GB NVHPC base, the reliable path is to **build locally
+and push**:
 
 ```bash
 docker build -f docker/Dockerfile.gpu \
@@ -85,12 +107,39 @@ docker push ghcr.io/anuga-community/anuga:develop-gpu
 require an org **owner**:
 1. Allow public packages org-wide: **Org Settings → "Code, planning, and
    automation" → Packages** → enable public packages.
-2. On the package: **Package settings → Danger Zone → Change visibility → Public**
-   (also link it to `anuga_core` via *Manage Actions access* so the workflow can
-   update it).
+2. On the package: **Package settings → Danger Zone → Change visibility → Public**.
 
 `ghcr.io/anuga-community/anuga:develop-gpu` is currently **published and public**
 (anonymous `docker pull` verified).
+
+#### A package pushed by hand is not writable by CI
+
+This bites exactly once, and the error is opaque, so it is worth knowing before
+it happens. A hand-pushed package (the `docker push` above, authenticated with a
+personal access token) is owned by the **org** but is not associated with any
+repository. `GITHUB_TOKEN` therefore has no write access to it, whatever
+`permissions:` the workflow requests, and `docker-publish.yml` fails at the push
+step with:
+
+```
+ERROR: denied: permission_denied: write_package
+```
+
+Grant the repository access once:
+
+> **Package settings → Manage Actions access → Add repository →** `anuga_core`,
+> role **Write**
+
+**Write**, not Admin: the workflow only uploads new versions. Admin additionally
+allows *deleting* published versions, which is only needed if a retention job is
+added later to prune the `<untagged>` manifests that accumulate as tags are
+rebuilt.
+
+After the first successful Actions push the package links itself to the
+repository (`docker/metadata-action` stamps `org.opencontainers.image.source`),
+and no further intervention is needed. This is what blocked the first CPU image:
+the package had been created by hand on 2026-08-03, so every later CI push was
+refused until the repository was granted Write.
 
 Verify offload actually reaches the GPU (needs `--gpus all`):
 


### PR DESCRIPTION
Brings the container work to `main`, which is what makes it usable — both
changes are inert until they land here, because `workflow_dispatch` resolves
from the default branch.

| PR | change |
|---|---|
| #253 | publish MPI-capable CPU and GPU images; make the GPU job dispatchable with an explicit version and tags |
| #252 | document the GHCR Actions-access trap and the real publish flow |

### Why it matters that these reach `main`

* The `gpu_dockerfile` input and the `Dockerfile.gpu.mpi` default are not
  selectable until they are on the default branch — so **no 4.0.0 GPU image can
  be built at all** right now.
* The MPI-enabled `Dockerfile.cpu` is likewise not what a dispatch would build.
  The currently published `4.0.0-cpu` has no `mpi4py`, so `anuga.parallel`
  inside it **silently runs a single rank** rather than erroring.

### Measured basis for the change

Full multi-arch builds on fork CI, then run on an RTX 5070:

| image | pull | on disk |
|---|---|---|
| `Dockerfile.gpu` (what CI published) | 15.94 GB | ~50 GB |
| `Dockerfile.gpu.mpi` (new default) | **0.60 GB** | 2.66 GB |
| `Dockerfile.cpu` + mpi | — | 1.72 GB (from 1.33) |

Verified on hardware rather than just built: `gpu.mpi` reports
`gpu_has_mpi: True` and `mpirun -np 2` gives both ranks; `cpu+mpi` reports Open
MPI 5.0.7 and two ranks; the slim GPU image runs a real offload evolve in
compute mode `unified`.

### Verification of this merge

Test merge is conflict-free, and the merged tree keeps `CITATION.cff` at
`version: 4.0.0` / `date-released: '2026-08-30'`, `mpi4py` in
`docker/Dockerfile.cpu`, and the `gpu_dockerfile` input in the workflow.

### Not included

`#254` (README corrections) and `#256` (widen the scheduled Windows matrix) are
still open on `develop`, as is `#259` (capture the solved Windows environment
for #255). They will need a second trip to `main` — `#256` in particular is
inert until it gets here, for the same default-branch reason.

### Unrelated known failure

Windows CI on Python 3.11-3.13 currently segfaults at pytest startup (#255).
It is not caused by anything in this PR: it reproduces on `develop` with the
solver source untouched, and persists with mpi4py removed entirely. The 4.0.0
wheels built and published green on all five versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
