### PR TITLE
sww: write passive tracers, and therefore sediment classes

### DIFF
--- a/anuga/file/sww.py
+++ b/anuga/file/sww.py
@@ -147,6 +147,30 @@ class SWW_file(Data_format):
                 static_c_quantities.append(q+'_c')
                 self._overwrite_c_quantities.append(q+'_c')
 
+        # Passive tracers, and therefore suspended sediment classes, which are
+        # tracers with settling parameters (see Domain.add_sediment_class).
+        #
+        # Tracers are NOT Quantity objects: they live in one contiguous
+        # (n_tracers, N) block so the C kernel can stride them and the device
+        # can map them in one go. They are deliberately kept out of
+        # domain.quantities -- that dict is walked by the solver, not just by
+        # this writer (mesh reordering rewrites vertex/edge/gradient arrays,
+        # set_beta pushes a per-quantity beta where tracers share one scalar),
+        # so registering a view there would put tracers in the path of
+        # machinery that assumes a real Quantity.
+        #
+        # They are centroid quantities, so they take the same route as a flag-3
+        # quantity: one dynamic <name>_c variable, no vertex storage, nothing
+        # interpolated that the solver never computed.
+        self._tracer_names = list(getattr(domain, '_tracer_names', []) or [])
+        if self._tracer_names and getattr(domain, 'store_tracers', True):
+            for name in self._tracer_names:
+                cname = name + '_c'
+                if cname not in dynamic_c_quantities:
+                    dynamic_c_quantities.append(cname)
+        else:
+            self._tracer_names = []
+
         # NetCDF file definition
         fid = NetCDFFile(self.filename, mode)
         if mode[0] == 'w':
@@ -406,8 +430,17 @@ class SWW_file(Data_format):
                 dynamic_quantities[name] = A
 
             for name in self.writer.dynamic_c_quantities:
