### PR TITLE
Generic passive tracers in the shallow water solver

### DIFF
--- a/anuga/parallel/parallel_generic_communications.py
+++ b/anuga/parallel/parallel_generic_communications.py
@@ -232,6 +232,88 @@ def communicate_ghosts_non_blocking(domain, quantities=None):
 
     domain.communication_time += time.time()-t0
 
+    # Tracers are not Quantity objects, so the loop above cannot see them.
+    communicate_tracer_ghosts(domain)
+
+
+
+def communicate_tracer_ghosts(domain):
+    """Exchange generic tracer values for ghost cells (legacy / mode 1).
+
+    The hydro exchange above iterates ``domain.conserved_quantities`` and reads
+    ``domain.quantities[q].centroid_values``. Tracers are raw ``(ns, n)`` arrays
+    on the Domain rather than Quantity objects, so they are invisible to it and
+    a partitioned run silently transports them with stale ghost values. The
+    symptom is subtle: total water volume stays exactly conserved while a
+    uniform tracer -- which must satisfy m == h exactly -- drifts away from it.
+
+    This cannot reuse the hydro buffers: ``full_send_dict[proc][2]`` is
+    allocated at distribute time with width ``len(conserved_quantities)``. So we
+    keep our own, allocated lazily and cached on the domain, and use a distinct
+    MPI tag.
+
+    Only the CONSERVED m = h*c is exchanged, matching both the hydro path and
+    gpu_halo.c: c is re-derived from m for ghost cells in extrapolation Step 1,
+    exactly as height is re-derived from stage.
+    """
+    import numpy as num
+    import time
+    import mpi4py
+
+    ns = getattr(domain, 'number_of_tracers', 0)
+    if ns == 0:
+        return
+
+    t0 = time.time()
+
+    sendDict = domain.full_send_dict
+    recvDict = domain.ghost_recv_dict
+    m = domain.tracer_conserved_values
+
+    # Cache the buffers, but key the cache on ns: add_tracer() reallocates the
+    # tracer arrays at a new width, and a stale buffer would silently exchange
+    # the wrong number of slots.
+    cache = getattr(domain, '_tracer_halo_buffers', None)
+    if cache is None or cache.get('ns') != ns:
+        cache = {'ns': ns, 'send': {}, 'recv': {}}
+        for proc in sendDict:
+            cache['send'][proc] = num.zeros((len(sendDict[proc][0]), ns),
+                                            dtype=num.float64)
+        for proc in recvDict:
+            cache['recv'][proc] = num.zeros((len(recvDict[proc][0]), ns),
+                                            dtype=num.float64)
+        domain._tracer_halo_buffers = cache
+
+    # Pack owned cells
+    for send_proc in sendDict:
+        Idf = sendDict[send_proc][0]
+        Xout = cache['send'][send_proc]
+        for s in range(ns):
+            Xout[:, s] = num.take(m[s], Idf)
+
+    # Tag 124: the hydro exchange above uses 123 on the same communicator and
+    # the two must not be matched against each other.
+    recv_requests = []
+    for recv_proc in recvDict:
+        recv_requests.append(
+            pypar.comm.Irecv(cache['recv'][recv_proc], recv_proc, 124))
+
+    send_requests = []
+    for send_proc in sendDict:
+        send_requests.append(
+            pypar.comm.Isend(cache['send'][send_proc], send_proc, 124))
+
+    mpi4py.MPI.Request.Waitall(recv_requests + send_requests)
+
+    # Unpack into ghost cells
+    for recv_proc in recvDict:
+        Idg = recvDict[recv_proc][0]
+        X = cache['recv'][recv_proc]
+        for s in range(ns):
+            num.put(m[s], Idg, X[:, s])
+
+    domain.communication_time += time.time() - t0
+
 
 def communicate_ghosts_asynchronous(domain, quantities=None):
 

--- a/anuga/shallow_water/gpu/core_kernels.c
+++ b/anuga/shallow_water/gpu/core_kernels.c
@@ -27,6 +27,8 @@ void core_extrapolate_second_order_edge(struct domain *D) {
     anuga_int extrapolate_velocity_second_order = D->extrapolate_velocity_second_order;
 
     // Parameters for hfactor computation (wet-dry limiting)
+    const anuga_int n_tracers_x = D->number_of_tracers;
+
     double a_tmp = 0.3;
     double b_tmp = 0.1;
     double c_tmp = 1.0 / (a_tmp - b_tmp);
@@ -58,6 +60,19 @@ void core_extrapolate_second_order_edge(struct domain *D) {
 
     anuga_int * restrict surrogate_neighbours = D->surrogate_neighbours;
     anuga_int * restrict number_of_boundaries = D->number_of_boundaries;
+
+    // Generic passive tracers. n_tracers == 0 in every ordinary run; keep only
+    // the loop-invariant count live in the common path.
+    const anuga_int n_tracers = D->number_of_tracers;
+    const double beta_tracer = D->beta_tracer;
+    // See the note above core_compute_fluxes_central: on a GPU build these must
+    // be loaded at function scope, because D is not mapped inside the 'omp
+    // target' regions below; on a CPU build they stay inside the guard.
+#ifndef CPU_ONLY_MODE
+    double * restrict t_cons = D->tracer_conserved_values;
+    double * restrict t_cv   = D->tracer_centroid_values;
+    double * restrict t_ev   = D->tracer_edge_values;
+#endif
     double * restrict x_centroid_work = D->x_centroid_work;
     double * restrict y_centroid_work = D->y_centroid_work;
 
@@ -85,6 +100,19 @@ void core_extrapolate_second_order_edge(struct domain *D) {
 
         xmom_cv[k] = xmom_out * inv_dk;
         ymom_cv[k] = ymom_out * inv_dk;
+
+        // Derive tracer concentration c = m/h from the conserved m, exactly as
+        // height is derived from stage above. Dry cells carry no concentration.
+        if (n_tracers_x > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_cons = D->tracer_conserved_values;
+            double * restrict t_cv   = D->tracer_centroid_values;
+#endif
+            double inv_h = is_dry ? 0.0 : (1.0 / dk);
+            for (anuga_int s = 0; s < n_tracers_x; s++) {
+                t_cv[s * n + k] = t_cons[s * n + k] * inv_h;
+            }
+        }
     }
 
     // Step 2: Main extrapolation loop
@@ -155,6 +183,19 @@ void core_extrapolate_second_order_edge(struct domain *D) {
                 ymom_ev[k3 + i] = ymom_c;
                 height_ev[k3 + i] = height_c;
                 bed_ev[k3 + i] = bed_c;
+            }
+
+            if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+                double * restrict t_cv = D->tracer_centroid_values;
+                double * restrict t_ev = D->tracer_edge_values;
+#endif
+                for (anuga_int sidx = 0; sidx < n_tracers; sidx++) {
+                    double tc = t_cv[sidx * n + k];
+                    t_ev[sidx * 3 * n + k3 + 0] = tc;
+                    t_ev[sidx * 3 * n + k3 + 1] = tc;
+                    t_ev[sidx * 3 * n + k3 + 2] = tc;
+                }
             }
 
         } else if (num_boundaries <= 1) {
@@ -231,6 +272,32 @@ void core_extrapolate_second_order_edge(struct domain *D) {
             ymom_ev[k3 + 1] = edge_vals[1];
             ymom_ev[k3 + 2] = edge_vals[2];
 
+            // Tracers. Reconstruct c (the intensive variable) rather than the
+            // conserved h*c: the limiter then bounds each edge value by the
+            // cell-and-neighbour range of c, which is what preserves positivity
+            // and prevents spurious extrema where h varies sharply.
+            if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+                double * restrict t_cv = D->tracer_centroid_values;
+                double * restrict t_ev = D->tracer_edge_values;
+#endif
+                double beta_t = beta_tracer * hfactor;
+                for (anuga_int sidx = 0; sidx < n_tracers; sidx++) {
+                    anuga_int off = sidx * n;
+                    if (beta_t > 0.0) {
+                        gpu_calc_edge_values_with_gradient(
+                            t_cv[off + k], t_cv[off + k0], t_cv[off + k1], t_cv[off + sn2],
+                            dxv0, dxv1, dxv2, dyv0, dyv1, dyv2,
+                            dx1, dx2, dy1, dy2, inv_area2, beta_t, edge_vals);
+                    } else {
+                        gpu_set_constant_edge_values(t_cv[off + k], edge_vals);
+                    }
+                    t_ev[sidx * 3 * n + k3 + 0] = edge_vals[0];
+                    t_ev[sidx * 3 * n + k3 + 1] = edge_vals[1];
+                    t_ev[sidx * 3 * n + k3 + 2] = edge_vals[2];
+                }
+            }
+
         } else {
             // Number of boundaries == 2
             // One internal neighbour, gradient is in direction of neighbour's centroid
@@ -295,6 +362,30 @@ void core_extrapolate_second_order_edge(struct domain *D) {
             ymom_ev[k3 + 0] = ymom_cv[k] + dqv[0];
             ymom_ev[k3 + 1] = ymom_cv[k] + dqv[1];
             ymom_ev[k3 + 2] = ymom_cv[k] + dqv[2];
+
+            // Tracers, 1D gradient toward the one internal neighbour
+            if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+                double * restrict t_cv = D->tracer_centroid_values;
+                double * restrict t_ev = D->tracer_edge_values;
+#endif
+                for (anuga_int sidx = 0; sidx < n_tracers; sidx++) {
+                    anuga_int off = sidx * n;
+                    double tk = t_cv[off + k];
+                    if (beta_tracer > 0.0) {
+                        dq1 = t_cv[off + kn] - tk;
+                        gpu_compute_dqv_from_gradient(dq1, grad_dx2, grad_dy2,
+                                                      dxv0, dxv1, dxv2, dyv0, dyv1, dyv2, dqv);
+                        gpu_compute_qmin_qmax_from_dq1(dq1, &qmin, &qmax);
+                        gpu_limit_gradient(dqv, qmin, qmax, beta_tracer);
+                    } else {
+                        dqv[0] = 0.0; dqv[1] = 0.0; dqv[2] = 0.0;
+                    }
+                    t_ev[sidx * 3 * n + k3 + 0] = tk + dqv[0];
+                    t_ev[sidx * 3 * n + k3 + 1] = tk + dqv[1];
+                    t_ev[sidx * 3 * n + k3 + 2] = tk + dqv[2];
+                }
+            }
         }
 
         // Convert velocity edge values back to momentum if needed
