### PR TITLE
Refuse to reorder or distribute a domain with tracers, for now

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -561,6 +561,18 @@ class Generic_Domain:
         self.tri_full_flag = self.tri_full_flag[new_order]
         self.number_of_full_triangles = int(num.sum(self.tri_full_flag))
 
+        # Tracers are not Quantity objects, so the loop below cannot see them
+        # and their (ns, N) / (ns, 3N) blocks would keep the OLD ordering while
+        # the mesh moved underneath -- cell k's concentration landing on
+        # whichever triangle used to be at k. Silent, and wrong. Refuse until
+        # #277 implements the permutation.
+        if getattr(self, 'number_of_tracers', 0) > 0:
+            raise NotImplementedError(
+                'reorder() cannot yet permute tracer arrays, so reordering a '
+                'domain with %d tracer(s) would silently misalign them with '
+                'the mesh. See issue #277. Reorder before adding tracers, or '
+                'do not reorder.' % self.number_of_tracers)
+
         # --- quantities ---
         # Reorder centroid_values and any cached per-triangle arrays.
         # vertex_values and edge_values are recomputed each timestep by

--- a/anuga/parallel/parallel_api.py
+++ b/anuga/parallel/parallel_api.py
@@ -213,6 +213,22 @@ def distribute(domain, verbose=False, debug=False, parameters = None):
       in the parallel domain instances
     """
 
+    # Tracers are not Quantity objects, so the "copy in quantity data" loop
+    # below cannot see them: the sub-domains would be built with no tracers at
+    # all, losing the names, the shared beta and every value. The per-timestep
+    # ghost exchange (communicate_tracer_ghosts) already exists and assumes
+    # they are present on every rank, which this never arranges. Refuse until
+    # #278 carries them across.
+    #
+    # Checked before the numprocs == 1 bypass would return: a serial run is
+    # unaffected either way, and failing here rather than later keeps the
+    # message close to the cause.
+    if getattr(domain, 'number_of_tracers', 0) > 0 and numprocs > 1:
+        raise NotImplementedError(
+            'distribute() cannot yet carry tracers to the sub-domains, so a '
+            'parallel run of a domain with %d tracer(s) would silently lose '
+            'them. See issue #278.' % domain.number_of_tracers)
+
     if not pypar_available or numprocs == 1 : return domain # Bypass
 
 

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -16,6 +16,7 @@ python_sources = [
 'test_DE_gpu_omp.py',
 'test_compute_mode.py',
 'test_tracers.py',
+'test_tracers_unsupported_paths.py',
 'test_tracers_gpu.py',
 'test_forcing.py',
 'test_friction.py',

--- a/anuga/shallow_water/tests/test_tracers_unsupported_paths.py
+++ b/anuga/shallow_water/tests/test_tracers_unsupported_paths.py
@@ -1,0 +1,72 @@
+"""The two paths that would silently mishandle tracers must refuse instead.
+
+Both stem from the same root: tracers are not Quantity objects, so machinery
+that walks `domain.quantities` does not see them.
+
+  reorder()    permutes every quantity but no tracer array, leaving the tracer
+               fields misaligned with the mesh (#277)
+  distribute() copies state by walking quantities, so the sub-domains would be
+               built with no tracers at all (#278)
+
+Until those are implemented, both raise. These tests exist so the guards cannot
+be removed without replacing them.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+
+
+def _domain(n=4):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    return d
+
+
+def test_reorder_without_tracers_still_works():
+    # The guard must not disturb the ordinary path.
+    d = _domain()
+    n = len(d)
+    order = num.arange(n - 1, -1, -1)      # reverse
+    d.reorder(order)                        # must not raise
+    assert len(d) == n
+
+
+def test_reorder_with_tracers_refuses():
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    order = num.arange(len(d) - 1, -1, -1)
+    with pytest.raises(NotImplementedError) as e:
+        d.reorder(order)
+    msg = str(e.value)
+    assert '277' in msg, 'the error should name the issue'
+    assert 'misalign' in msg
+
+
+def test_reorder_error_counts_the_tracers():
+    d = _domain()
+    d.add_tracer('a')
+    d.add_tracer('b')
+    with pytest.raises(NotImplementedError, match='2 tracer'):
+        d.reorder(num.arange(len(d) - 1, -1, -1))
+
+
+def test_distribute_with_tracers_refuses():
+    # distribute() returns the domain unchanged on 1 process, so the guard is
+    # checked ahead of that bypass; on 1 process it must NOT fire, since a
+    # serial run is unaffected.
+    from anuga.parallel.parallel_api import distribute
+    from anuga import numprocs
+
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+
+    if numprocs == 1:
+        assert distribute(d) is d
+    else:
+        with pytest.raises(NotImplementedError, match='278'):
+            distribute(d)


### PR DESCRIPTION
Two paths would mishandle tracers **silently**, for the same underlying reason:
tracers are not `Quantity` objects, so machinery that walks `domain.quantities`
does not see them. That is the deliberate design — #276 explains why registering
views in that dict is worse — but it cuts both ways: staying out of the dict
also means being missed by everything that iterates it.

| path | what happens today |
|---|---|
| `reorder()` (#277) | permutes every quantity's centroid/vertex/edge/gradient arrays and the `(3N,)` per-edge arrays, and **no tracer array**. Cell `k`'s concentration lands on whichever triangle used to be at `k`. No error. |
| `distribute()` (#278) | copies state by walking quantities, so sub-domains are built with **no tracers at all** — no names, no shared beta, no values. |

Neither is fixed here. Both now raise `NotImplementedError` naming the issue.

## Why guard rather than wait for the fix

It converts two silent-wrong-answer paths into an explicit *"not supported
yet"*, which is the right failure while the real fixes are designed. Leaving
them silent because a fix is coming is how #229 lived for a decade.

The `distribute()` guard is checked **before** the `numprocs == 1` bypass
returns, so a serial run is unaffected and the message stays close to its cause.

## Note on `distribute()`

The per-timestep ghost exchange already exists —
`communicate_tracer_ghosts()`, added precisely because *"tracers are not
Quantity objects, so the loop above cannot see them"*. It assumes tracers are
present on every rank, which `distribute()` never arranges. The halo was
handled; the handing-out was not.

## Tests

`test_tracers_unsupported_paths.py` pins both, including that `reorder` still
works on a tracer-free domain and that `distribute` is a no-op on one process.
They exist so the guards cannot be dropped without replacing them.

Verified: 4 pass; `test_tracers` 26 pass; the 14 `reorder` tests across the
suite still pass, so the guard does not disturb the ordinary path.

Related: #277, #278, #279 (no boundary-value API), #276 (sww output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
