### PR TITLE
CI: pin netcdf4 to the _104 build series on Windows (#255)

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -112,6 +112,23 @@ jobs:
            # msmpi: Microsoft MPI — standard Windows MPI on conda-forge; provides
            # mpi.h under Library/include and is picked up by meson.build automatically.
            conda install -c conda-forge -n anuga_env msmpi mpi4py
+           # PIN (#255): hold netcdf4 at the _104 build series on Windows.
+           #
+           # conda-forge stopped building py312/py313 variants of netcdf4 1.7.4
+           # after _104 -- the _105.._109 series exists only for py311 and py314.
+           # The solver therefore resolves the **py311** build into py312/py313
+           # environments, and loading that _netCDF4.pyd segfaults the
+           # interpreter: `python -c "import netCDF4"` alone dies with exit 139,
+           # no ANUGA and no pytest involved.
+           #
+           # _104 has a matching build for every Python we test, and pulls the
+           # coherent older stack (hdf5 1.14.6 / libnetcdf 4.10.0) that Python
+           # 3.10 has been passing on throughout.
+           #
+           # TEMPORARY. Remove once conda-forge publishes py312/py313 builds of
+           # the current series, or fixes the constraints so a mismatched build
+           # cannot be selected.
+           conda install -c conda-forge -n anuga_env "netcdf4=1.7.4=*_104"
 
            # conda install -c conda-forge -n anuga_env compilers
            # The compilers package on windows which uses clang. We run into


### PR DESCRIPTION
Fixes #255.

## Root cause

conda-forge **stopped building py312/py313 variants of netcdf4 1.7.4 after the `_104` series** — `_105` through `_109` exist only for py311 and py314. The solver therefore resolves the **py311** build into py312 and py313 environments, and loading that `_netCDF4.pyd` crashes the interpreter.

## Evidence

* `python -c "import netCDF4"` **alone** segfaults on 3.12 — no ANUGA, no pytest, no collection, exit 139. On 3.14 the same command prints `netCDF4 1.7.4 | hdf5 2.2.0 | libnetcdf 4.10.1` and continues.
* Solved environments of a failing 3.13 and a passing 3.14 differ in **nothing but the interpreter**: 224 vs 225 packages, only `cpython` and `python-gil` differ in version. Same netcdf4 build, hdf5, libnetcdf, numpy — so there was no dependency regression, and nothing to pin *by version*.
* `conda search` confirms the gap: py312/py313 stop at `_104`, py311/py314 continue to `_109`.
* Removing mpi4py entirely did not help (#257), so the analogy to the existing Python 3.9 workaround was wrong.

## The pin, verified before pushing

Dry-run solves of win-64 for 3.11/3.12/3.13 each resolve to their **own** build, and to the coherent older stack:

```
3.11 -> netcdf4-1.7.4-nompi_py311h463f251_104   hdf5 1.14.6  libnetcdf 4.10.0
3.12 -> netcdf4-1.7.4-nompi_py312h54f3ad3_104   hdf5 1.14.6  libnetcdf 4.10.0
3.13 -> netcdf4-1.7.4-nompi_py313hbf62ba6_104   hdf5 1.14.6  libnetcdf 4.10.0
```

That is the stack Python 3.10 has been passing on throughout.

**Pinning `hdf5` alone does not work** — I tried it, and the solver still selects the py311 netcdf4 build. The pin has to be on netcdf4's build string.

## Temporary

Remove once conda-forge publishes py312/py313 builds of the current series, or fixes the constraints so a mismatched build cannot be selected. Worth reporting upstream to netcdf4-feedstock either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)