### PR TITLE
Tracer boundary values: prescribed on inflow, interior value on outflow

### DIFF
--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -674,6 +674,9 @@ class Domain(Generic_Domain):
         self.number_of_tracers = 0
         self.beta_tracer = 1.0
         self._tracer_names = []
+        # (tracer index, boundary tag) -> callable, for time-varying
+        # inflow concentrations. See set_tracer_boundary().
+        self._tracer_boundary_functions = {}
         self.tracer_centroid_values = None      # c            (ns, N)
         self.tracer_edge_values = None          # c at edges   (ns, 3N)
         self.tracer_boundary_values = None      # c at bdry    (ns, boundary_length)
@@ -933,6 +936,96 @@ class Domain(Generic_Domain):
             self.set_tracer(name, initial_value)
 
         return index
+
+    def set_tracer_boundary(self, name, tag, value):
+        """Concentration that tracer `name` brings in across boundary `tag`.
+
+        Only used where water FLOWS IN. The flux kernel picks the upwind value
+        edge by edge from the sign of the water flux:
+
+            inflow  (n.U into the domain)   ->  this boundary value
+            outflow (n.U out of the domain) ->  the interior edge value
+
+        so there is nothing to set for an outflow, and nothing that can be set:
+        prescribing a concentration on an outflow would over-determine the
+        advection, and the kernel would ignore it anyway. A boundary that only
+        ever lets water out therefore needs no call at all, and one that
+        alternates gets Dirichlet-on-inflow / transmissive-on-outflow
+        automatically -- the characteristic condition, without a switch.
+
+        Parameters
+        ----------
+        name : str
+            A registered tracer.
+        tag : str
+            A boundary tag, as used by `set_boundary`.
+        value : float, array-like, or callable
+            A scalar applies to every edge carrying `tag`. An array must have
+            one value per edge of that tag, ordered as
+            `domain.tag_boundary_cells[tag]`. A callable is evaluated as
+            `value(t)` at each timestep and must return a scalar or such an
+            array, for a time-varying inflow.
+
+        Notes
+        -----
+        UNSET BOUNDARIES BRING c = 0. The array is zero-filled at
+        `add_tracer`, so with no call here an inflow carries clean water. That
+        is a modelling assumption, not a neutral default: for salinity or
+        suspended sediment it is usually wrong, and it is invisible in the
+        output. It is preserved because changing it would silently alter
+        existing results, but set it explicitly wherever water enters.
+        """
+        s = self.get_tracer_index(name)
+
+        if tag not in self.tag_boundary_cells:
+            raise ValueError(
+                'no boundary tagged %r on this domain; known tags: %s'
+                % (tag, sorted(self.tag_boundary_cells)))
+
+        idx = num.asarray(self.tag_boundary_cells[tag], dtype=num.intp)
+
+        if callable(value):
+            # Re-evaluated each timestep by update_tracer_boundary_values().
+            self._tracer_boundary_functions[(s, tag)] = value
+            self._apply_tracer_boundary(s, idx, value(self.get_time()), tag)
+        else:
+            self._tracer_boundary_functions.pop((s, tag), None)
+            self._apply_tracer_boundary(s, idx, value, tag)
+
+    def _apply_tracer_boundary(self, s, idx, value, tag):
+        """Write one tracer's boundary values for the edges of one tag."""
+        v = num.asarray(value, dtype=num.float64)
+        if v.ndim == 0:
+            self.tracer_boundary_values[s, idx] = float(v)
+        elif v.shape == idx.shape:
+            self.tracer_boundary_values[s, idx] = v
+        else:
+            raise ValueError(
+                'tracer boundary %r on tag %r: expected a scalar or %d values '
+                '(one per edge of that tag), got shape %r'
+                % (self._tracer_names[s], tag, idx.size, v.shape))
+
+    def update_tracer_boundary_values(self):
+        """Re-evaluate any callable tracer boundary values for this time.
+
+        Called from the evolve loop alongside update_boundary(). A no-op unless
+        set_tracer_boundary() was given a callable, so a domain with constant
+        boundary concentrations pays nothing.
+        """
+        if not self._tracer_boundary_functions:
+            return
+        t = self.get_time()
+        for (s, tag), f in self._tracer_boundary_functions.items():
+            idx = num.asarray(self.tag_boundary_cells[tag], dtype=num.intp)
+            self._apply_tracer_boundary(s, idx, f(t), tag)
+
+    def get_tracer_boundary(self, name, tag):
+        """Return the boundary concentrations of `name` on `tag`."""
+        s = self.get_tracer_index(name)
+        if tag not in self.tag_boundary_cells:
+            raise ValueError('no boundary tagged %r on this domain' % tag)
+        idx = num.asarray(self.tag_boundary_cells[tag], dtype=num.intp)
+        return self.tracer_boundary_values[s, idx]
 
     def get_tracer_index(self, name):
         """Return the row index of tracer `name`."""
