### PR TITLE
CI: stop the gpu_arch input silently narrowing the published image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,8 +45,8 @@ on:
         description: 'nvcr.io/nvidia/nvhpc devel tag for the GPU image'
         default: '25.9-devel-cuda_multi-ubuntu24.04'
       gpu_arch:
-        description: 'nvc -gpu arch list for the GPU image'
-        default: 'cc75,cc80,cc86,cc89,cc90,cc120'
+        description: 'nvc -gpu arch list. Empty = whatever the Dockerfile defaults to, which is the right answer unless you are deliberately narrowing it for a fast test build.'
+        default: ''
 
 permissions:
   contents: read
@@ -158,6 +158,16 @@ jobs:
             type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
             type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
+      - name: Report the GPU arch list actually being used
+        run: |
+          want=$(grep -m1 '^ARG GPU_ARCH=' "${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.mpi' }}" | sed 's/^ARG GPU_ARCH=//')
+          got='${{ inputs.gpu_arch }}'
+          if [ -z "$got" ]; then
+            echo "GPU_ARCH not overridden; Dockerfile default applies: $want"
+          else
+            echo "::warning::GPU_ARCH overridden to '$got'; the Dockerfile default is '$want'. A published image should normally use the Dockerfile default -- docker/README.md tells users the image spans cc70-cc120."
+          fi
+
       - name: Build & push GPU image
         id: build
         uses: docker/build-push-action@v6
@@ -165,9 +175,12 @@ jobs:
           context: .
           file: ${{ inputs.gpu_dockerfile || 'docker/Dockerfile.gpu.mpi' }}
           push: true
+          # GPU_ARCH is passed only when the input is non-empty: an empty
+          # build-arg would override the Dockerfile's ARG default with an empty
+          # string rather than falling back to it.
           build-args: |
             NVHPC_TAG=${{ inputs.nvhpc_tag }}
-            GPU_ARCH=${{ inputs.gpu_arch }}
+            ${{ inputs.gpu_arch != '' && format('GPU_ARCH={0}', inputs.gpu_arch) || '' }}
             ANUGA_VERSION=${{ steps.ver.outputs.v }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The workflow input defaulted to `cc75,cc80,cc86,cc89,cc90,cc120` while **all three** GPU Dockerfiles default to `cuda12.9,cc70,cc75,cc80,cc86,cc89,cc90,cc120` — and the input was passed as a build-arg unconditionally, so the workflow's narrower list silently won.

A dispatch that accepted the defaults would drop **cc70 (V100)** and the leading **cuda12.9** that `Dockerfile.gpu.slim`'s comment says is required — while `docker/README.md` tells AWS Batch users the image spans cc70–cc120.

Today's `4.0.0-gpu` is correct **only because I passed the arch list explicitly** on the dispatch. That shouldn't depend on someone remembering.

## Fix

* the input defaults to empty and is passed **only when non-empty**, so the Dockerfile's own default applies unless someone deliberately narrows it (handy for a fast single-arch test build);
* the value now lives in **one** place rather than two that can drift.

An empty build-arg would override the `ARG` default with an empty string rather than falling back to it, hence the conditional rather than simply blanking the default.

## Also

A step that prints the arch list in force and emits a `::warning::` when the input overrides the Dockerfile — so a narrowed publish is visible in the log, rather than discovered later by a user on a V100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)