@@ -377,6 +468,7 @@ void core_distribute_edges_to_vertices(struct domain *D) {
 
 void core_update_conserved_quantities(struct domain *D, double timestep) {
     anuga_int n = D->number_of_elements;
+    const anuga_int n_tracers = D->number_of_tracers;
 
     double * restrict stage_cv = D->stage_centroid_values;
     double * restrict xmom_cv = D->xmom_centroid_values;
@@ -389,6 +481,20 @@ void core_update_conserved_quantities(struct domain *D, double timestep) {
     double * restrict stage_siu = D->stage_semi_implicit_update;
     double * restrict xmom_siu = D->xmom_semi_implicit_update;
     double * restrict ymom_siu = D->ymom_semi_implicit_update;
+
+    // Tracer pointers are hoisted to FUNCTION SCOPE here, not loaded inside the
+    // n_tracers > 0 guard as in the flux kernel. On a GPU build OMP_PARALLEL_LOOP
+    // is 'omp target teams loop', and D itself is NOT mapped to the device, so a
+    // D->member load inside the loop reads a host address on the device: the
+    // tracer update silently does nothing (m never changes, while the flux
+    // kernel still fills explicit_update). Hoisting lets the pointer values be
+    // captured as firstprivate scalars and address-translated. The flux kernel's
+    // in-guard loading is a CPU hot-loop optimisation (HANDOVER 2.4, +2.26%% at
+    // Ns=0) and does not apply to these much cheaper elementwise loops.
+#ifndef CPU_ONLY_MODE
+    double * restrict t_cons = D->tracer_conserved_values;
+    double * restrict t_eu   = D->tracer_explicit_update;
+#endif
 
     OMP_PARALLEL_LOOP
     for (anuga_int k = 0; k < n; k++) {
@@ -429,6 +535,20 @@ void core_update_conserved_quantities(struct domain *D, double timestep) {
         stage_siu[k] = 0.0;
         xmom_siu[k] = 0.0;
         ymom_siu[k] = 0.0;
+
+        // Tracers: integrate the conserved m = h*c. No semi-implicit term and
+        // deliberately NO clamping -- clamping would break exact conservation.
+        // Positivity is instead a property of the upwind flux under CFL, and is
+        // asserted by the tests rather than enforced here.
+        if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_cons = D->tracer_conserved_values;
+            double * restrict t_eu   = D->tracer_explicit_update;
+#endif
+            for (anuga_int s = 0; s < n_tracers; s++) {
+                t_cons[s * n + k] += timestep * t_eu[s * n + k];
+            }
+        }
     }
 }
 
@@ -438,6 +558,7 @@ void core_update_conserved_quantities(struct domain *D, double timestep) {
 
 void core_backup_conserved_quantities(struct domain *D) {
     anuga_int n = D->number_of_elements;
+    const anuga_int n_tracers = D->number_of_tracers;
 
     double * restrict stage_cv = D->stage_centroid_values;
     double * restrict xmom_cv = D->xmom_centroid_values;
@@ -447,11 +568,35 @@ void core_backup_conserved_quantities(struct domain *D) {
     double * restrict xmom_bk = D->xmom_backup_values;
     double * restrict ymom_bk = D->ymom_backup_values;
 
+    // Tracer pointers are hoisted to FUNCTION SCOPE here, not loaded inside the
+    // n_tracers > 0 guard as in the flux kernel. On a GPU build OMP_PARALLEL_LOOP
+    // is 'omp target teams loop', and D itself is NOT mapped to the device, so a
+    // D->member load inside the loop reads a host address on the device: the
+    // tracer update silently does nothing (m never changes, while the flux
+    // kernel still fills explicit_update). Hoisting lets the pointer values be
+    // captured as firstprivate scalars and address-translated. The flux kernel's
+    // in-guard loading is a CPU hot-loop optimisation (HANDOVER 2.4, +2.26%% at
+    // Ns=0) and does not apply to these much cheaper elementwise loops.
+#ifndef CPU_ONLY_MODE
+    double * restrict t_cons = D->tracer_conserved_values;
+    double * restrict t_bk   = D->tracer_backup_values;
+#endif
+
     OMP_PARALLEL_LOOP
     for (anuga_int k = 0; k < n; k++) {
         stage_bk[k] = stage_cv[k];
         xmom_bk[k] = xmom_cv[k];
         ymom_bk[k] = ymom_cv[k];
+
+        if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_cons = D->tracer_conserved_values;
+            double * restrict t_bk   = D->tracer_backup_values;
+#endif
+            for (anuga_int s = 0; s < n_tracers; s++) {
+                t_bk[s * n + k] = t_cons[s * n + k];
+            }
+        }
     }
 }
 
@@ -461,6 +606,7 @@ void core_backup_conserved_quantities(struct domain *D) {
 
 void core_saxpy_conserved_quantities(struct domain *D, double a, double b, double c) {
     anuga_int n = D->number_of_elements;
+    const anuga_int n_tracers = D->number_of_tracers;
 
     double * restrict stage_cv = D->stage_centroid_values;
     double * restrict xmom_cv = D->xmom_centroid_values;
@@ -470,12 +616,38 @@ void core_saxpy_conserved_quantities(struct domain *D, double a, double b, doubl
     double * restrict xmom_bk = D->xmom_backup_values;
     double * restrict ymom_bk = D->ymom_backup_values;
 
+    // Tracer pointers are hoisted to FUNCTION SCOPE here, not loaded inside the
+    // n_tracers > 0 guard as in the flux kernel. On a GPU build OMP_PARALLEL_LOOP
+    // is 'omp target teams loop', and D itself is NOT mapped to the device, so a
+    // D->member load inside the loop reads a host address on the device: the
+    // tracer update silently does nothing (m never changes, while the flux
+    // kernel still fills explicit_update). Hoisting lets the pointer values be
+    // captured as firstprivate scalars and address-translated. The flux kernel's
+    // in-guard loading is a CPU hot-loop optimisation (HANDOVER 2.4, +2.26%% at
+    // Ns=0) and does not apply to these much cheaper elementwise loops.
+#ifndef CPU_ONLY_MODE
+    double * restrict t_cons = D->tracer_conserved_values;
+    double * restrict t_bk   = D->tracer_backup_values;
+#endif
+
     // Standard SAXPY: Q = a*Q + b*Q_backup
     OMP_PARALLEL_LOOP
     for (anuga_int k = 0; k < n; k++) {
         stage_cv[k] = a * stage_cv[k] + b * stage_bk[k];
         xmom_cv[k] = a * xmom_cv[k] + b * xmom_bk[k];
         ymom_cv[k] = a * ymom_cv[k] + b * ymom_bk[k];
+
+        // SAXPY must act on the CONSERVED m, not on c: h differs between RK
+        // stages, so averaging c would not average the transported mass.
+        if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_cons = D->tracer_conserved_values;
+            double * restrict t_bk   = D->tracer_backup_values;
+#endif
+            for (anuga_int s = 0; s < n_tracers; s++) {
+                t_cons[s * n + k] = a * t_cons[s * n + k] + b * t_bk[s * n + k];
+            }
+        }
     }
 
     // Apply c scaling if needed: Q = Q / c
@@ -488,6 +660,12 @@ void core_saxpy_conserved_quantities(struct domain *D, double a, double b, doubl
             stage_cv[k] *= c_inv;
             xmom_cv[k] *= c_inv;
             ymom_cv[k] *= c_inv;
+            if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+                double * restrict t_cons = D->tracer_conserved_values;
+#endif
+                for (anuga_int s = 0; s < n_tracers; s++) t_cons[s * n + k] *= c_inv;
+            }
         }
     }
 }
@@ -962,6 +1140,33 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
     anuga_int * restrict riverwall_rowIndex = D->riverwall_rowIndex;
     double * restrict riverwall_hydraulic_properties = D->riverwall_hydraulic_properties;
 
+    // Generic passive tracers.  n_tracers == 0 in every ordinary run;
+    // all tracer work below is guarded on this loop-invariant integer.
+    const anuga_int n_tracers = D->number_of_tracers;
+
+// Tracer base pointers: WHERE they are loaded is build-dependent, and both
+// choices are load-bearing.
+//
+//   CPU build  -- load them INSIDE the n_tracers > 0 guard. Hoisting them to
+//                 function scope keeps them live across the hot loop and cost
+//                 +2.26% on the CPU path at Ns=0 (HANDOVER.md 2.4). Only the
+//                 benchmark caught that; every correctness test passed.
+//   GPU build  -- the loops below are 'omp target' regions and D is NOT mapped
+//                 to the device, so a D->member load inside the region reads a
+//                 host address on the device. The tracer work then silently
+//                 does nothing: no crash, explicit_update stays zero on the
+//                 device, and m never moves. They must be loaded at function
+//                 scope so the pointer VALUES are captured as firstprivate
+//                 scalars and address-translated via the present table.
+//
+// So: hoisted declarations under #ifndef CPU_ONLY_MODE, in-guard declarations
+// under #ifdef CPU_ONLY_MODE. The loop bodies are identical either way.
+#ifndef CPU_ONLY_MODE
+    double * restrict t_eu = D->tracer_explicit_update;
+    double * restrict t_ev = D->tracer_edge_values;
+    double * restrict t_bv = D->tracer_boundary_values;
+#endif
+
     // Reduction variables
     double local_timestep = 1.0e+100;
     double boundary_flux_sum_substep = 0.0;
@@ -981,6 +1186,12 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
         stage_eu[k] = 0.0;
         xmom_eu[k] = 0.0;
         ymom_eu[k] = 0.0;
+        if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_eu = D->tracer_explicit_update;
+#endif
+            for (anuga_int s = 0; s < n_tracers; s++) t_eu[s * n + k] = 0.0;
+        }
 
         // Get centroid values for this element
         double hc = height_cv[k];
@@ -1129,6 +1340,36 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
             xmom_eu[k] += edgeflux[1];
             ymom_eu[k] += edgeflux[2];
 
+            // --- Passive tracer advection -------------------------------
+            // edgeflux[0] is the water mass flux through this edge, already
+            // multiplied by -length.  Sign convention after that negation:
+            //     edgeflux[0] < 0  ->  OUTflow from k, donor is k
+            //     edgeflux[0] > 0  ->  INflow  to   k, donor is the neighbour
+            // Using the same edgeflux[0] for both cells sharing the edge makes
+            // tracer mass conservation structural, independent of cell sizes.
+            if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+                double * restrict t_ev = D->tracer_edge_values;
+                double * restrict t_bv = D->tracer_boundary_values;
+                double * restrict t_eu = D->tracer_explicit_update;
+#endif
+                const anuga_int t_bl = D->boundary_length;
+                const double wflux = edgeflux[0];
+                const int    inflow = (wflux > 0.0);
+                for (anuga_int s = 0; s < n_tracers; s++) {
+                    double c_up;
+                    if (inflow) {
+                        c_up = is_boundary
+                             ? t_bv[s * t_bl + (-neighbour - 1)]
+                             : t_ev[s * 3 * n + neighbour * 3 + neighbour_edges[ki]];
+                    } else {
+                        c_up = t_ev[s * 3 * n + ki];
+                    }
+                    t_eu[s * n + k] += wflux * c_up;
+                }
+            }
+            // -------------------------------------------------------------
+
             // Boundary flux tracking: if this cell is not a ghost, and the neighbour
             // is a boundary condition OR a ghost cell, add the flux to boundary integral
             if (tri_full_flag != NULL) {
@@ -1163,6 +1404,12 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
         stage_eu[k] *= inv_area;
         xmom_eu[k] *= inv_area;
         ymom_eu[k] *= inv_area;
+        if (n_tracers > 0) {
+#ifdef CPU_ONLY_MODE
+            double * restrict t_eu = D->tracer_explicit_update;
+#endif
+            for (anuga_int s = 0; s < n_tracers; s++) t_eu[s * n + k] *= inv_area;
+        }
 
     } // End element loop
 

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -770,6 +770,39 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         GD->backup_arrays_mapped = 1;
     }
 