-                Q = domain.quantities[name[:-2]]
-                dynamic_quantities_centroid[name] = Q.centroid_values
+                base = name[:-2]
+                if base in self._tracer_names:
+                    # A tracer: a row of the (n_tracers, N) block, not a
+                    # Quantity. The block is REALLOCATED by add_tracer, so it
+                    # is looked up on the domain each step rather than cached.
+                    s_idx = domain._tracer_names.index(base)
+                    dynamic_quantities_centroid[name] = \
+                        domain.tracer_centroid_values[s_idx]
+                else:
+                    Q = domain.quantities[base]
+                    dynamic_quantities_centroid[name] = Q.centroid_values
 
             # Store dynamic quantities
             slice_index = self.writer.store_quantities(fid,

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -16,6 +16,7 @@ python_sources = [
 'test_DE_gpu_omp.py',
 'test_compute_mode.py',
 'test_tracers.py',
+'test_tracers_sww.py',
 'test_tracers_gpu.py',
 'test_forcing.py',
 'test_friction.py',

--- a/anuga/shallow_water/tests/test_tracers_sww.py
+++ b/anuga/shallow_water/tests/test_tracers_sww.py
@@ -1,0 +1,121 @@
+"""Tracers must reach the sww file.
+
+A tracer is not a Quantity -- it lives in the (n_tracers, N) block so the C
+kernel can stride it -- so it takes the same route as a flag-3 quantity: one
+dynamic `<name>_c` variable per tracer, centroids only, nothing interpolated
+that the solver never computed.
+
+Sediment classes are tracers (Domain.add_sediment_class calls add_tracer), so
+they are covered by the same path.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+
+netCDF4 = pytest.importorskip('netCDF4')
+
+
+def _domain(n=6):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    return d
+
+
+def _run(d, tmp_path, name='tracer_sww', finaltime=1.0):
+    d.set_name(name)
+    d.set_datadir(str(tmp_path))
+    for _ in d.evolve(yieldstep=0.5, finaltime=finaltime):
+        pass
+    return tmp_path / (name + '.sww')
+
+
+def test_no_tracers_means_no_tracer_variables(tmp_path):
+    # A domain without tracers must look exactly as it did before. Note
+    # domain.store_centroids defaults to True, so stage_c and friends are
+    # already written -- what must not appear is a tracer variable.
+    d = _domain()
+    with netCDF4.Dataset(_run(d, tmp_path)) as ds:
+        assert 'stage_c' in ds.variables, 'baseline: centroids are stored'
+        assert not [v for v in ds.variables
+                    if v.endswith('_c') and v[:-2] not in
+                    ('stage', 'elevation', 'friction', 'xmomentum',
+                     'ymomentum', 'height', 'xvelocity', 'yvelocity')], \
+            'no unexpected _c variables on a tracer-free domain'
+
+
+def test_a_tracer_is_written_every_timestep(tmp_path):
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    with netCDF4.Dataset(_run(d, tmp_path)) as ds:
+        assert 'salinity_c' in ds.variables, \
+            'a registered tracer must appear in the sww'
+        v = ds.variables['salinity_c']
+        assert v.dimensions == ('number_of_timesteps', 'number_of_volumes')
+        assert v.shape[0] > 1, 'tracers are dynamic, not stored once'
+        assert v.shape[1] == len(d)
+
+
+def test_the_stored_values_are_the_concentrations(tmp_path):
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    path = _run(d, tmp_path)
+    with netCDF4.Dataset(path) as ds:
+        first = num.asarray(ds.variables['salinity_c'][0, :])
+    # Uniform initial concentration, still water: c stays 0.02 everywhere.
+    assert num.allclose(first, 0.02, atol=1e-6), \
+        'stored values should be c, not m = h*c'
+
+
+def test_two_tracers_do_not_alias(tmp_path):
+    d = _domain()
+    d.add_tracer('a', initial_value=0.10)
+    d.add_tracer('b', initial_value=0.90)
+    with netCDF4.Dataset(_run(d, tmp_path)) as ds:
+        a = num.asarray(ds.variables['a_c'][0, :])
+        b = num.asarray(ds.variables['b_c'][0, :])
+    assert num.allclose(a, 0.10, atol=1e-6)
+    assert num.allclose(b, 0.90, atol=1e-6)
+
+
+def test_store_tracers_false_opts_out(tmp_path):
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    d.store_tracers = False
+    with netCDF4.Dataset(_run(d, tmp_path)) as ds:
+        assert 'salinity_c' not in ds.variables
+
+
+def test_tracer_output_does_not_disturb_the_usual_quantities(tmp_path):
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    with netCDF4.Dataset(_run(d, tmp_path)) as ds:
+        for expected in ('stage', 'elevation', 'xmomentum', 'ymomentum'):
+            assert expected in ds.variables, \
+                '%s went missing once tracers were stored' % expected
+
+
+def test_a_transported_tracer_actually_changes_in_the_file(tmp_path):
+    """The property a modeller depends on: the field moves in the output."""
+    d = _domain(10)
+    d.set_quantity('elevation', lambda x, y: -0.1 * x)
+    d.set_quantity('stage', lambda x, y: num.maximum(0.5 - 0.1 * x, 0.05))
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    # A blob on one side, so transport shows up as a change in the field.
+    d.add_tracer('dye', initial_value=0.0)
+    idx = d.get_centroid_coordinates()[:, 0] < 0.3
+    c = d.get_tracer('dye')
+    c[idx] = 1.0
+    d.set_tracer('dye', c)
+
+    path = _run(d, tmp_path, name='tracer_move', finaltime=3.0)
+    with netCDF4.Dataset(path) as ds:
+        arr = num.asarray(ds.variables['dye_c'][:])
+    assert arr.shape[0] > 2
+    assert not num.allclose(arr[0], arr[-1]), \
+        'the tracer field never changed, so nothing was transported or stored'


### PR DESCRIPTION
Closes the main half of #274: tracers could be computed but not seen. A run
transported them correctly and then wrote an sww with no trace of them, so the
field a tracer exists to represent could not be plotted, compared or validated.

**Sediment comes along free** — `add_sediment_class` calls `add_tracer`, so
suspended concentration was invisible for exactly the same reason and is now
written by the same path.

## What it does

One dynamic `<name>_c` variable per tracer, shape
`(number_of_timesteps, number_of_volumes)` — the same route the writer already
provides for flag-3 (centroid-only dynamic) quantities.

## Why not register them as `Quantity` views

That was the other option in #274, and it would have reused everything —
`quantities_to_be_stored`, centroid/vertex handling, sww2vtu, the GUI. I went
the other way after finding that `domain.quantities` is walked by the **solver**,
not only by this writer:

* `generic_domain.py:570` — the mesh **reorder** rewrites
  `centroid_values`/`_vertex_values`/`edge_values`/`_x_gradient` under a
  permutation. A tracer view that did not reorder identically would silently
  corrupt data — and `add_tracer` **reallocates** the block, so any held view is
  already fragile.
* `set_beta` (`:781`) pushes a per-quantity beta, but tracers share **one**
  `beta_tracer` scalar in the C struct. The two models disagree.
* `get_quantity_names()` and the domain diagnostics would start reporting
  tracers as quantities.

So the writer learns about the `(n_tracers, N)` block instead, and tracers stay
out of the solver's way. The block is looked up on the domain each timestep
rather than cached, precisely because `add_tracer` reallocates it.

## Two deliberate limits

**Centroids only.** Tracers have centroid and edge values but no vertex values.
Deriving them the way `bed_vv` comes from `bed_ev` would invent data the solver
never computed. If visualisation needs vertex output later, that is a separate
and deliberate change.

**All tracers are written**, with `domain.store_tracers = False` to opt out. A
tracer is registered because someone cares about it, so opt-in would mostly be a
way to get an empty file by accident.

## Tests

`test_tracers_sww.py` — variables appear with the right dimensions; values are
`c` and not the conserved `m = h*c`; two tracers do not alias; `store_tracers`
opts out; the ordinary quantities are undisturbed; and a transported blob
actually changes between first and last frame.

Verified **both ways**: 7 pass with the change; with it reverted, 4 fail on a
missing tracer variable (`KeyError: 'a_c'`).

## Not included

The elevation-storage half of #274 — an evolving bed stored as static — is
handled separately, on `develop_sed` where bed evolution lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