@@ -2722,6 +2815,12 @@ class Domain(Generic_Domain):
         """
 
         nvtxRangePush('update_boundary')
+
+        # Time-varying tracer inflow concentrations, if any. Hooked here rather
+        # than at update_boundary()'s eight call sites in generic_domain, and a
+        # no-op unless set_tracer_boundary() was given a callable.
+        if self.number_of_tracers > 0:
+            self.update_tracer_boundary_values()
 
         # GPU mode - use GPU boundary functions if all boundaries are GPU-supported
         if self.multiprocessor_mode == MULTIPROCESSOR_GPU and self.gpu_interface is not None:

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -16,6 +16,7 @@ python_sources = [
 'test_DE_gpu_omp.py',
 'test_compute_mode.py',
 'test_tracers.py',
+'test_tracers_boundary.py',
 'test_tracers_sww.py',
 'test_tracers_unsupported_paths.py',
 'test_tracers_gpu.py',

--- a/anuga/shallow_water/tests/test_tracers_boundary.py
+++ b/anuga/shallow_water/tests/test_tracers_boundary.py
@@ -1,0 +1,152 @@
+"""Tracer boundary values: prescribed on inflow, interior value on outflow.
+
+The flux kernel already picks the upwind value edge by edge from the sign of
+the water flux, so the only thing a user can supply -- and the only thing that
+is physically well posed -- is the concentration arriving on an INFLOW. An
+outflow takes the interior edge value, which is the transmissive condition, and
+prescribing there would over-determine the advection.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+
+
+def _domain(n=6):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    d.add_tracer('salinity', initial_value=0.0)
+    return d
+
+
+def test_unset_boundaries_bring_clean_water():
+    # Documented default: the array is zero-filled, so an unset inflow carries
+    # c = 0. Pinned so a change to it has to be deliberate.
+    d = _domain()
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.0)
+
+
+def test_a_scalar_applies_to_every_edge_of_the_tag():
+    d = _domain()
+    d.set_tracer_boundary('salinity', 'left', 0.03)
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.03)
+    # and only that tag
+    assert num.allclose(d.get_tracer_boundary('salinity', 'right'), 0.0)
+
+
+def test_an_array_sets_each_edge():
+    d = _domain()
+    n_left = len(d.tag_boundary_cells['left'])
+    vals = num.linspace(0.0, 1.0, n_left)
+    d.set_tracer_boundary('salinity', 'left', vals)
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), vals)
+
+
+def test_a_wrong_length_array_is_refused():
+    d = _domain()
+    n_left = len(d.tag_boundary_cells['left'])
+    with pytest.raises(ValueError, match='one per edge'):
+        d.set_tracer_boundary('salinity', 'left', num.zeros(n_left + 1))
+
+
+def test_an_unknown_tag_is_refused():
+    d = _domain()
+    with pytest.raises(ValueError, match='no boundary tagged'):
+        d.set_tracer_boundary('salinity', 'nonexistent', 0.03)
+
+
+def test_an_unknown_tracer_is_refused():
+    d = _domain()
+    with pytest.raises(Exception):
+        d.set_tracer_boundary('not_a_tracer', 'left', 0.03)
+
+
+def test_a_callable_is_evaluated_now_and_on_update():
+    d = _domain()
+    d.set_tracer_boundary('salinity', 'left', lambda t: 0.1 * (t + 1.0))
+    # evaluated immediately at t = 0
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.1)
+    d.set_time(4.0)
+    d.update_tracer_boundary_values()
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.5)
+
+
+def test_a_constant_replaces_a_previous_callable():
+    d = _domain()
+    d.set_tracer_boundary('salinity', 'left', lambda t: 0.1 * (t + 1.0))
+    d.set_tracer_boundary('salinity', 'left', 0.02)
+    d.set_time(9.0)
+    d.update_tracer_boundary_values()      # must not re-apply the old callable
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.02)
+
+
+def test_boundary_values_survive_adding_another_tracer():
+    # add_tracer REALLOCATES every tracer array; earlier rows must be kept.
+    d = _domain()
+    d.set_tracer_boundary('salinity', 'left', 0.03)
+    d.add_tracer('dye', initial_value=0.0)
+    assert num.allclose(d.get_tracer_boundary('salinity', 'left'), 0.03)
+    assert num.allclose(d.get_tracer_boundary('dye', 'left'), 0.0)
+
+
+def test_outflow_does_not_take_the_boundary_value():
+    """The characteristic condition: an outflow ignores whatever is prescribed.
+
+    Interior tracer is 0.5 everywhere and the domain drains outward, so if the
+    boundary value were applied on outflow the interior would be dragged toward
+    0.9. It must not be.
+    """
+    d = anuga.rectangular_cross_domain(10, 10)
+    d.set_quantity('elevation', lambda x, y: -0.2 * x)
+    d.set_quantity('stage', lambda x, y: num.maximum(0.4 - 0.2 * x, 0.02))
+    Bt = anuga.Transmissive_boundary(d)
+    d.set_boundary({'left': Bt, 'right': Bt, 'top': Bt, 'bottom': Bt})
+    d.add_tracer('c', initial_value=0.5)
+    d.set_tracer_boundary('c', 'right', 0.9)     # the downstream, outflow side
+
+    for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+
+    c = d.get_tracer('c')
+    wet = (d.quantities['stage'].centroid_values
+           - d.quantities['elevation'].centroid_values) > 1e-3
+    assert c[wet].max() <= 0.5 + 1e-6, \
+        'an outflow boundary must not inject its prescribed concentration'
+
+
+def test_inflow_brings_the_prescribed_concentration():
+    """The other half: water entering must carry what was set.
+
+    Flat bed, interior initially clean, and a Dirichlet boundary on the left
+    holding a higher stage so water flows IN there. The prescribed
+    concentration must appear in the domain.
+    """
+    d = anuga.rectangular_cross_domain(10, 10)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 0.2)
+    Bin = anuga.Dirichlet_boundary([0.6, 0.4, 0.0])   # higher stage, flowing in
+    Bout = anuga.Transmissive_boundary(d)
+    Br = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': Bin, 'right': Bout, 'top': Br, 'bottom': Br})
+
+    d.add_tracer('c', initial_value=0.0)
+    d.set_tracer_boundary('c', 'left', 1.0)
+
+    # Stopped part-way: given long enough the inflow floods the whole domain
+    # to c = 1, which is correct but says nothing about WHERE it entered.
+    for _ in d.evolve(yieldstep=0.1, finaltime=0.4):
+        pass
+
+    c = d.get_tracer('c')
+    x = d.get_centroid_coordinates()[:, 0]
+
+    assert c.max() > 0.05, \
+        'nothing entered: the inflow boundary concentration was not applied'
+    assert c.max() <= 1.0 + 1e-6, \
+        'concentration exceeded what the boundary supplied'
+    assert c[x < 0.3].mean() > c[x > 0.7].mean(), \
+        'the tracer should be strongest near the boundary it entered through'


