### PR TITLE
tk_scaling: stay importable without Tk (#266)

### DIFF
--- a/anuga/utilities/tk_scaling.py
+++ b/anuga/utilities/tk_scaling.py
@@ -16,8 +16,34 @@ changes, so this is safe to call unconditionally at startup.
 import os
 import re
 import subprocess
-import tkinter as tk
-import tkinter.font as tkfont
+
+# Tk is imported defensively so this module stays importable without it.
+#
+# conda-forge's `tk` does not depend on `xorg-libx11`; it expects libX11.so.6
+# from outside the prefix, so whether `_tkinter` imports depends on whether
+# something else in the environment happened to pull libX11 in. That made the
+# 4.0.0 conda-forge build fail on linux_64/py3.10 only, while the other four
+# Python versions passed by luck of the solve (#266). Any headless or minimal
+# Linux image hits the same thing.
+#
+# Nothing here needs a display: detect_dpi/detect_scale read Xft.dpi and xrandr
+# and fall back to arithmetic, so they are worth keeping testable and callable
+# where Tk will never exist. Only apply_hidpi_scaling touches Tk objects, and it
+# already requires a live root passed in by the caller.
+try:
+    import tkinter as tk
+    import tkinter.font as tkfont
+    TclError = tk.TclError
+except ImportError:  # no Tk, or Tk present but its C extension cannot load
+    tk = None
+    tkfont = None
+
+    class TclError(Exception):
+        """Placeholder so ``except TclError`` parses when Tk is absent.
+
+        Unreachable in that case: the calls that raise it need a Tk root, which
+        cannot exist without Tk.
+        """
 
 
 # Named fonts every Tk/ttk widget references by default; resizing these resizes
@@ -58,11 +84,11 @@ def detect_dpi(root):
         px = root.winfo_screenwidth()
         mm = root.winfo_screenmmwidth()
         tk_dpi = (px * 25.4 / mm) if mm and mm > 0 else 96.0
-    except tk.TclError:
+    except TclError:
         tk_dpi = 96.0
     try:
         tk_dpi = max(tk_dpi, root.winfo_fpixels('1i'))
-    except tk.TclError:
+    except TclError:
         pass
     return tk_dpi
 
@@ -142,7 +168,7 @@ def apply_hidpi_scaling(root, lo=1.0, hi=3.0):
     for name in _NAMED_FONTS:
         try:
             f = tkfont.nametofont(name)
-        except tk.TclError:
+        except TclError:
             continue
         size = f.cget('size')
         if not size:        # 0 == "unspecified"; leave it to Tk
@@ -157,7 +183,7 @@ def apply_hidpi_scaling(root, lo=1.0, hi=3.0):
     # told otherwise.  That is why scaled fonts alone still look cramped.
     try:
         root.tk.call('tk', 'scaling', (96.0 * scale) / 72.0)
-    except tk.TclError:
+    except TclError:
         pass
 
     return scale


### PR DESCRIPTION
Fixes #266 — the issue that broke the conda-forge 4.0.0 build.

## Fix

`tkinter` is imported defensively, with `TclError` bound to a placeholder when Tk is absent. Nothing in this module needs a display: `detect_dpi`/`detect_scale` read `Xft.dpi` and xrandr and fall back to arithmetic. Only `apply_hidpi_scaling` touches Tk objects, and it already requires a live root from the caller — which cannot exist without Tk.

## Why option 2 and not option 1

The issue offered `pytest.importorskip` as the lighter fix. **The test module needs no change at all** — it drives `detect_scale` through a `_FakeRoot` and never constructs a real Tk root, so making the module importable is sufficient. Adding a skip would *lose* coverage that can in fact run headless, which is the opposite of what we want on a machine with no display.

## Verified, not assumed

Simulated the failure with a `meta_path` finder raising the exact libX11 `ImportError`:

| | result |
|---|---|
| unpatched module | reproduces the reported traceback at line 19 |
| patched module | imports; `tk is None`; `detect_dpi` 192.0; `detect_scale` 2.49 |
| `test_tk_scaling` **with** tkinter | 8 passed |
| `test_tk_scaling` **with tkinter blocked** | 8 passed |

## Not changed: the pmesh GUI modules

`anuga/pmesh/{toolbarbutton,ProgressBar,visualmesh,AppShell}.py` also import tkinter at module scope. Nothing collects them, so nothing fails today, and they use Tk pervasively at class-definition time — deferring it there is an invasive refactor with no tests to protect it. Better as a deliberate pass than churned alongside a build fix.

## Feedstock

Once this is released, [conda-forge/anuga-feedstock#25](https://github.com/conda-forge/anuga-feedstock/pull/25)'s `xorg-libx11` test dependency can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)