+    // Map generic tracer arrays if any tracers are registered.
+    //
+    // Layout is tracer-major and C-contiguous, matching the indexing the shared
+    // kernels use: centroid[s*n + k], edge[s*3n + 3k + i], boundary[s*nb + m].
+    // All six must be mapped together: the kernels' n_tracers > 0 guard reads
+    // all of them, so a partial mapping is an illegal device address, not a
+    // degraded result.
+    if (GD->D.number_of_tracers > 0) {
+        anuga_int ns = GD->D.number_of_tracers;
+        double *tr_cv = GD->D.tracer_centroid_values;
+        double *tr_ev = GD->D.tracer_edge_values;
+        double *tr_eu = GD->D.tracer_explicit_update;
+        double *tr_qv = GD->D.tracer_conserved_values;
+        double *tr_bk = GD->D.tracer_backup_values;
+        #pragma omp target enter data map(to: \
+            tr_cv[0:ns*n], tr_ev[0:ns*3*n], \
+            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n])
+
+        // Boundary values are sized by boundary_length, which is zero on a
+        // domain with no boundary edges -- mapping a zero-length array is not
+        // meaningful, so follow the same nb > 0 guard the other bv arrays use.
+        if (nb > 0) {
+            double *tr_bv = GD->D.tracer_boundary_values;
+            #pragma omp target enter data map(to: tr_bv[0:ns*nb])
+        }
+        // Deliberately NOT recording a 'tracer_arrays_mapped' flag in
+        // struct gpu_domain: that struct embeds struct domain D, so adding a
+        // member risks the silent offset-aliasing failure documented in
+        // HANDOVER.md 2.1. number_of_tracers cannot change over the lifetime
+        // of a mapped domain (add_tracer tears the GPU interface down), so the
+        // unmap path re-tests the same condition instead.
+    }
+
     // Map halo exchange arrays if we have neighbors
     if (H->num_neighbors > 0) {
         int send_size = H->total_send_size;
@@ -778,9 +811,13 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         int *flat_recv = H->flat_recv_indices;
         double *send_buf = H->send_buffer;
         double *recv_buf = H->recv_buffer;
+        // Must match gpu_halo_stride() in gpu_halo.c: 3 conserved hydro
+        // quantities plus one m slot per tracer. A mismatch here maps a buffer
+        // shorter than the exchange writes.
+        const int halo_stride = 3 + (int)GD->D.number_of_tracers;
 
         #pragma omp target enter data map(to: flat_send[0:send_size], flat_recv[0:recv_size]) \
-            map(alloc: send_buf[0:3*send_size], recv_buf[0:3*recv_size])
+            map(alloc: send_buf[0:halo_stride*send_size], recv_buf[0:halo_stride*recv_size])
     }
 
     GD->gpu_initialized = 1;
@@ -1158,6 +1195,24 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
             stage_backup[0:n], xmom_backup[0:n], ymom_backup[0:n])
     }
 
+    // Unmap tracer arrays. Same condition as the map path above -- see the note
+    // there on why this is re-tested rather than recorded in a struct flag.
+    if (GD->D.number_of_tracers > 0) {
+        anuga_int ns = GD->D.number_of_tracers;
+        double *tr_cv = GD->D.tracer_centroid_values;
+        double *tr_ev = GD->D.tracer_edge_values;
+        double *tr_eu = GD->D.tracer_explicit_update;
+        double *tr_qv = GD->D.tracer_conserved_values;
+        double *tr_bk = GD->D.tracer_backup_values;
+        #pragma omp target exit data map(delete: \
+            tr_cv[0:ns*n], tr_ev[0:ns*3*n], \
+            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n])
+        if (nb > 0) {
+            double *tr_bv = GD->D.tracer_boundary_values;
+            #pragma omp target exit data map(delete: tr_bv[0:ns*nb])
+        }
+    }
+
     // Unmap halo arrays
     if (H->num_neighbors > 0) {
         int send_size = H->total_send_size;
@@ -1166,10 +1221,14 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         int *flat_recv = H->flat_recv_indices;
         double *send_buf = H->send_buffer;
         double *recv_buf = H->recv_buffer;
+        // Must match gpu_halo_stride() in gpu_halo.c: 3 conserved hydro
+        // quantities plus one m slot per tracer. A mismatch here maps a buffer
+        // shorter than the exchange writes.
+        const int halo_stride = 3 + (int)GD->D.number_of_tracers;
 
         #pragma omp target exit data map(delete: \
             flat_send[0:send_size], flat_recv[0:recv_size], \
-            send_buf[0:3*send_size], recv_buf[0:3*recv_size])
+            send_buf[0:halo_stride*send_size], recv_buf[0:halo_stride*recv_size])
     }
 
     GD->gpu_initialized = 0;