### PR DESCRIPTION
Closes #279.

## The key finding: the characteristic condition is already implemented

Not in Python — in the flux kernel. It picks the upwind value edge by edge from
the sign of the water flux:

```c
const int inflow = (wflux > 0.0);
if (inflow) {
    c_up = is_boundary ? t_bv[s * t_bl + (-neighbour - 1)]   // prescribed
                       : t_ev[... neighbour ...];
} else {
    c_up = t_ev[s * 3 * n + ki];                             // interior edge value
}
```

So, of the options in the question:

| | status |
|---|---|
| **transmissive / outflow** | **already free.** Outflow takes the interior edge value — that *is* zero-gradient. Nothing to set. |
| **characteristic / upwind on n·U** | **already free.** The switch is the sign of the water mass flux, i.e. `n·U` weighted by depth and edge length. |
| **Dirichlet on inflow** | the only missing piece, and the only well-posed one — prescribing on an outflow would over-determine the advection. |

A boundary that alternates therefore gets Dirichlet-on-inflow /
transmissive-on-outflow automatically, with no mode to select. This PR supplies
the one degree of freedom the mathematics leaves.

## API

```python
domain.set_tracer_boundary('salinity', 'left', 0.03)     # scalar
domain.set_tracer_boundary('salinity', 'left', array)    # one per edge of the tag
domain.set_tracer_boundary('salinity', 'left', f)        # f(t), time-varying
```

Keyed by **boundary tag on the domain**, not attached to the boundary objects:
tracers already sit outside the Quantity system, boundary objects return arrays
sized to the conserved quantities, and this way no boundary class — including
third-party ones — has to learn about tracers to keep working.
`tag_boundary_cells[tag]` is already a list of indices into the second axis of
`tracer_boundary_values`, so the mapping is a direct index.

Callables are re-evaluated from `update_boundary()`, which
`shallow_water_domain` overrides — one hook rather than the eight
`update_boundary()` call sites in `generic_domain` — and skipped entirely unless
a callable was registered.

## The default, now stated

**Unset boundaries still bring `c = 0`.** That is today's behaviour (the array
is zero-filled at `add_tracer`) and changing it would silently alter existing
results. But it is a modelling assumption — *"inflow is clean water"* — not a
neutral default, and it was previously invisible inside a `num.zeros`. It is now
in the docstring and pinned by a test.

## Tests

11, covering **both halves** of the characteristic condition — an inflow carries
the prescribed concentration and is strongest near the edge it entered through;
an outflow ignores a prescribed value rather than injecting it — plus scalars,
per-edge arrays, wrong lengths, unknown tags and tracers, callables re-evaluated
on time change, a constant replacing a callable, and survival of the array
reallocation `add_tracer` performs.

Verified both ways: **11 pass**; with the change reverted, **10 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
