### PR TITLE
CI: remove the netCDF4 isolation probe (#255 is solved)

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -193,24 +193,6 @@ jobs:
           conda list                > "conda-list-py${{ matrix.python-version }}.txt"     || true
           echo "=== solved env: $(wc -l < "conda-explicit-py${{ matrix.python-version }}.txt") lines ==="
 
-      # Decisive isolation test for #255. The segfault's stack is
-      #   test_sww2vtu.py -> sww2vtu.py -> netCDF4/__init__.py:11 -> create_module
-      # i.e. it dies loading _netCDF4.pyd. If importing netCDF4 on its own also
-      # segfaults, then ANUGA and pytest are irrelevant and this is purely a bad
-      # netCDF4/hdf5/libnetcdf combination -- a known netCDF4 failure mode on
-      # win-64, where the DLL bundling is the fragile part.
-      # continue-on-error so this reports without masking the real test result.
-      - name: Probe netCDF4 in isolation (Windows, #255)
-        if: always() && runner.os == 'Windows'
-        continue-on-error: true
-        shell: bash -el {0}
-        run: |
-          conda activate anuga_env
-          echo "--- versions (segfault here => purely environmental) ---"
-          python -c "import netCDF4; print('netCDF4', netCDF4.__version__, '| hdf5', netCDF4.__hdf5libversion__, '| libnetcdf', netCDF4.__netcdf4libversion__)"
-          echo "--- import of the module that triggers it ---"
-          python -c "import anuga.file_conversion.sww2vtu as m; print('sww2vtu imported OK')"
-
       - name: Upload the solved environment (Windows, #255)
         if: always() && runner.os == 'Windows'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The probe was added in #261 to decide whether the Windows segfault was
environmental. It did that job — a bare `import netCDF4` segfaulting with no
ANUGA and no pytest is what ruled ANUGA out and pointed at the environment,
which led to `libpython` (#271). **#255 is closed**, so it has nothing left to
prove.

It is worth removing rather than leaving, because it was **half-broken and
reported success anyway**. Its second command,

```
python -c "import anuga.file_conversion.sww2vtu as m; ..."
```

ran from the repository root, where the source tree shadows the installed
package, so it always failed with

```
ModuleNotFoundError: No module named 'anuga._version'
```

— #237's message doing exactly its job. Every other step that touches the
installed package does `cd sandpit` first; this one never did. With
`continue-on-error` the step then reported green regardless, so a step that had
never worked looked fine for as long as it existed.

**Kept:** the `Record`/`Upload the solved environment` steps. Capturing
`conda list --explicit` is what made the #255 environment diff possible at all —
comparing a failing anuga_core env against a passing lab env package-for-package
is how `libpython _103` vs `_104` was found — and it costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
