### PR TITLE
CI: probe netCDF4 in isolation on Windows (#255)

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -178,6 +178,24 @@ jobs:
           conda list                > "conda-list-py${{ matrix.python-version }}.txt"     || true
           echo "=== solved env: $(wc -l < "conda-explicit-py${{ matrix.python-version }}.txt") lines ==="
 
+      # Decisive isolation test for #255. The segfault's stack is
+      #   test_sww2vtu.py -> sww2vtu.py -> netCDF4/__init__.py:11 -> create_module
+      # i.e. it dies loading _netCDF4.pyd. If importing netCDF4 on its own also
+      # segfaults, then ANUGA and pytest are irrelevant and this is purely a bad
+      # netCDF4/hdf5/libnetcdf combination -- a known netCDF4 failure mode on
+      # win-64, where the DLL bundling is the fragile part.
+      # continue-on-error so this reports without masking the real test result.
+      - name: Probe netCDF4 in isolation (Windows, #255)
+        if: always() && runner.os == 'Windows'
+        continue-on-error: true
+        shell: bash -el {0}
+        run: |
+          conda activate anuga_env
+          echo "--- versions (segfault here => purely environmental) ---"
+          python -c "import netCDF4; print('netCDF4', netCDF4.__version__, '| hdf5', netCDF4.__hdf5libversion__, '| libnetcdf', netCDF4.__netcdf4libversion__)"
+          echo "--- import of the module that triggers it ---"
+          python -c "import anuga.file_conversion.sww2vtu as m; print('sww2vtu imported OK')"
+
       - name: Upload the solved environment (Windows, #255)
         if: always() && runner.os == 'Windows'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The half of #259 that missed the merge. #259 landed with the environment capture only — the probe commit was pushed a moment after it merged, so it never reached `develop`.

The segfault stack is:

```
test_sww2vtu.py:11 -> sww2vtu.py:31 -> netCDF4/__init__.py:11 -> create_module -> SEGFAULT
```

so it dies loading `_netCDF4.pyd`, not in ANUGA code and not in pytest's assertion rewriter as the first report suggested.

This adds a step that imports netCDF4 **alone** and prints the hdf5 and libnetcdf versions it was built against, then imports `sww2vtu`:

```
python -c "import netCDF4; print(netCDF4.__version__, netCDF4.__hdf5libversion__, netCDF4.__netcdf4libversion__)"
```

If that bare import segfaults, ANUGA and pytest are **conclusively** irrelevant and this is a bad netCDF4/hdf5/libnetcdf combination — a known netCDF4 failure mode on win-64, where the DLL bundling is the fragile part.

`continue-on-error`, so it reports without masking the real test outcome. Windows only, `always()`, matching the capture steps already on `develop`.

Diagnostic only — this does not attempt a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)