@@ -1186,6 +1245,21 @@ void gpu_domain_sync_to_device(struct gpu_domain *GD) {
     double *height_cv = GD->D.height_centroid_values;
 
     #pragma omp target update to(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
+
+    // Tracers: the conserved variable m = h*c is what the device integrates,
+    // and c is what Python seeds via set_tracer, so both have to go across.
+    // Boundary values too -- they are set on the host by boundary conditions.
+    if (GD->D.number_of_tracers > 0) {
+        anuga_int ns = GD->D.number_of_tracers;
+        anuga_int nb = GD->D.boundary_length;
+        double *tr_cv = GD->D.tracer_centroid_values;
+        double *tr_qv = GD->D.tracer_conserved_values;
+        #pragma omp target update to(tr_cv[0:ns*n], tr_qv[0:ns*n])
+        if (nb > 0) {
+            double *tr_bv = GD->D.tracer_boundary_values;
+            #pragma omp target update to(tr_bv[0:ns*nb])
+        }
+    }
 }
 
 void gpu_domain_sync_from_device(struct gpu_domain *GD) {
@@ -1199,6 +1273,16 @@ void gpu_domain_sync_from_device(struct gpu_domain *GD) {
     double *height_cv = GD->D.height_centroid_values;
 
     #pragma omp target update from(stage_cv[0:n], xmom_cv[0:n], ymom_cv[0:n], height_cv[0:n])
+
+    // Tracers: bring back both the conserved m and the derived c. Python reads
+    // c via get_tracer and computes mass from m, so returning only one of them
+    // would hand back a domain whose c and m disagree.
+    if (GD->D.number_of_tracers > 0) {
+        anuga_int ns = GD->D.number_of_tracers;
+        double *tr_cv = GD->D.tracer_centroid_values;
+        double *tr_qv = GD->D.tracer_conserved_values;
+        #pragma omp target update from(tr_cv[0:ns*n], tr_qv[0:ns*n])
+    }
 }
 
 void gpu_domain_sync_all_from_device(struct gpu_domain *GD) {

--- a/anuga/shallow_water/gpu/gpu_halo.c
+++ b/anuga/shallow_water/gpu/gpu_halo.c
@@ -17,6 +17,27 @@
 // Halo Exchange Setup
 // ============================================================================
 
+// Number of doubles exchanged per halo element.
+//
+// The halo carries the CONSERVED centroid quantities: stage, xmom, ymom, and
+// then one slot per tracer for m = h*c. Derived quantities are not exchanged --
+// height is recomputed from the exchanged stage in extrapolation Step 1, and c
+// is recomputed from the exchanged m in exactly the same place, for ghost cells
+// as well as owned ones.
+//
+// The stride is DERIVED from number_of_tracers rather than stored in
+// struct halo_exchange, because that struct is embedded in struct gpu_domain,
+// which embeds struct domain D -- adding a member there risks the silent offset
+// aliasing of HANDOVER.md 2.1. Deriving it is safe because the count cannot
+// change between init and exchange: gpu_halo_init runs after
+// get_domain_pointers has set number_of_tracers, and add_tracer() tears the
+// whole GPU interface down, forcing a re-init.
+//
+// At Ns=0 this is exactly 3, so the no-tracer path is byte-for-byte unchanged.
+static inline int gpu_halo_stride(const struct gpu_domain *GD) {
+    return 3 + (int)GD->D.number_of_tracers;
+}
+
 int gpu_halo_init(struct gpu_domain *GD,
                   int num_neighbors,
                   int *neighbor_ranks,
@@ -65,12 +86,13 @@ int gpu_halo_init(struct gpu_domain *GD,
     memcpy(H->flat_recv_indices, flat_recv_indices, H->total_recv_size * sizeof(int));
 
     // Allocate communication buffers
-    // 3 quantities per element: stage, xmom, ymom centroid values
+    // stride quantities per element: stage, xmom, ymom, then one m per tracer
+    const int stride = gpu_halo_stride(GD);
 #ifdef GPU_AWARE_MPI
     // Device buffers for GPU pack/unpack kernels
     int dev = omp_get_default_device();
-    H->send_buffer = (double *)omp_target_alloc(3 * H->total_send_size * sizeof(double), dev);
-    H->recv_buffer = (double *)omp_target_alloc(3 * H->total_recv_size * sizeof(double), dev);
+    H->send_buffer = (double *)omp_target_alloc(stride * H->total_send_size * sizeof(double), dev);
+    H->recv_buffer = (double *)omp_target_alloc(stride * H->total_recv_size * sizeof(double), dev);
     if (!H->send_buffer || !H->recv_buffer) {
         fprintf(stderr, "ERROR: omp_target_alloc failed for halo buffers\n");
         return -1;
@@ -80,15 +102,15 @@ int gpu_halo_init(struct gpu_domain *GD,
     // access omp_target_alloc device pointers, causing a SIGSEGV in MPI_Isend.
     // We always stage through host memory; the overhead is small because halos
     // are tiny compared to the full domain.
-    H->host_send_buffer = (double *)malloc(3 * H->total_send_size * sizeof(double));
-    H->host_recv_buffer = (double *)malloc(3 * H->total_recv_size * sizeof(double));
+    H->host_send_buffer = (double *)malloc(stride * H->total_send_size * sizeof(double));
+    H->host_recv_buffer = (double *)malloc(stride * H->total_recv_size * sizeof(double));
     if (!H->host_send_buffer || !H->host_recv_buffer) {
         fprintf(stderr, "ERROR: malloc failed for halo host staging buffers\n");
         return -1;
     }
 #else
-    H->send_buffer = (double *)malloc(3 * H->total_send_size * sizeof(double));
-    H->recv_buffer = (double *)malloc(3 * H->total_recv_size * sizeof(double));
+    H->send_buffer = (double *)malloc(stride * H->total_send_size * sizeof(double));
+    H->recv_buffer = (double *)malloc(stride * H->total_recv_size * sizeof(double));
     H->host_send_buffer = NULL;
     H->host_recv_buffer = NULL;
 #endif
@@ -162,9 +184,16 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     int send_size = H->total_send_size;
     int recv_size = H->total_recv_size;
 
+    const int stride = gpu_halo_stride(GD);
+    const int ns = (int)GD->D.number_of_tracers;
+    const anuga_int n = GD->D.number_of_elements;
+
     double *stage = GD->D.stage_centroid_values;
     double *xmom = GD->D.xmom_centroid_values;
     double *ymom = GD->D.ymom_centroid_values;
+    // Loaded at function scope, never inside the loop: these loops are 'omp
+    // target' regions on a GPU build and D is not mapped to the device.
+    double *t_cons = GD->D.tracer_conserved_values;
     double *send_buf = H->send_buffer;
     double *recv_buf = H->recv_buffer;
     int *flat_send = H->flat_send_indices;
@@ -179,9 +208,12 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
 #endif
     for (int idx = 0; idx < send_size; idx++) {
         int k = flat_send[idx];  // Local element index
-        send_buf[3*idx + 0] = stage[k];
-        send_buf[3*idx + 1] = xmom[k];
-        send_buf[3*idx + 2] = ymom[k];
+        send_buf[stride*idx + 0] = stage[k];
+        send_buf[stride*idx + 1] = xmom[k];
+        send_buf[stride*idx + 2] = ymom[k];
+        for (int s_i = 0; s_i < ns; s_i++) {
+            send_buf[stride*idx + 3 + s_i] = t_cons[(anuga_int)s_i * n + k];
+        }
     }
 
 #ifdef GPU_AWARE_MPI
@@ -199,7 +231,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
         int host = omp_get_initial_device();
         int dev  = omp_get_default_device();
         omp_target_memcpy(host_send, send_buf,
-                          3 * send_size * sizeof(double),
+                          stride * send_size * sizeof(double),
                           0, 0, host, dev);
 
         int req_count = 0;
@@ -209,7 +241,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
         for (int ni = 0; ni < H->num_neighbors; ni++) {
             int partner = H->neighbor_ranks[ni];
             int count = H->recv_counts[ni];
-            MPI_Irecv(&host_recv[3*recv_offset], 3*count, MPI_DOUBLE,
+            MPI_Irecv(&host_recv[stride*recv_offset], stride*count, MPI_DOUBLE,
                       partner, 0, GD->comm, &H->requests[req_count++]);
             recv_offset += count;
         }
@@ -218,7 +250,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
         for (int ni = 0; ni < H->num_neighbors; ni++) {
             int partner = H->neighbor_ranks[ni];
             int count = H->send_counts[ni];
-            MPI_Isend(&host_send[3*send_offset], 3*count, MPI_DOUBLE,
+            MPI_Isend(&host_send[stride*send_offset], stride*count, MPI_DOUBLE,
                       partner, 0, GD->comm, &H->requests[req_count++]);
             send_offset += count;
         }
@@ -228,7 +260,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
 
         // Copy received halo data from host staging buffer to device
         omp_target_memcpy(recv_buf, host_recv,
-                          3 * recv_size * sizeof(double),
+                          stride * recv_size * sizeof(double),
                           0, 0, dev, host);
     }
 
@@ -237,7 +269,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     // This is still efficient because halo is much smaller than full domain
 
     // Copy packed send buffer from GPU to host
-    #pragma omp target update from(send_buf[0:3*send_size])
+    #pragma omp target update from(send_buf[0:stride*send_size])
 
     // MPI communication on host
     int req_count = 0;
@@ -247,7 +279,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     for (int ni = 0; ni < H->num_neighbors; ni++) {
         int partner = H->neighbor_ranks[ni];
         int count = H->recv_counts[ni];
-        MPI_Irecv(&recv_buf[3*recv_offset], 3*count, MPI_DOUBLE,
+        MPI_Irecv(&recv_buf[stride*recv_offset], stride*count, MPI_DOUBLE,
                   partner, 0, GD->comm, &H->requests[req_count++]);
         recv_offset += count;
     }
@@ -256,7 +288,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     for (int ni = 0; ni < H->num_neighbors; ni++) {
         int partner = H->neighbor_ranks[ni];
         int count = H->send_counts[ni];
-        MPI_Isend(&send_buf[3*send_offset], 3*count, MPI_DOUBLE,
+        MPI_Isend(&send_buf[stride*send_offset], stride*count, MPI_DOUBLE,
                   partner, 0, GD->comm, &H->requests[req_count++]);
         send_offset += count;
     }
@@ -265,7 +297,7 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
     MPI_Waitall(req_count, H->requests, MPI_STATUSES_IGNORE);
 
     // Copy received halo data from host to GPU
-    #pragma omp target update to(recv_buf[0:3*recv_size])
+    #pragma omp target update to(recv_buf[0:stride*recv_size])
 #endif
 
     // Unpack receive buffer on GPU
@@ -276,9 +308,12 @@ void gpu_exchange_ghosts(struct gpu_domain *GD) {
 #endif
     for (int idx = 0; idx < recv_size; idx++) {
         int k = flat_recv[idx];  // Local ghost element index
-        stage[k] = recv_buf[3*idx + 0];
-        xmom[k] = recv_buf[3*idx + 1];
-        ymom[k] = recv_buf[3*idx + 2];
+        stage[k] = recv_buf[stride*idx + 0];
+        xmom[k] = recv_buf[stride*idx + 1];
+        ymom[k] = recv_buf[stride*idx + 2];
+        for (int s_i = 0; s_i < ns; s_i++) {
+            t_cons[(anuga_int)s_i * n + k] = recv_buf[stride*idx + 3 + s_i];
+        }
     }
     NVTX_POP();
 }

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -665,6 +665,23 @@ class Domain(Generic_Domain):
         self._Domain_C_struct = None
 
         #-------------------------------
+        # Generic passive tracers (see add_tracer).
+        #
+        # Ns = 0 is the default and costs nothing: the kernels read
+        # number_of_tracers and skip the tracer work entirely, and the six
+        # arrays below are passed to the C struct as NULL.
+        #-------------------------------
+        self.number_of_tracers = 0
+        self.beta_tracer = 1.0
+        self._tracer_names = []
+        self.tracer_centroid_values = None      # c            (ns, N)
+        self.tracer_edge_values = None          # c at edges   (ns, 3N)
+        self.tracer_boundary_values = None      # c at bdry    (ns, boundary_length)
+        self.tracer_explicit_update = None      # dm/dt        (ns, N)
+        self.tracer_conserved_values = None     # m = h*c      (ns, N)
+        self.tracer_backup_values = None        # m backup     (ns, N)
+
+        #-------------------------------
         # If environment variable OMP_NUM_THREADS is not set,
         # then set to default (1 thread). If a value is given to
         # the method, then it will override the default.
@@ -806,6 +823,158 @@ class Domain(Generic_Domain):
         self._Domain_C_struct = None
         # Force the mode-2 device interface to be rebuilt on demand.
         self.gpu_interface = None
+
+    #------------------------------------------------
+    # Generic passive tracers
+    #------------------------------------------------
+    _TRACER_ARRAYS = ('tracer_centroid_values', 'tracer_edge_values',
+                      'tracer_boundary_values', 'tracer_explicit_update',
+                      'tracer_conserved_values', 'tracer_backup_values')
+
+    def add_tracer(self, name, beta=None, initial_value=0.0):
+        """Register a passive tracer named `name` and return its index.
+
+        A tracer is a depth-averaged concentration `c` advected with the water
+        flux.  The conserved variable is `m = h*c`; `c` is derived from it each
+        substep, exactly as height is derived from stage.
+
+        Parameters
+        ----------
+        name : str
+            Identifier for the tracer.  Must be unique on this domain.
+        beta : float, optional
+            Edge-reconstruction limiter coefficient.  0 selects first order,
+            > 0 a limited second-order reconstruction.  **This is a single
+            value shared by every tracer** (the C struct carries one
+            `beta_tracer` scalar), so passing a value that disagrees with an
+            already-registered tracer is an error rather than a silent
+            last-writer-wins.  Defaults to leaving the current value alone.
+        initial_value : float or array-like, optional
+            Initial concentration `c`.  A scalar fills the domain; an array
+            must have one value per cell.  `m = h*c` is seeded consistently.
+
+        Returns
+        -------
+        int
+            The tracer's index, i.e. its row in the `(ns, ...)` arrays.
+
+        Notes
+        -----
+        Registering a tracer **reallocates** all six tracer arrays, so any
+        reference held to one of them beforehand becomes stale.  Add every
+        tracer before seeding values, or re-fetch via `get_tracer`.
+        """
+        if not isinstance(name, str) or not name:
+            raise ValueError('tracer name must be a non-empty string')
+        if name in self._tracer_names:
+            raise ValueError(
+                'a tracer named %r is already registered (index %d)'
+                % (name, self._tracer_names.index(name)))
+
+        if beta is not None:
+            beta = float(beta)
+            if beta < 0.0:
+                raise ValueError('beta must be >= 0, got %g' % beta)
+            # One scalar serves all tracers, so a second, different value would
+            # silently change the reconstruction of the tracers already added.
+            if self.number_of_tracers > 0 and beta != self.beta_tracer:
+                raise ValueError(
+                    'beta_tracer is shared by all tracers on a domain: cannot '
+                    'add %r with beta=%g while existing tracers use beta=%g'
+                    % (name, beta, self.beta_tracer))
+            self.beta_tracer = beta
+
+        N = self.number_of_elements
+        ns = self.number_of_tracers
+        shapes = {
+            'tracer_centroid_values':  (ns + 1, N),
+            'tracer_edge_values':      (ns + 1, 3 * N),
+            'tracer_boundary_values':  (ns + 1, self.boundary_length),
+            'tracer_explicit_update':  (ns + 1, N),
+            'tracer_conserved_values': (ns + 1, N),
+            'tracer_backup_values':    (ns + 1, N),
+        }
+
+        # Grow each array by one row, preserving the tracers already there.
+        # The kernels index these as centroid[s*N + k] etc., so they must stay
+        # C-contiguous float64 -- num.zeros gives both.
+        for attr in self._TRACER_ARRAYS:
+            new = num.zeros(shapes[attr], dtype=num.float64)
+            if ns > 0:
+                old = getattr(self, attr)
+                new[:ns] = old
+            setattr(self, attr, new)
+
+        index = ns
+        self._tracer_names.append(name)
+        self.number_of_tracers = ns + 1
+
+        # THE TRAP: the C struct is built once and cached, and evolve() never
+        # passes update_domain_c_struct=True. Without this line a tracer
+        # registered after the struct exists is invisible to the kernels --
+        # no error, the tracer simply never moves. It also now holds pointers
+        # into the arrays we just replaced. Invalidate so the next call
+        # rebuilds it against the new arrays.
+        self._Domain_C_struct = None
+
+        # Same argument on the device side: the GPU interface has the OLD
+        # tracer arrays mapped (or none at all, if it was built at Ns=0), and
+        # the arrays it points at have just been freed. Tear it down so it is
+        # rebuilt and re-mapped against the new ones. _ensure_gpu_interface()
+        # recreates it on demand.
+        self.gpu_interface = None
+        # NB: this flag is tested with hasattr, not for truthiness (see
+        # update_boundary), so it must be DELETED, not set False -- setting it
+        # False would skip the re-initialisation that defines _gpu_all_on_gpu.
+        if hasattr(self, '_gpu_boundary_info_initialized'):
+            del self._gpu_boundary_info_initialized
+
+        if initial_value is not None:
+            self.set_tracer(name, initial_value)
+
+        return index
+
+    def get_tracer_index(self, name):
+        """Return the row index of tracer `name`."""
+        try:
+            return self._tracer_names.index(name)
+        except ValueError:
+            raise ValueError('no tracer named %r; registered tracers are %r'
+                             % (name, list(self._tracer_names)))
+
+    def get_tracer_names(self):
+        """Return the registered tracer names, in index order."""
+        return list(self._tracer_names)
+
+    def _tracer_depth(self):
+        """Cell depth h = stage - elevation, floored at zero."""
+        h = (self.quantities['stage'].centroid_values
+             - self.quantities['elevation'].centroid_values)
+        return num.maximum(h, 0.0)
+
+    def get_tracer(self, name):
+        """Return the concentration `c` of tracer `name`, one value per cell."""
+        return self.tracer_centroid_values[self.get_tracer_index(name)]
+
+    def set_tracer(self, name, values):
+        """Set the concentration `c` of tracer `name`.
+
+        Seeds both `c` and the conserved `m = h*c`, which must agree: setting
+        `c` alone leaves the conserved variable stale and the first substep
+        overwrites `c` from it.
+        """
+        s = self.get_tracer_index(name)
+        # asarray, not ascontiguousarray: the latter promotes a 0-d scalar to
+        # shape (1,), which would defeat the scalar branch below.
+        c = num.asarray(values, dtype=num.float64)
+        if c.ndim == 0:
+            c = num.full(self.number_of_elements, float(c))
+        elif c.shape != (self.number_of_elements,):
+            raise ValueError(
+                'tracer %r: expected a scalar or %d values, got shape %r'
+                % (name, self.number_of_elements, c.shape))
+        self.tracer_centroid_values[s] = c
+        self.tracer_conserved_values[s] = self._tracer_depth() * c
 
     def update_domain_c_struct(self):
         """Update the C domain structure from the Python Domain object.

--- a/anuga/shallow_water/sw_domain.h
+++ b/anuga/shallow_water/sw_domain.h
@@ -118,6 +118,41 @@ struct domain {
     double* xmom_backup_values;
     double* ymom_backup_values;
 
+    /* ------------------------------------------------------------------
+     * Generic passive tracers (sediment concentration, salinity, ...).
+     *
+     * Appended at the END of the struct on purpose so every pre-existing
+     * field keeps its offset and the cache layout of the hot arrays is
+     * untouched. Adding a member anywhere else silently shifts the offset of
+     * everything after it, and the Cython extensions are not rebuilt when
+     * this header changes -- so the failure is a wrong binary, not a
+     * compile error.
+     *
+     * number_of_tracers == 0 is the ordinary case and must cost nothing:
+     * the flux kernel guards all tracer work behind a single test on this
+     * loop-invariant integer.
+     *
+     * Layout is tracer-major:
+     *   centroid[s*n + k]          n = number_of_elements
+     *   edge    [s*3n + 3k + i]
+     *   boundary[s*boundary_length + m]
+     *   explicit_update[s*n + k]
+     * ------------------------------------------------------------------ */
+    anuga_int number_of_tracers;
+    double* tracer_centroid_values;
+    double* tracer_edge_values;
+    double* tracer_boundary_values;
+    double* tracer_explicit_update;
+    /* m = h*c, the CONSERVED tracer variable. Integrated by
+     * update/backup/saxpy exactly like stage; tracer_centroid_values (c) is
+     * DERIVED from it each substep, exactly as height is derived from stage. */
+    double* tracer_conserved_values;
+    double* tracer_backup_values;
+    /* Reconstruction aggressiveness for tracers, analogous to beta_w for stage.
+     * 0.0 => first order; >0 => limited second order. Appended at the very end
+     * so no previously-existing field offset moves. */
+    double beta_tracer;
+
 };
 
 

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -101,6 +101,14 @@ cdef extern from "gpu_domain.h" nogil:
         int64_t* tri_full_flag
         # Riverwall arrays
         int64_t number_of_riverwall_edges
+        int64_t number_of_tracers
+        double beta_tracer
+        double* tracer_centroid_values
+        double* tracer_edge_values
+        double* tracer_boundary_values
+        double* tracer_explicit_update
+        double* tracer_conserved_values
+        double* tracer_backup_values
         int64_t ncol_riverwall_hydraulic_properties
         int64_t nrow_riverwall_hydraulic_properties
         int64_t* edge_flux_type
@@ -799,6 +807,37 @@ cdef void get_domain_pointers(gpu_domain *GD, object domain_object):
         D.edge_flux_type = &edge_flux_type[0]
     else:
         D.edge_flux_type = NULL
+
+    # Generic tracers. number_of_tracers MUST be set explicitly -- the mode-2
+    # struct is PyMem_Malloc'd and not reliably zeroed, and a garbage count makes
+    # the kernel guard fire on the device (CUDA_ERROR_ILLEGAL_ADDRESS).
+    D.number_of_tracers = getattr(domain_object, 'number_of_tracers', 0)
+    D.beta_tracer = getattr(domain_object, 'beta_tracer', 1.0)
+    # Phase 2: wire the tracer arrays for the device. The pointers must be set
+    # whenever number_of_tracers > 0 -- the shared kernels guard on that count
+    # and dereference all six, so a NULL here is CUDA_ERROR_ILLEGAL_ADDRESS on
+    # the device, not a degraded result. gpu_domain_core.c maps them.
+    cdef double[:, ::1] tr2
+    if D.number_of_tracers > 0:
+        tr2 = domain_object.tracer_centroid_values
+        D.tracer_centroid_values = &tr2[0, 0]
+        tr2 = domain_object.tracer_edge_values
+        D.tracer_edge_values = &tr2[0, 0]
+        tr2 = domain_object.tracer_boundary_values
+        D.tracer_boundary_values = &tr2[0, 0]
+        tr2 = domain_object.tracer_explicit_update
+        D.tracer_explicit_update = &tr2[0, 0]
+        tr2 = domain_object.tracer_conserved_values
+        D.tracer_conserved_values = &tr2[0, 0]
+        tr2 = domain_object.tracer_backup_values
+        D.tracer_backup_values = &tr2[0, 0]
+    else:
+        D.tracer_centroid_values = NULL
+        D.tracer_edge_values = NULL
+        D.tracer_boundary_values = NULL
+        D.tracer_explicit_update = NULL
+        D.tracer_conserved_values = NULL
+        D.tracer_backup_values = NULL
 
     # Extract riverwall arrays (may be empty if no riverwalls)
     D.number_of_riverwall_edges = getattr(domain_object, 'number_of_riverwall_edges', 0)

--- a/anuga/shallow_water/sw_domain_openmp_ext.pyx
+++ b/anuga/shallow_water/sw_domain_openmp_ext.pyx
@@ -19,6 +19,14 @@ cdef extern from "sw_domain_openmp.c" nogil:
 		anuga_int number_of_elements
 		anuga_int boundary_length
 		anuga_int number_of_riverwall_edges
+		anuga_int number_of_tracers
+		double beta_tracer
+		double* tracer_centroid_values
+		double* tracer_edge_values
+		double* tracer_boundary_values
+		double* tracer_explicit_update
+		double* tracer_conserved_values
+		double* tracer_backup_values
 		anuga_int optimise_dry_cells
 		anuga_int extrapolate_velocity_second_order
 		anuga_int low_froude
@@ -152,6 +160,11 @@ cdef inline get_python_domain_parameters(domain *D, object domain_py_object):
 	D.number_of_elements = domain_py_object.number_of_elements
 	D.boundary_length = domain_py_object.boundary_length
 	D.number_of_riverwall_edges = domain_py_object.number_of_riverwall_edges
+	# Generic tracers. The struct is PyMem_Malloc'd (not zeroed), so this
+	# MUST be set on every fill or the flux kernel guard reads garbage.
+	D.number_of_tracers = getattr(domain_py_object, 'number_of_tracers', 0)
+	# 0.0 => first order; >0 => limited second order (see sw_domain.h)
+	D.beta_tracer = getattr(domain_py_object, 'beta_tracer', 1.0)
 	D.optimise_dry_cells = domain_py_object.optimise_dry_cells
 	D.extrapolate_velocity_second_order = domain_py_object.extrapolate_velocity_second_order
 	D.low_froude = domain_py_object.low_froude
@@ -307,6 +320,30 @@ cdef inline get_python_domain_pointers(domain *D, object domain_py_object):
 	#------------------------------------------------------
 	# Quantity structures
 	#------------------------------------------------------
+	# Generic tracer arrays. Owned by the Python Domain as C-contiguous
+	# (ns, ...) float64 arrays; NULL when no tracers are registered.
+	cdef double[:, ::1] tr2
+	if getattr(domain_py_object, 'number_of_tracers', 0) > 0:
+		tr2 = domain_py_object.tracer_centroid_values
+		D.tracer_centroid_values = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_edge_values
+		D.tracer_edge_values = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_boundary_values
+		D.tracer_boundary_values = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_explicit_update
+		D.tracer_explicit_update = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_conserved_values
+		D.tracer_conserved_values = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_backup_values
+		D.tracer_backup_values = &tr2[0, 0]
+	else:
+		D.tracer_centroid_values = NULL
+		D.tracer_edge_values = NULL
+		D.tracer_boundary_values = NULL
+		D.tracer_explicit_update = NULL
+		D.tracer_conserved_values = NULL
+		D.tracer_backup_values = NULL
+
 	quantities = domain_py_object.quantities
 	stage = quantities["stage"]
 	xmomentum = quantities["xmomentum"]

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -15,6 +15,8 @@ python_sources = [
 'test_sw_domain_openmp.py',
 'test_DE_gpu_omp.py',
 'test_compute_mode.py',
+'test_tracers.py',
+'test_tracers_gpu.py',
 'test_forcing.py',
 'test_friction.py',
 'test_loadsave.py',

--- a/anuga/shallow_water/tests/test_tracers.py
+++ b/anuga/shallow_water/tests/test_tracers.py
@@ -18,6 +18,11 @@ The properties tested here, in the order they matter:
   API             `add_tracer` shapes, contiguity, cache invalidation, and the
                   errors it raises
 
+The transport tests are parametrised over every flow algorithm, because a
+kernel that does not carry tracers drops them silently -- nothing errors, the
+concentration just stops moving. `test_every_transport_path_is_covered` fails
+if a new path selector appears without the parametrisation growing to match.
+
 Mode 1 only. The mode 1 / mode 2 comparison is in test_tracers_gpu.py, which
 has to guard itself against the NVHPC runtime.
 """
@@ -148,9 +153,24 @@ def test_order_of_accuracy_on_a_smooth_monotone_field():
 
 # ---------------------------------------------------------------- flux kernel
 
-def _dam_break_domain(nxy=20, names=('c',), beta=1.0):
+# Every distinct transport path this build offers. The tracer tests below are
+# parametrised over it, which is what makes "a tracer is transported" an
+# enforced guarantee rather than an argued one: a flux or update kernel that
+# does not carry tracers fails here instead of silently dropping them, and a
+# dropped tracer is invisible -- the concentration simply stops moving.
+#
+# Adding a path is one entry. See test_every_transport_path_is_covered below,
+# which fails when a new path selector appears and this list has not grown.
+_FLOW_ALGORITHMS = ('DE0', 'DE1', 'DE2')
+
+# Domain attributes, not yet present, that will select an alternative flux or
+# update kernel. Named here so their arrival is noticed; see the test.
+_FUTURE_PATH_SELECTORS = ('reconstruct_edge_bed',)
+
+
+def _dam_break_domain(nxy=20, names=('c',), beta=1.0, algorithm='DE0'):
     d = rectangular_cross_domain(nxy, nxy, len1=LEN, len2=LEN)
-    d.set_flow_algorithm('DE0')
+    d.set_flow_algorithm(algorithm)
     d.set_low_froude(0)
     d.store = False
     d.set_quantity('elevation', 0.0)
@@ -263,9 +283,10 @@ def test_two_tracers_are_indexed_and_do_not_alias():
 
 # ---------------------------------------------------------------- integration
 
-def test_uniform_tracer_survives_a_dam_break_unchanged():
+@pytest.mark.parametrize('algorithm', _FLOW_ALGORITHMS)
+def test_uniform_tracer_survives_a_dam_break_unchanged(algorithm):
     """Free stream: a uniform c must stay uniform however violent the flow."""
-    d = _dam_break_domain(nxy=30)
+    d = _dam_break_domain(nxy=30, algorithm=algorithm)
     d.set_tracer('c', 0.4)
     d.tracer_boundary_values[0, :] = 0.4
     d.evolve_to_end(finaltime=20.0)
@@ -276,8 +297,9 @@ def test_uniform_tracer_survives_a_dam_break_unchanged():
     assert np.abs(c - 0.4).max() < 1e-9
 
 
-def test_tracer_mass_is_conserved_positive_and_bounded():
-    d = _dam_break_domain(nxy=30)
+@pytest.mark.parametrize('algorithm', _FLOW_ALGORITHMS)
+def test_tracer_mass_is_conserved_positive_and_bounded(algorithm):
+    d = _dam_break_domain(nxy=30, algorithm=algorithm)
     xc = d.centroid_coordinates[:, 0]
     d.set_tracer('c', np.where(xc < LEN / 4, 0.8, 0.0))
     d.tracer_boundary_values[0, :] = 0.0
@@ -301,13 +323,14 @@ def test_tracer_mass_is_conserved_positive_and_bounded():
 
 
 @pytest.mark.slow
-def test_tracer_is_actually_transported():
+@pytest.mark.parametrize('algorithm', _FLOW_ALGORITHMS)
+def test_tracer_is_actually_transported(algorithm):
     """Guards against a suite that would pass on a tracer that never moves.
 
     Needs the whole upstream reservoir, and long enough to matter: over 20 s
     the centre of mass barely shifts and the test measures nothing.
     """
-    d = _dam_break_domain(nxy=30)
+    d = _dam_break_domain(nxy=30, algorithm=algorithm)
     xc = d.centroid_coordinates[:, 0]
     d.set_tracer('c', np.where(xc < LEN / 2, 1.0, 0.0))
     d.tracer_boundary_values[0, :] = 0.0
@@ -317,6 +340,29 @@ def test_tracer_is_actually_transported():
     w = d.tracer_conserved_values[0] * d.areas
     x1 = float((w * xc).sum() / max(w.sum(), 1e-30))
     assert x1 > x0 + 1.0, 'the tracer centre of mass did not move downstream'
+
+
+def test_every_transport_path_is_covered():
+    """Fail when a new transport path appears that the tests do not cover.
+
+    A flux or update kernel that does not carry tracers drops them SILENTLY --
+    the concentration simply stops moving, with no error and no failing test
+    unless something exercises that path. The parametrisation above covers the
+    paths that exist today; this exists so that the next one cannot arrive
+    unnoticed.
+
+    If this fails, a domain attribute selecting an alternative kernel has been
+    added. That is not a defect -- the fix is to decide whether tracers are
+    carried on the new path, make sure they are, and add it to _FLOW_ALGORITHMS
+    or to a parametrisation of its own so the guarantee stays enforced.
+    """
+    d = _small_domain()
+    present = [name for name in _FUTURE_PATH_SELECTORS if hasattr(d, name)]
+    assert not present, (
+        'Domain now has %s, which selects an alternative flux or update '
+        'kernel. Check that kernel carries tracers, then extend the '
+        'parametrisation in this file to cover it and remove the name from '
+        '_FUTURE_PATH_SELECTORS.' % ', '.join(repr(n) for n in present))
 
 
 # ---------------------------------------------------------------- add_tracer

--- a/anuga/shallow_water/tests/test_tracers.py
+++ b/anuga/shallow_water/tests/test_tracers.py
@@ -1,0 +1,404 @@
+"""Generic passive tracers carried by the shallow water solver.
+
+A tracer is a depth-averaged concentration `c` transported as the conserved
+quantity `m = h c`, alongside stage and momentum and through the same flux
+kernel. Domains carry none by default; `domain.add_tracer(name)` registers one.
+
+The properties tested here, in the order they matter:
+
+  reconstruction  first order at beta = 0, constants exact, monotone on a step
+                  (which is what keeps `c` positive), second order on a smooth
+                  monotone field
+  flux            consistency (`c = 1` reproduces the stage tendency exactly),
+                  linearity, upwinding, and discrete conservation
+  striding        with two tracers the tracer-major `(ns, ...)` layout is
+                  indexed correctly and the slots do not alias
+  integration     mass conserved through a dam break, `c` positive and bounded
+                  without being clamped, and actually transported
+  API             `add_tracer` shapes, contiguity, cache invalidation, and the
+                  errors it raises
+
+Mode 1 only. The mode 1 / mode 2 comparison is in test_tracers_gpu.py, which
+has to guard itself against the NVHPC runtime.
+"""
+import numpy as np
+import pytest
+
+import anuga
+from anuga import Reflective_boundary, rectangular_cross_domain
+from anuga.shallow_water.sw_domain_openmp_ext import (
+    compute_fluxes_ext_central, extrapolate_second_order_sw)
+
+LEN = 1000.0
+
+
+def _flat_domain(nxy, beta=1.0, stage=5.0, names=('c',)):
+    """A uniformly wet, flat, still domain -- deep enough that the wet/dry
+    hfactor does not throttle the reconstruction."""
+    d = rectangular_cross_domain(nxy, nxy, len1=LEN, len2=LEN)
+    d.set_flow_algorithm('DE0')
+    d.set_low_froude(0)
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', stage)
+    d.set_quantity('xmomentum', 0.0)
+    d.set_quantity('ymomentum', 0.0)
+    d.set_boundary({t: Reflective_boundary(d) for t in d.get_boundary_tags()})
+    for i, nm in enumerate(names):
+        d.add_tracer(nm, beta=beta if i == 0 else None)
+    return d
+
+
+def _reconstruct(d, cfield, slot=0):
+    """Seed m = h c, extrapolate, and return the edge values.
+
+    `c` is derived from the conserved `m` each substep, so the field has to be
+    seeded through `m` rather than written to the centroid values directly.
+    """
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    d.tracer_conserved_values[slot, :] = np.maximum(h, 0.0) * cfield
+    d.tracer_centroid_values[slot, :] = cfield
+    d.tracer_edge_values[slot, :] = np.nan      # poison: detect non-writes
+    extrapolate_second_order_sw(d, update_domain_c_struct=True)
+    ev = d.tracer_edge_values[slot].copy()
+    assert not np.isnan(ev).any(), 'some edge values were never written'
+    return ev
+
+
+# ---------------------------------------------------------------- reconstruction
+
+def test_beta_zero_is_first_order():
+    """beta = 0 must leave every edge value equal to its centroid value."""
+    d = _flat_domain(12, beta=0.0)
+    c = 0.5 + 0.4 * np.sin(2 * np.pi * d.centroid_coordinates[:, 0] / LEN)
+    ev = _reconstruct(d, c)
+    # c is derived as m/h, so the round trip costs about one ulp.
+    assert np.max(np.abs(ev - np.repeat(c, 3))) < 1e-15
+
+
+def test_uniform_field_is_reproduced_exactly():
+    """A reconstruction that cannot reproduce a constant is broken outright."""
+    d = _flat_domain(12, beta=1.0)
+    ev = _reconstruct(d, np.full(len(d), 0.7))
+    assert np.allclose(ev, 0.7, rtol=0, atol=1e-15)
+
+
+def test_step_creates_no_new_extrema_and_stays_positive():
+    """Monotonicity on a step is what protects positivity of concentration."""
+    d = _flat_domain(24, beta=1.0)
+    xc = d.centroid_coordinates[:, 0]
+    c = np.where(xc < LEN / 2, 1.0, 0.0)
+    ev = _reconstruct(d, c)
+    assert ev.max() - c.max() <= 1e-14, 'overshoot above the centroid maximum'
+    assert c.min() - ev.min() <= 1e-14, 'undershoot below the centroid minimum'
+    assert ev.min() >= 0.0, 'negative edge concentration'
+
+
+def test_linear_field_is_exact_on_interior_cells():
+    """A linear field is the fixed point of a second-order reconstruction.
+
+    Interior cells only: where a cell touches the boundary,
+    `surrogate_neighbours` substitutes the cell itself and degrades the
+    gradient stencil. That is ANUGA's existing behaviour, and stage shows the
+    same error on the same cells.
+    """
+    d = _flat_domain(16, beta=1.0)
+    cc = d.centroid_coordinates
+    def f(x, y):
+        return 0.5 + 0.3 * (x / LEN) + 0.2 * (y / LEN)
+    ev = _reconstruct(d, f(cc[:, 0], cc[:, 1]))
+    ec = d.get_edge_midpoint_coordinates()
+    err = np.abs(ev - f(ec[:, 0], ec[:, 1]))
+    interior = np.repeat(d.number_of_boundaries, 3) == 0
+    assert err[interior].max() < 1e-12
+
+
+@pytest.mark.slow
+def test_order_of_accuracy_on_a_smooth_monotone_field():
+    """beta = 0 converges at first order, beta = 1 at second.
+
+    The field is deliberately monotone. A limiter cannot be both
+    unconditionally monotone and cleanly second order at a smooth extremum
+    (Godunov), so it clips at crests and drops locally to first order there --
+    which is the price of the monotonicity tested above, and the right trade.
+    """
+    def f(x, y):
+        return 0.5 + 0.4 * (x / LEN) ** 2
+
+    def rms_errors(beta, sizes):
+        out = []
+        for nxy in sizes:
+            d = _flat_domain(nxy, beta=beta)
+            cc = d.centroid_coordinates
+            ev = _reconstruct(d, f(cc[:, 0], cc[:, 1]))
+            ec = d.get_edge_midpoint_coordinates()
+            m = np.repeat(d.number_of_boundaries, 3) == 0
+            out.append(float(np.sqrt(np.mean((ev[m] - f(ec[m, 0], ec[m, 1])) ** 2))))
+        return out
+
+    sizes = (8, 16, 32)
+    e1 = rms_errors(0.0, sizes)
+    e2 = rms_errors(1.0, sizes)
+    o1 = np.mean([np.log2(e1[i] / e1[i + 1]) for i in range(len(e1) - 1)])
+    o2 = np.mean([np.log2(e2[i] / e2[i + 1]) for i in range(len(e2) - 1)])
+    assert 0.7 < o1 < 1.3, 'beta=0 should be first order, got %.2f' % o1
+    assert o2 > 1.95, 'beta=1 should be second order, got %.2f' % o2
+
+
+# ---------------------------------------------------------------- flux kernel
+
+def _dam_break_domain(nxy=20, names=('c',), beta=1.0):
+    d = rectangular_cross_domain(nxy, nxy, len1=LEN, len2=LEN)
+    d.set_flow_algorithm('DE0')
+    d.set_low_froude(0)
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', lambda x, y: np.where(x < LEN / 2, 2.0, 0.5))
+    d.set_quantity('xmomentum', 0.0)
+    d.set_quantity('ymomentum', 0.0)
+    d.set_boundary({t: Reflective_boundary(d) for t in d.get_boundary_tags()})
+    for i, nm in enumerate(names):
+        d.add_tracer(nm, beta=beta if i == 0 else None)
+    return d
+
+
+def _prime(d, finaltime=2.0):
+    """Advance far enough that there is real flow through interior edges.
+
+    This also gets the boundary conditions applied. Evaluating fluxes on a
+    freshly built domain instead measures nothing useful: the boundary arrays
+    are still unset, tracer leaks out through the walls, and the conservation
+    check below fails with a residual of 87% rather than 4e-17.
+    """
+    d.evolve_to_end(finaltime=finaltime)
+    return d
+
+
+def _fluxes(d):
+    """Take one flux evaluation with the current tracer state."""
+    d.tracer_explicit_update[:] = 0.0
+    # Recompute so the stage/momentum edge values match the current centroids.
+    d.distribute_to_vertices_and_edges()
+    d.update_boundary()
+    compute_fluxes_ext_central(d, d.evolve_max_timestep,
+                               update_domain_c_struct=True)
+    return (d.quantities['stage'].explicit_update.copy(),
+            d.tracer_explicit_update.copy())
+
+
+def _seed_uniform(d, value, slot=0):
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    d.tracer_conserved_values[slot, :] = np.maximum(h, 0.0) * value
+    d.tracer_centroid_values[slot, :] = value
+    d.tracer_boundary_values[slot, :] = value
+
+
+def test_flux_consistency_c_equal_one_reproduces_the_stage_tendency():
+    """With c = 1 everywhere, m = h, so dm/dt must equal dh/dt exactly."""
+    d = _prime(_dam_break_domain())
+    _seed_uniform(d, 1.0)
+    stage_eu, tracer_eu = _fluxes(d)
+    scale = max(np.abs(stage_eu).max(), 1e-30)
+    assert np.abs(tracer_eu[0] - stage_eu).max() < 1e-12 * scale
+
+
+def test_flux_is_linear_in_concentration():
+    d = _prime(_dam_break_domain())
+    K = 0.375
+    _seed_uniform(d, K)
+    stage_eu, tracer_eu = _fluxes(d)
+    scale = max(np.abs(K * stage_eu).max(), 1e-30)
+    assert np.abs(tracer_eu[0] - K * stage_eu).max() < 1e-12 * scale
+
+
+def test_flux_is_conservative_on_a_closed_domain():
+    """Reflective everywhere, so the area-weighted tendency must sum to zero."""
+    d = _prime(_dam_break_domain())
+    rng = np.random.default_rng(42)
+    _seed_uniform(d, 0.0)
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    c = rng.random(len(d))
+    d.tracer_conserved_values[0, :] = np.maximum(h, 0.0) * c
+    d.tracer_centroid_values[0, :] = c
+    d.tracer_boundary_values[0, :] = 0.0
+    _, tracer_eu = _fluxes(d)
+    total = float((tracer_eu[0] * d.areas).sum())
+    scale = float((np.abs(tracer_eu[0]) * d.areas).sum())
+    assert abs(total) < 1e-12 * max(scale, 1e-30)
+
+
+def test_transport_is_upwinded():
+    """Cold cells ahead of the front stay cold; cells at the front gain."""
+    d = _prime(_dam_break_domain())
+    xc = d.centroid_coordinates[:, 0]
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    c = np.where(xc < LEN / 2, 1.0, 0.0)
+    d.tracer_conserved_values[0, :] = np.maximum(h, 0.0) * c
+    d.tracer_centroid_values[0, :] = c
+    d.tracer_boundary_values[0, :] = 0.0
+    _, tracer_eu = _fluxes(d)
+    far = xc > 0.75 * LEN
+    assert np.abs(tracer_eu[0][far]).max() < 1e-14, 'action at a distance'
+    front = (xc > LEN / 2) & (xc < 0.55 * LEN)
+    assert tracer_eu[0][front].max() > 0.0, 'no tracer crossed the front'
+
+
+# ---------------------------------------------------------------- two tracers
+
+def test_two_tracers_are_indexed_and_do_not_alias():
+    """The tracer-major (ns, ...) layout is indexed as s*n / s*3n."""
+    d = _prime(_dam_break_domain(names=('a', 'b')))
+    _seed_uniform(d, 1.0, slot=0)
+    _seed_uniform(d, 0.375, slot=1)
+    stage_eu, tracer_eu = _fluxes(d)
+    scale = max(np.abs(stage_eu).max(), 1e-30)
+    assert np.abs(tracer_eu[0] - stage_eu).max() < 1e-12 * scale
+    assert np.abs(tracer_eu[1] - 0.375 * stage_eu).max() < 1e-12 * scale
+    assert not np.allclose(tracer_eu[0], tracer_eu[1]), 'the slots alias'
+
+
+# ---------------------------------------------------------------- integration
+
+def test_uniform_tracer_survives_a_dam_break_unchanged():
+    """Free stream: a uniform c must stay uniform however violent the flow."""
+    d = _dam_break_domain(nxy=30)
+    d.set_tracer('c', 0.4)
+    d.tracer_boundary_values[0, :] = 0.4
+    d.evolve_to_end(finaltime=20.0)
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    wet = h > 1e-3
+    c = d.tracer_conserved_values[0][wet] / h[wet]
+    assert np.abs(c - 0.4).max() < 1e-9
+
+
+def test_tracer_mass_is_conserved_positive_and_bounded():
+    d = _dam_break_domain(nxy=30)
+    xc = d.centroid_coordinates[:, 0]
+    d.set_tracer('c', np.where(xc < LEN / 4, 0.8, 0.0))
+    d.tracer_boundary_values[0, :] = 0.0
+    m0 = float((d.tracer_conserved_values[0] * d.areas).sum())
+
+    cmin, cmax = [], []
+    for _ in d.evolve(yieldstep=5.0, finaltime=20.0):
+        h = (d.quantities['stage'].centroid_values
+             - d.quantities['elevation'].centroid_values)
+        wet = h > 1e-3
+        if wet.any():
+            c = d.tracer_conserved_values[0][wet] / h[wet]
+            cmin.append(c.min())
+            cmax.append(c.max())
+
+    m1 = float((d.tracer_conserved_values[0] * d.areas).sum())
+    assert abs(m1 - m0) < 1e-10 * max(abs(m0), 1.0), 'mass drifted'
+    # Positivity and boundedness are EMERGENT here -- nothing clamps c.
+    assert min(cmin) > -1e-12, 'concentration went negative'
+    assert max(cmax) < 0.8 + 1e-9, 'concentration exceeded its initial maximum'
+
+
+@pytest.mark.slow
+def test_tracer_is_actually_transported():
+    """Guards against a suite that would pass on a tracer that never moves.
+
+    Needs the whole upstream reservoir, and long enough to matter: over 20 s
+    the centre of mass barely shifts and the test measures nothing.
+    """
+    d = _dam_break_domain(nxy=30)
+    xc = d.centroid_coordinates[:, 0]
+    d.set_tracer('c', np.where(xc < LEN / 2, 1.0, 0.0))
+    d.tracer_boundary_values[0, :] = 0.0
+    w = d.tracer_conserved_values[0] * d.areas
+    x0 = float((w * xc).sum() / max(w.sum(), 1e-30))
+    d.evolve_to_end(finaltime=120.0)
+    w = d.tracer_conserved_values[0] * d.areas
+    x1 = float((w * xc).sum() / max(w.sum(), 1e-30))
+    assert x1 > x0 + 1.0, 'the tracer centre of mass did not move downstream'
+
+
+# ---------------------------------------------------------------- add_tracer
+
+def _small_domain(nxy=10):
+    d = rectangular_cross_domain(nxy, nxy, len1=500.0, len2=500.0)
+    d.set_flow_algorithm('DE0')
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    d.set_boundary({t: Reflective_boundary(d) for t in d.get_boundary_tags()})
+    return d
+
+
+def test_a_fresh_domain_has_no_tracers():
+    d = _small_domain()
+    assert getattr(d, 'number_of_tracers', 0) == 0
+
+
+def test_add_tracer_registers_and_shapes_the_arrays():
+    d = _small_domain()
+    assert d.add_tracer('mud') == 0
+    assert d.number_of_tracers == 1
+    n, bl = len(d), d.boundary_length
+    expected = {'tracer_centroid_values': (1, n),
+                'tracer_edge_values': (1, 3 * n),
+                'tracer_boundary_values': (1, bl),
+                'tracer_explicit_update': (1, n),
+                'tracer_conserved_values': (1, n),
+                'tracer_backup_values': (1, n)}
+    for name, shape in expected.items():
+        a = getattr(d, name)
+        assert a.shape == shape, '%s has shape %s' % (name, a.shape)
+        # The kernel indexes these as s*N + k, so the layout is load-bearing.
+        assert a.flags['C_CONTIGUOUS'], '%s is not C-contiguous' % name
+        assert a.dtype == np.float64, '%s is not float64' % name
+
+
+def test_add_tracer_invalidates_the_cached_c_struct():
+    """Adding a tracer after an evolve must not leave a stale struct behind."""
+    d = _small_domain()
+    d.add_tracer('a')
+    d.evolve_to_end(finaltime=0.2)
+    assert d._Domain_C_struct is not None
+    d.add_tracer('b')
+    assert d._Domain_C_struct is None
+
+
+def test_growing_to_two_tracers_preserves_the_first():
+    d = _small_domain()
+    d.add_tracer('a')
+    d.set_tracer('a', 0.25)
+    d.tracer_explicit_update[0, :] = 7.0        # a distinctive row
+    d.add_tracer('b')
+    assert np.allclose(d.get_tracer('a'), 0.25), 'tracer 0 was disturbed'
+    assert np.allclose(d.tracer_explicit_update[0], 7.0)
+    assert np.allclose(d.tracer_explicit_update[1], 0.0), 'new row not zeroed'
+
+
+def test_set_tracer_accepts_a_scalar_or_a_field():
+    d = _small_domain()
+    d.add_tracer('s')
+    field = np.linspace(0.0, 1.0, len(d))
+    d.set_tracer('s', field)
+    assert np.allclose(d.get_tracer('s'), field)
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    assert np.allclose(d.tracer_conserved_values[0], h * field)
+    d.set_tracer('s', 0.5)
+    assert np.all(d.get_tracer('s') == 0.5)
+
+
+def test_the_api_rejects_mistakes():
+    d = _small_domain()
+    d.add_tracer('x', beta=1.0)
+    with pytest.raises(ValueError):
+        d.add_tracer('x')                       # duplicate name
+    with pytest.raises(ValueError):
+        d.set_tracer('x', np.zeros(len(d) + 1))  # wrong length
+    with pytest.raises(ValueError):
+        d.set_tracer('nope', 1.0)               # unknown name
+    with pytest.raises(ValueError):
+        # beta is shared by every tracer, so a conflicting value must be
+        # refused rather than silently applied to all of them.
+        d.add_tracer('y', beta=0.0)

--- a/anuga/shallow_water/tests/test_tracers_gpu.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu.py
@@ -1,0 +1,148 @@
+"""Generic passive tracers: the legacy (mode 1) and unified (mode 2) paths agree.
+
+Both compute modes call the same tracer code in `gpu/core_kernels.c`, so a
+disagreement between them is a mapping or binding fault rather than a physics
+one -- most often a `D->member` load inside an `omp target` region, which reads
+a host address on the device and makes the work silently not happen.
+
+The properties tested here are exactly the ones such a fault breaks: the two
+modes must agree on the hydrodynamics, on each tracer's concentration and
+conserved mass, and on the total; and two tracers must stay distinct on the
+device rather than one aliasing the other.
+
+Deliberately NO `sync_from_device()` after the mode-2 evolve. The comparison
+reads what an ordinary user's script would see when it inspects centroid values
+after `evolve`, which is the thing that has to be right.
+"""
+import os
+import warnings
+
+import numpy as np
+import pytest
+
+import anuga
+from anuga import Reflective_boundary, rectangular_cross_domain
+
+LEN = 500.0
+NXY = 20
+FINALTIME = 20.0
+
+_gpu_error = None
+_gpu_avail = None
+
+
+def gpu_available():
+    """Check if the GPU OpenMP interface is importable."""
+    global _gpu_error, _gpu_avail
+    if _gpu_avail is not None:
+        return _gpu_avail
+    try:
+        from anuga.shallow_water.sw_domain_gpu_ext import init_gpu_domain  # noqa: F401
+        _gpu_avail = True
+    except Exception as e:
+        _gpu_avail = False
+        _gpu_error = '%s: %s' % (type(e).__name__, e)
+    return _gpu_avail
+
+
+# On a GPU-offload build (nvc, -Dgpu_offload=true) the NVHPC OpenMP-target
+# runtime aborts the process once many mode-2 domains have been created in it,
+# so files that build them are skipped in a normal in-process run and are
+# executed one class per fresh process by run_gpu_tests_isolated.sh, which sets
+# ANUGA_GPU_TESTS_ISOLATED=1. On a CPU build the omp-target regions run on the
+# host and this file is fine in one process. Mirrors test_DE_gpu_omp.py.
+if (gpu_available() and anuga.gpu_offload_supported()
+        and not os.environ.get('ANUGA_GPU_TESTS_ISOLATED')):
+    _skip_reason = (
+        "GPU-offload build: run this file via "
+        "anuga/shallow_water/tests/run_gpu_tests_isolated.sh (one fresh process "
+        "per class) - running it in one process aborts the NVHPC OpenMP-target "
+        "runtime. Set ANUGA_GPU_TESTS_ISOLATED=1 to force in-process collection.")
+    warnings.warn(_skip_reason, stacklevel=1)
+    pytest.skip(_skip_reason, allow_module_level=True)
+
+
+def _build(mode):
+    d = rectangular_cross_domain(NXY, NXY, len1=LEN, len2=LEN)
+    d.set_flow_algorithm('DE0')
+    d.set_low_froude(0)
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', lambda x, y: np.where(x < LEN / 2, 2.0, 0.5))
+    d.set_quantity('xmomentum', 0.0)
+    d.set_quantity('ymomentum', 0.0)
+    d.set_boundary({t: Reflective_boundary(d) for t in d.get_boundary_tags()})
+    # One uniform tracer (tests consistency) and one structured (tests that the
+    # device sees per-slot data rather than aliasing slot 0).
+    d.add_tracer('uniform', beta=1.0)
+    d.add_tracer('wedge', beta=1.0)
+    x = d.centroid_coordinates[:, 0]
+    d.set_tracer('uniform', 1.0)
+    d.set_tracer('wedge', np.where(x < LEN / 2, 1.0, 0.0))
+    d.set_multiprocessor_mode(mode)
+    return d
+
+
+@pytest.fixture(scope='module')
+def evolved():
+    """One mode-1 and one mode-2 run of the same problem."""
+    if not gpu_available():
+        pytest.skip('GPU OpenMP interface not available: %s' % _gpu_error)
+
+    cpu = _build(1)
+    cpu.evolve_to_end(finaltime=FINALTIME)
+
+    gpu = _build(2)
+    if getattr(gpu, 'multiprocessor_mode', None) != 2:
+        # Comparing mode 1 against a silent mode-1 fallback would be a false
+        # green, so refuse rather than pass.
+        pytest.fail('mode 2 did not engage: multiprocessor_mode=%r compute_mode=%r'
+                    % (getattr(gpu, 'multiprocessor_mode', None),
+                       getattr(gpu, 'compute_mode', None)))
+
+    from anuga.shallow_water.sw_domain_gpu_ext import sync_to_device
+    sync_to_device(gpu.gpu_interface.gpu_dom)
+    gpu.evolve_to_end(finaltime=FINALTIME)
+    return cpu, gpu
+
+
+@pytest.mark.parametrize('name', ['stage', 'xmomentum', 'ymomentum'])
+def test_hydrodynamics_agree(evolved, name):
+    cpu, gpu = evolved
+    a = cpu.quantities[name].centroid_values
+    b = gpu.quantities[name].centroid_values
+    assert np.abs(a - b).max() < 1e-10
+
+
+@pytest.mark.parametrize('slot,name', [(0, 'uniform'), (1, 'wedge')])
+def test_tracer_fields_agree(evolved, slot, name):
+    cpu, gpu = evolved
+    ma = cpu.tracer_conserved_values[slot]
+    mb = gpu.tracer_conserved_values[slot]
+    assert np.abs(ma - mb).max() < 1e-10, 'conserved m disagrees for %r' % name
+
+    ha = (cpu.quantities['stage'].centroid_values
+          - cpu.quantities['elevation'].centroid_values)
+    hb = (gpu.quantities['stage'].centroid_values
+          - gpu.quantities['elevation'].centroid_values)
+    wet = (ha > 1e-3) & (hb > 1e-3)
+    assert np.abs(ma[wet] / ha[wet] - mb[wet] / hb[wet]).max() < 1e-10
+
+    tot_a = float((ma * cpu.areas).sum())
+    tot_b = float((mb * gpu.areas).sum())
+    assert abs(tot_a - tot_b) < 1e-10 * max(abs(tot_a), 1.0)
+
+
+def test_the_two_tracers_stay_distinct_on_the_device(evolved):
+    """Guards against slot 1 aliasing slot 0 in the device mapping."""
+    _, gpu = evolved
+    assert not np.allclose(gpu.tracer_conserved_values[0],
+                           gpu.tracer_conserved_values[1])
+
+
+def test_depth_is_consistent_with_stage_in_both_modes(evolved):
+    """A tracer must not corrupt the hydrodynamic state it rides on."""
+    for nm, d in zip(('mode 1', 'mode 2'), evolved):
+        h = (d.quantities['stage'].centroid_values
+             - d.quantities['elevation'].centroid_values)
+        assert h.min() > -1e-10, '%s: negative depth %.3e' % (nm, h.min())


### PR DESCRIPTION
Brings `develop_tracers` onto `develop`. **Deliberately not proposed for `main`
yet** — this is new solver capability, and 4.0.0 has only just shipped.

Three commits, +1351/−23 across 11 files. Merges cleanly into `develop` (test
merge is conflict-free).

### What it adds

A tracer is a depth-averaged concentration `c` transported as the conserved
quantity `m = h*c`, carried alongside stage and momentum through the same flux
kernel:

```python
domain.add_tracer('salinity')
domain.set_tracer('salinity', 0.02)
```

Domains have none by default, so nothing changes for existing models. Useful for
any passive scalar — salinity, temperature, a pollutant, sediment concentration —
and it is the substrate a sediment transport module needs.

Both compute modes share the implementation in `gpu/core_kernels.c`, so mode 1
and mode 2 run the same code. Tracer arrays are mapped to the device and carried
through the halo exchange on both the unified and legacy parallel paths.

### Tests

`test_tracers.py` (19 tests, mode 1) and `test_tracers_gpu.py` (7, mode 1 vs
mode 2), covering reconstruction (first order at β=0, constants exact, monotone
on a step, second order on a smooth field), flux consistency to 1e-17,
linearity, upwinding, discrete conservation, two-tracer striding, dam-break
integration, and the `add_tracer` API.

The third commit parametrises transport over **DE0, DE1 and DE2**, on the
reasoning that a kernel which does not carry tracers drops them *silently* — no
error, no failing test, the concentration simply stops moving. All three pass
(centre of mass moves 102 m, mass drift ≤ 5.7e-15), so that is coverage rather
than a found bug. `test_every_transport_path_is_covered` is a tripwire that
fails when a new alternative-kernel attribute appears — currently it would fire
on `reconstruct_edge_bed`, proposed in #241.

### One coverage gap worth knowing

CI has no GPU, so `test_tracers_gpu.py`'s mode-2 paths execute on the host
there. The GPU offload path is therefore **not** exercised by this PR's CI. It
is worth running `test_tracers_gpu.py` on a real GPU build before this goes any
further than `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
