### PR TITLE
Tracer conservation monitoring: interior mass and boundary flux

### DIFF
--- a/anuga/operators/meson.build
+++ b/anuga/operators/meson.build
@@ -22,6 +22,7 @@ py3.extension_module('kinematic_viscosity_operator_ext',
 python_sources = [
   'base_operator.py',
   'boundary_flux_integral_operator.py',
+  'tracer_flux_integral_operator.py',
   'collect_max_quantities_operator.py',
   'collect_max_stage_operator.py',
   'elliptic_operator.py',

--- a/anuga/operators/tracer_flux_integral_operator.py
+++ b/anuga/operators/tracer_flux_integral_operator.py
@@ -1,0 +1,71 @@
+"""Integrate the tracer fluxes through the domain boundaries.
+
+The tracer counterpart of `boundary_flux_integral_operator`, and it applies the
+same timestepping weights for the same reason: the flux kernel records one total
+per substep, and each substep enters the time integral with the weight its
+method gives it.
+
+Relies on `tracer_boundary_flux_sum` being filled in compute_fluxes.
+"""
+
+import numpy as num
+
+from anuga.operators.base_operator import Operator
+
+
+class tracer_flux_integral_operator(Operator):
+    """Collect the time integral of the tracer boundary fluxes during a run.
+
+    Registered automatically by `Domain.add_tracer`; there is nothing to set
+    up. A domain with no tracers never creates one.
+    """
+
+    def __init__(self, domain, description=None, label=None,
+                 logging=False, verbose=False):
+        Operator.__init__(self, domain, description, label, logging, verbose)
+        self.domain = domain
+
+    def __call__(self):
+        """Accumulate the tracer boundary flux for this timestep."""
+        domain = self.domain
+        ns = domain.number_of_tracers
+        if ns == 0 or domain.tracer_boundary_flux_sum is None:
+            return
+
+        dt = domain.timestep
+        ts_method = domain.timestepping_method
+        # (substep, tracer), matching the kernel's [substep*ns + s] indexing.
+        fs = domain.tracer_boundary_flux_sum.reshape(-1, ns)
+
+        if ts_method == 'euler':
+            contribution = dt * fs[0]
+        elif ts_method == 'rk2':
+            contribution = 0.5 * dt * fs[0:2].sum(axis=0)
+        elif ts_method == 'rk3':
+            contribution = (1.0 / 6.0) * dt * (fs[0] + fs[1] + 4.0 * fs[2])
+        elif ts_method == 'ader2':
+            # fs[0] holds the flux from the Q^{n+1/2} midpoint state.
+            contribution = dt * fs[0]
+        else:
+            raise Exception(
+                'Cannot compute tracer boundary flux integral with '
+                'timestepping method %r' % ts_method)
+
+        domain._tracer_flux_integral[:ns] += contribution
+        # Zero for the next step, exactly as the water operator does.
+        domain.tracer_boundary_flux_sum[:] = 0.0
+
+    def parallel_safe(self):
+        """Applied independently on each parallel sub-domain.
+
+        Each rank counts only the boundary edges of cells it owns -- the kernel
+        skips ghosts -- so the per-rank integrals sum to the whole-domain one,
+        and `get_tracer_mass` reduces the same way.
+        """
+        return True
+
+    def statistics(self):
+        return self.label + ': tracer_flux_integral_operator'
+
+    def timestepping_statistics(self):
+        return ''

--- a/anuga/shallow_water/gpu/core_kernels.c
+++ b/anuga/shallow_water/gpu/core_kernels.c
@@ -1165,6 +1165,7 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
     double * restrict t_eu = D->tracer_explicit_update;
     double * restrict t_ev = D->tracer_edge_values;
     double * restrict t_bv = D->tracer_boundary_values;
+    double * restrict t_bf = D->tracer_boundary_flux;
 #endif
 
     // Reduction variables
@@ -1352,10 +1353,17 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
                 double * restrict t_ev = D->tracer_edge_values;
                 double * restrict t_bv = D->tracer_boundary_values;
                 double * restrict t_eu = D->tracer_explicit_update;
+                double * restrict t_bf = D->tracer_boundary_flux;
 #endif
                 const anuga_int t_bl = D->boundary_length;
                 const double wflux = edgeflux[0];
                 const int    inflow = (wflux > 0.0);
+                /* Conservation accounting: record what crosses a DOMAIN boundary edge,
+                 * on the same terms the water balance uses -- a real boundary, and this
+                 * cell owned rather than a ghost. A ghost cell's copy of the edge
+                 * belongs to its owner, so counting it here would double it. */
+                const int count_bdry = (t_bf != NULL) && is_boundary
+                    && (tri_full_flag == NULL || tri_full_flag[k] == 1);
                 for (anuga_int s = 0; s < n_tracers; s++) {
                     double c_up;
                     if (inflow) {
@@ -1366,6 +1374,10 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
                         c_up = t_ev[s * 3 * n + ki];
                     }
                     t_eu[s * n + k] += wflux * c_up;
+                    if (count_bdry) {
+                        /* Same sign as edgeflux[0]: positive is inflow. */
+                        t_bf[s * n + k] += wflux * c_up;
+                    }
                 }
             }
             // -------------------------------------------------------------
@@ -1416,6 +1428,37 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
     // Store boundary flux sum for this substep
     if (D->boundary_flux_sum != NULL && substep_count < timestep_fluxcalls) {
         D->boundary_flux_sum[substep_count] = boundary_flux_sum_substep;
+    }
+
+    /* Same, per tracer. The main loop accumulated per cell so it needed no
+     * reduction; total it here with ONE SCALAR REDUCTION PER TRACER, which is
+     * a pattern every target supports, instead of the runtime-length array
+     * reduction the main loop would have required. n_tracers is small, and the
+     * whole block is skipped when there are none. The scratch is zeroed in the
+     * same pass, ready for the next substep. */
+    if (n_tracers > 0 && D->tracer_boundary_flux != NULL
+            && D->tracer_boundary_flux_sum != NULL
+            && substep_count < timestep_fluxcalls) {
+#ifdef CPU_ONLY_MODE
+        /* The GPU build has this hoisted to function scope (see the note on
+         * tracer base pointers above); the CPU build loads it in-guard inside
+         * the element loop, so it needs its own here. */
+        double * restrict t_bf = D->tracer_boundary_flux;
+#endif
+        for (anuga_int s = 0; s < n_tracers; s++) {
+            double tsum = 0.0;
+            const anuga_int off = s * n;
+#ifdef CPU_ONLY_MODE
+            #pragma omp parallel for reduction(+:tsum)
+#else
+            #pragma omp target teams distribute parallel for reduction(+:tsum)
+#endif
+            for (anuga_int k = 0; k < n; k++) {
+                tsum += t_bf[off + k];
+                t_bf[off + k] = 0.0;
+            }
+            D->tracer_boundary_flux_sum[substep_count * n_tracers + s] = tsum;
+        }
     }
 
     // Return timestep (only meaningful on first substep)

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -784,9 +784,15 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
         double *tr_eu = GD->D.tracer_explicit_update;
         double *tr_qv = GD->D.tracer_conserved_values;
         double *tr_bk = GD->D.tracer_backup_values;
+        // tracer_boundary_flux is per-cell conservation scratch: the kernel
+        // accumulates into it and totals it per substep, so it belongs with the
+        // rest of the block for the same reason -- the n_tracers > 0 guard
+        // reads it, and a partial mapping is an illegal device address.
+        double *tr_bf = GD->D.tracer_boundary_flux;
         #pragma omp target enter data map(to: \
             tr_cv[0:ns*n], tr_ev[0:ns*3*n], \
-            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n])
+            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n], \
+            tr_bf[0:ns*n])
 
         // Boundary values are sized by boundary_length, which is zero on a
         // domain with no boundary edges -- mapping a zero-length array is not
@@ -1204,9 +1210,11 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
         double *tr_eu = GD->D.tracer_explicit_update;
         double *tr_qv = GD->D.tracer_conserved_values;
         double *tr_bk = GD->D.tracer_backup_values;
+        double *tr_bf = GD->D.tracer_boundary_flux;
         #pragma omp target exit data map(delete: \
             tr_cv[0:ns*n], tr_ev[0:ns*3*n], \
-            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n])
+            tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n], \
+            tr_bf[0:ns*n])
         if (nb > 0) {
             double *tr_bv = GD->D.tracer_boundary_values;
             #pragma omp target exit data map(delete: tr_bv[0:ns*nb])

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -680,6 +680,17 @@ class Domain(Generic_Domain):
         self.tracer_explicit_update = None      # dm/dt        (ns, N)
         self.tracer_conserved_values = None     # m = h*c      (ns, N)
         self.tracer_backup_values = None        # m backup     (ns, N)
+        self.tracer_boundary_flux = None        # d(mass)/dt across the
+                                                # domain boundary, per cell,
+                                                # accumulated by the kernel (ns, N)
+        # Per-substep totals of the above, (max_time_substeps * ns), mirroring
+        # boundary_flux_sum for water; and the running time integral, which
+        # tracer_flux_integral_operator advances with the timestepping method's
+        # own weights. _tracer_initial_mass is the baseline a conservation
+        # check is measured against.
+        self.tracer_boundary_flux_sum = None
+        self._tracer_flux_integral = None
+        self._tracer_initial_mass = None
 
         #-------------------------------
         # If environment variable OMP_NUM_THREADS is not set,
@@ -829,7 +840,8 @@ class Domain(Generic_Domain):
     #------------------------------------------------
     _TRACER_ARRAYS = ('tracer_centroid_values', 'tracer_edge_values',
                       'tracer_boundary_values', 'tracer_explicit_update',
-                      'tracer_conserved_values', 'tracer_backup_values')
+                      'tracer_conserved_values', 'tracer_backup_values',
+                      'tracer_boundary_flux')
 
     def add_tracer(self, name, beta=None, initial_value=0.0):
         """Register a passive tracer named `name` and return its index.
@@ -893,11 +905,28 @@ class Domain(Generic_Domain):
             'tracer_explicit_update':  (ns + 1, N),
             'tracer_conserved_values': (ns + 1, N),
             'tracer_backup_values':    (ns + 1, N),
+            'tracer_boundary_flux':    (ns + 1, N),
         }
 
         # Grow each array by one row, preserving the tracers already there.
         # The kernels index these as centroid[s*N + k] etc., so they must stay
         # C-contiguous float64 -- num.zeros gives both.
+        # The per-substep totals and the running integral are sized by tracer
+        # count, not by cells, so they are rebuilt here rather than in the loop
+        # below. The integral and the baseline mass are PRESERVED across a
+        # later add_tracer: a tracer registered mid-setup must not silently
+        # reset another tracer's accounting.
+        max_substeps = len(self.boundary_flux_sum)
+        new_sum = num.zeros((ns + 1) * max_substeps, dtype=num.float64)
+        new_int = num.zeros(ns + 1, dtype=num.float64)
+        new_m0 = num.zeros(ns + 1, dtype=num.float64)
+        if ns > 0 and self._tracer_flux_integral is not None:
+            new_int[:ns] = self._tracer_flux_integral
+            new_m0[:ns] = self._tracer_initial_mass
+        self.tracer_boundary_flux_sum = new_sum
+        self._tracer_flux_integral = new_int
+        self._tracer_initial_mass = new_m0
+
         for attr in self._TRACER_ARRAYS:
             new = num.zeros(shapes[attr], dtype=num.float64)
             if ns > 0:
@@ -932,7 +961,78 @@ class Domain(Generic_Domain):
         if initial_value is not None:
             self.set_tracer(name, initial_value)
 
+        # The operator that turns the kernel's per-substep boundary totals into
+        # a time integral. Registered here rather than left to the user: without
+        # it get_tracer_boundary_flux_integral() would silently read zero, which
+        # is exactly the failure a conservation check exists to catch.
+        from anuga.operators.tracer_flux_integral_operator import (
+            tracer_flux_integral_operator)
+        if not any(isinstance(op, tracer_flux_integral_operator)
+                   for op in self.fractional_step_operators):
+            tracer_flux_integral_operator(self)
+
+        # Baseline for check_tracer_conservation, taken AFTER the initial value
+        # is seeded so it is the mass actually present at t = 0.
+        self._tracer_initial_mass[index] = self.get_tracer_mass(name)
+
         return index
+
+    def get_tracer_mass(self, name):
+        """Total mass of tracer `name` in the domain: the integral of m = h*c.
+
+        The tracer analogue of `get_water_volume`. Summed over owned cells only
+        and reduced across ranks, so it is the whole-domain figure in parallel
+        as well as in serial.
+        """
+        s = self.get_tracer_index(name)
+        m = self.tracer_conserved_values[s]           # m = h*c per cell
+        areas = self.areas
+        if self.tri_full_flag is not None:
+            mass = float(num.sum(m * areas * (self.tri_full_flag == 1)))
+        else:
+            mass = float(num.sum(m * areas))
+
+        from anuga import numprocs
+        if numprocs == 1:
+            return mass
+        from mpi4py import MPI
+        return MPI.COMM_WORLD.allreduce(mass, op=MPI.SUM)
+
+    def get_tracer_boundary_flux_integral(self, name):
+        """Net tracer mass that has crossed the domain boundary, since t=0.
+
+        Positive is INTO the domain, matching the sign of the water balance.
+        The tracer analogue of `get_boundary_flux_integral`, and the other half
+        of a mass budget:
+
+            mass(t) - mass(0) == boundary_flux_integral(t)
+
+        to within the timestepping error, for a domain with no source terms.
+        `check_tracer_conservation` does exactly that comparison.
+
+        The kernel accumulates the per-edge boundary flux into a per-cell array
+        each substep; `tracer_flux_integral_operator` applies the timestepping
+        method's own weights and zeroes it, exactly as
+        `boundary_flux_integral_operator` does for water.
+        """
+        s = self.get_tracer_index(name)
+        return float(self._tracer_flux_integral[s])
+
+    def check_tracer_conservation(self, name):
+        """Return (change_in_mass, boundary_flux_integral, discrepancy).
+
+        For a domain with no tracer source terms the first two should agree, so
+        the discrepancy is the conservation error. On a CLOSED domain the flux
+        integral is zero and this reduces to "did the mass stay constant".
+
+        Returns absolute quantities, not a relative error: for a tracer that is
+        zero almost everywhere a relative measure is meaningless, and the caller
+        knows the scale that matters.
+        """
+        s = self.get_tracer_index(name)
+        change = self.get_tracer_mass(name) - self._tracer_initial_mass[s]
+        flux = self.get_tracer_boundary_flux_integral(name)
+        return change, flux, change - flux
 
     def get_tracer_index(self, name):
         """Return the row index of tracer `name`."""
@@ -962,6 +1062,12 @@ class Domain(Generic_Domain):
         Seeds both `c` and the conserved `m = h*c`, which must agree: setting
         `c` alone leaves the conserved variable stale and the first substep
         overwrites `c` from it.
+
+        Because `m = h*c`, this reads the CURRENT depth: set `stage` and
+        `elevation` before the tracer, not after.
+
+        Called before the run starts, this also rebases the conservation
+        baseline (see `check_tracer_conservation`); called mid-run it does not.
         """
         s = self.get_tracer_index(name)
         # asarray, not ascontiguousarray: the latter promotes a 0-d scalar to
@@ -975,6 +1081,20 @@ class Domain(Generic_Domain):
                 % (name, self.number_of_elements, c.shape))
         self.tracer_centroid_values[s] = c
         self.tracer_conserved_values[s] = self._tracer_depth() * c
+
+        # Setting the field before the run starts IS the initial condition, so
+        # rebase the conservation baseline on it. Without this, the common
+        # add_tracer(name) / set_tracer(name, field) pairing would leave the
+        # baseline at the mass add_tracer seeded and check_tracer_conservation
+        # would report the difference as a conservation error.
+        #
+        # Mid-run a set_tracer is a genuine intervention that really does break
+        # the budget, so leave the baseline alone there and let it show up as a
+        # discrepancy rather than silently absorbing it.
+        if (self._tracer_initial_mass is not None
+                and s < len(self._tracer_initial_mass)
+                and self.relative_time == self.evolve_starttime):
+            self._tracer_initial_mass[s] = self.get_tracer_mass(name)
 
     def update_domain_c_struct(self):
         """Update the C domain structure from the Python Domain object.
@@ -5316,6 +5436,8 @@ class Domain(Generic_Domain):
 
         from anuga.operators.rate_operators import Rate_operator
         from anuga.operators.boundary_flux_integral_operator import boundary_flux_integral_operator
+        from anuga.operators.tracer_flux_integral_operator import (
+            tracer_flux_integral_operator)
         from anuga.structures.inlet_operator import Inlet_operator
         from anuga.structures.gpu_culvert_manager import GPUCulvertManager
         from anuga.operators.collect_max_quantities_operator import Collect_max_quantities_operator
@@ -5341,6 +5463,13 @@ class Domain(Generic_Domain):
             elif isinstance(op, boundary_flux_integral_operator):
                 # boundary_flux_integral_operator only reads boundary_flux_sum (small array)
                 # and accumulates a scalar - doesn't need full centroid sync
+                continue
+            elif isinstance(op, tracer_flux_integral_operator):
+                # Same shape as the water one: reads the small per-substep
+                # tracer_boundary_flux_sum, which the kernel writes on the HOST,
+                # and accumulates into a per-tracer scalar. The per-cell scratch
+                # it totals lives and is zeroed on the device, so no centroid
+                # sync is needed here either.
                 continue
             elif isinstance(op, Inlet_operator):
                 # Force GPU initialization if not already done

--- a/anuga/shallow_water/sw_domain.h
+++ b/anuga/shallow_water/sw_domain.h
@@ -148,6 +148,23 @@ struct domain {
      * DERIVED from it each substep, exactly as height is derived from stage. */
     double* tracer_conserved_values;
     double* tracer_backup_values;
+    /* Per-cell accumulation of tracer flux across DOMAIN BOUNDARY edges, for
+     * conservation accounting; (n_tracers, N), same layout as the rest.
+     *
+     * Per-cell rather than a scalar reduction on purpose. The water equivalent
+     * uses reduction(+:boundary_flux_sum_substep), but the tracer version would
+     * need a runtime-length ARRAY reduction, reduction(+:t[0:ns]), which is
+     * unproven on nvc GPU targets. Each cell only ever writes its own edges, so
+     * accumulating per cell needs no reduction and no atomics, and the sum is
+     * taken on the host at yield time.
+     *
+     * Sign follows edgeflux[0]: positive is INTO the domain. */
+    double* tracer_boundary_flux;
+    /* Per-substep, per-tracer totals of the above; (timestep_fluxcalls,
+     * n_tracers), mirroring boundary_flux_sum for water. Filled by ns SCALAR
+     * reductions after the flux loop -- one per tracer, which every target
+     * supports -- rather than one array reduction inside it. */
+    double* tracer_boundary_flux_sum;
     /* Reconstruction aggressiveness for tracers, analogous to beta_w for stage.
      * 0.0 => first order; >0 => limited second order. Appended at the very end
      * so no previously-existing field offset moves. */

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -109,6 +109,8 @@ cdef extern from "gpu_domain.h" nogil:
         double* tracer_explicit_update
         double* tracer_conserved_values
         double* tracer_backup_values
+        double* tracer_boundary_flux
+        double* tracer_boundary_flux_sum
         int64_t ncol_riverwall_hydraulic_properties
         int64_t nrow_riverwall_hydraulic_properties
         int64_t* edge_flux_type
@@ -818,6 +820,7 @@ cdef void get_domain_pointers(gpu_domain *GD, object domain_object):
     # and dereference all six, so a NULL here is CUDA_ERROR_ILLEGAL_ADDRESS on
     # the device, not a degraded result. gpu_domain_core.c maps them.
     cdef double[:, ::1] tr2
+    cdef double[::1] tr1
     if D.number_of_tracers > 0:
         tr2 = domain_object.tracer_centroid_values
         D.tracer_centroid_values = &tr2[0, 0]
@@ -831,6 +834,10 @@ cdef void get_domain_pointers(gpu_domain *GD, object domain_object):
         D.tracer_conserved_values = &tr2[0, 0]
         tr2 = domain_object.tracer_backup_values
         D.tracer_backup_values = &tr2[0, 0]
+        tr2 = domain_object.tracer_boundary_flux
+        D.tracer_boundary_flux = &tr2[0, 0]
+        tr1 = domain_object.tracer_boundary_flux_sum
+        D.tracer_boundary_flux_sum = &tr1[0]
     else:
         D.tracer_centroid_values = NULL
         D.tracer_edge_values = NULL
@@ -838,6 +845,8 @@ cdef void get_domain_pointers(gpu_domain *GD, object domain_object):
         D.tracer_explicit_update = NULL
         D.tracer_conserved_values = NULL
         D.tracer_backup_values = NULL
+        D.tracer_boundary_flux = NULL
+        D.tracer_boundary_flux_sum = NULL
 
     # Extract riverwall arrays (may be empty if no riverwalls)
     D.number_of_riverwall_edges = getattr(domain_object, 'number_of_riverwall_edges', 0)

--- a/anuga/shallow_water/sw_domain_openmp_ext.pyx
+++ b/anuga/shallow_water/sw_domain_openmp_ext.pyx
@@ -27,6 +27,8 @@ cdef extern from "sw_domain_openmp.c" nogil:
 		double* tracer_explicit_update
 		double* tracer_conserved_values
 		double* tracer_backup_values
+		double* tracer_boundary_flux
+		double* tracer_boundary_flux_sum
 		anuga_int optimise_dry_cells
 		anuga_int extrapolate_velocity_second_order
 		anuga_int low_froude
@@ -323,6 +325,7 @@ cdef inline get_python_domain_pointers(domain *D, object domain_py_object):
 	# Generic tracer arrays. Owned by the Python Domain as C-contiguous
 	# (ns, ...) float64 arrays; NULL when no tracers are registered.
 	cdef double[:, ::1] tr2
+	cdef double[::1] tr1
 	if getattr(domain_py_object, 'number_of_tracers', 0) > 0:
 		tr2 = domain_py_object.tracer_centroid_values
 		D.tracer_centroid_values = &tr2[0, 0]
@@ -336,6 +339,10 @@ cdef inline get_python_domain_pointers(domain *D, object domain_py_object):
 		D.tracer_conserved_values = &tr2[0, 0]
 		tr2 = domain_py_object.tracer_backup_values
 		D.tracer_backup_values = &tr2[0, 0]
+		tr2 = domain_py_object.tracer_boundary_flux
+		D.tracer_boundary_flux = &tr2[0, 0]
+		tr1 = domain_py_object.tracer_boundary_flux_sum
+		D.tracer_boundary_flux_sum = &tr1[0]
 	else:
 		D.tracer_centroid_values = NULL
 		D.tracer_edge_values = NULL
@@ -343,6 +350,8 @@ cdef inline get_python_domain_pointers(domain *D, object domain_py_object):
 		D.tracer_explicit_update = NULL
 		D.tracer_conserved_values = NULL
 		D.tracer_backup_values = NULL
+		D.tracer_boundary_flux = NULL
+		D.tracer_boundary_flux_sum = NULL
 
 	quantities = domain_py_object.quantities
 	stage = quantities["stage"]

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -18,6 +18,7 @@ python_sources = [
 'test_tracers.py',
 'test_tracers_sww.py',
 'test_tracers_unsupported_paths.py',
+'test_tracers_conservation.py',
 'test_tracers_gpu.py',
 'test_forcing.py',
 'test_friction.py',

--- a/anuga/shallow_water/tests/test_tracers_conservation.py
+++ b/anuga/shallow_water/tests/test_tracers_conservation.py
@@ -1,0 +1,129 @@
+"""Tracer mass budget: mass(t) - mass(0) == boundary flux integral.
+
+The tracer counterpart of the water balance. `get_tracer_mass` integrates the
+conserved m = h*c; the flux kernel records what crosses each domain-boundary
+edge, per substep; `tracer_flux_integral_operator` time-integrates it with the
+timestepping method's own weights.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+
+
+def _closed(n=12):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', lambda x, y: -0.1 * x)
+    d.set_quantity('stage', 0.5)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    return d
+
+
+def _draining(n=16):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', lambda x, y: -0.3 * x)
+    d.set_quantity('stage', lambda x, y: num.maximum(0.5 - 0.3 * x, 0.05))
+    Bt = anuga.Transmissive_boundary(d)
+    Br = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': Br, 'right': Bt, 'top': Br, 'bottom': Br})
+    return d
+
+
+def test_mass_is_the_integral_of_h_times_c():
+    d = _closed()
+    d.add_tracer('c', initial_value=0.3)
+    # h = 0.5 - (-0.1x) so the mass is sum(h*c*area); compare against the
+    # conserved variable directly rather than restating the formula.
+    expected = float(num.sum(d.tracer_conserved_values[0] * d.areas))
+    assert num.isclose(d.get_tracer_mass('c'), expected, rtol=1e-12)
+
+
+def test_a_closed_domain_conserves_tracer_mass():
+    d = _closed()
+    d.add_tracer('c', initial_value=0.3)
+    m0 = d.get_tracer_mass('c')
+    for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+    change, flux, disc = d.check_tracer_conservation('c')
+    assert abs(change) < 1e-12 * max(m0, 1.0), 'mass moved on a closed domain'
+    assert abs(flux) < 1e-12 * max(m0, 1.0), 'flux across a closed boundary'
+    assert abs(disc) < 1e-12 * max(m0, 1.0)
+
+
+def test_the_budget_balances_when_tracer_leaves():
+    """The real test: tracer leaves, and the flux integral accounts for it."""
+    d = _draining()
+    d.add_tracer('c', initial_value=0.4)
+    m0 = d.get_tracer_mass('c')
+    for _ in d.evolve(yieldstep=0.25, finaltime=3.0):
+        pass
+    change, flux, disc = d.check_tracer_conservation('c')
+
+    assert change < -0.1 * m0, 'the test is vacuous unless tracer actually left'
+    assert flux < 0.0, 'net flux should be outward'
+    assert abs(disc) < 1e-10 * abs(change), \
+        'mass change and boundary flux integral disagree: %g vs %g' % (change, flux)
+
+
+def test_two_tracers_are_accounted_separately():
+    d = _draining()
+    d.add_tracer('a', initial_value=0.4)
+    d.add_tracer('b', initial_value=0.1)
+    for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+    ca, fa, da = d.check_tracer_conservation('a')
+    cb, fb, db = d.check_tracer_conservation('b')
+    assert abs(da) < 1e-10 * abs(ca)
+    assert abs(db) < 1e-10 * abs(cb)
+    # b started at a quarter of a's concentration, so it should have lost
+    # about a quarter as much -- not the same amount, which would mean the
+    # rows are aliased.
+    assert not num.isclose(ca, cb, rtol=1e-3)
+
+
+def test_the_baseline_is_taken_after_the_initial_value():
+    # _tracer_initial_mass must reflect the seeded field, not an empty domain.
+    d = _closed()
+    d.add_tracer('c', initial_value=0.25)
+    change, _, _ = d.check_tracer_conservation('c')
+    assert abs(change) < 1e-14, 'baseline was taken before the tracer was seeded'
+
+
+def test_a_second_tracer_does_not_reset_the_first_accounting():
+    d = _draining()
+    d.add_tracer('a', initial_value=0.4)
+    for _ in d.evolve(yieldstep=0.5, finaltime=1.0):
+        pass
+    integral_before = d.get_tracer_boundary_flux_integral('a')
+    assert integral_before != 0.0
+    d.add_tracer('b', initial_value=0.2)      # reallocates every tracer array
+    assert d.get_tracer_boundary_flux_integral('a') == integral_before
+
+
+def test_set_tracer_before_the_run_rebases_the_baseline():
+    """add_tracer(name) then set_tracer(name, field) is the usual idiom."""
+    d = _closed()
+    d.add_tracer('c')                      # seeds zero
+    x = d.centroid_coordinates[:, 0]
+    d.set_tracer('c', num.where(x < 0.5, 1.0, 0.0))
+    assert d.get_tracer_mass('c') > 0.0
+    change, _, _ = d.check_tracer_conservation('c')
+    assert abs(change) < 1e-14, 'baseline did not follow set_tracer'
+
+
+def test_set_tracer_mid_run_is_not_silently_absorbed():
+    """A mid-run set_tracer really does break the budget; it must show."""
+    d = _closed()
+    d.add_tracer('c', initial_value=0.2)
+    for _ in d.evolve(yieldstep=0.5, finaltime=1.0):
+        pass
+    before = d.get_tracer_mass('c')
+    d.set_tracer('c', 0.6)                 # a deliberate intervention
+    added = d.get_tracer_mass('c') - before
+    assert added > 0.0
+
+    _, _, disc = d.check_tracer_conservation('c')
+    assert abs(disc - added) < 1e-10 * added, \
+        'mid-run set_tracer was rebased away instead of showing as a discrepancy'

--- a/anuga/shallow_water/tests/test_tracers_gpu.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu.py
@@ -146,3 +146,76 @@ def test_depth_is_consistent_with_stage_in_both_modes(evolved):
         h = (d.quantities['stage'].centroid_values
              - d.quantities['elevation'].centroid_values)
         assert h.min() > -1e-10, '%s: negative depth %.3e' % (nm, h.min())
+
+
+# The draining case: a flat bed with the water already moving toward an open
+# right wall, so a large fraction of the tracer is flushed out. The point is to
+# move enough that a boundary integral which silently read zero could not still
+# look "close enough" -- a gently draining domain loses a fraction of a percent
+# and would not discriminate.
+DRAIN_FINALTIME = 60.0
+DRAIN_DEPTH = 2.0
+DRAIN_SPEED = 2.0
+
+
+def _build_draining(mode):
+    """Same problem, but the right wall is open so tracer leaves the domain."""
+    d = rectangular_cross_domain(NXY, NXY, len1=LEN, len2=LEN)
+    d.set_flow_algorithm('DE0')
+    d.set_low_froude(0)
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', DRAIN_DEPTH)
+    d.set_quantity('xmomentum', DRAIN_DEPTH * DRAIN_SPEED)
+    d.set_quantity('ymomentum', 0.0)
+    Br = Reflective_boundary(d)
+    Bt = anuga.Transmissive_boundary(d)
+    d.set_boundary({'left': Br, 'top': Br, 'bottom': Br, 'right': Bt})
+    d.add_tracer('c', beta=1.0)
+    d.set_tracer('c', 1.0)
+    d.set_multiprocessor_mode(mode)
+    return d
+
+
+@pytest.fixture(scope='module')
+def drained():
+    if not gpu_available():
+        pytest.skip('GPU OpenMP interface not available: %s' % _gpu_error)
+
+    cpu = _build_draining(1)
+    cpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+
+    gpu = _build_draining(2)
+    if getattr(gpu, 'multiprocessor_mode', None) != 2:
+        pytest.fail('mode 2 did not engage: multiprocessor_mode=%r'
+                    % getattr(gpu, 'multiprocessor_mode', None))
+    from anuga.shallow_water.sw_domain_gpu_ext import sync_to_device
+    sync_to_device(gpu.gpu_interface.gpu_dom)
+    gpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+    return cpu, gpu
+
+
+def test_the_tracer_budget_balances_on_the_device(drained):
+    """The mode-2 boundary accounting must be real, not a silent zero.
+
+    `tracer_boundary_flux` is written inside the flux kernel's `omp target`
+    region, so it is subject to the same trap the module docstring describes:
+    load its base pointer off `D` inside the region and the accumulation
+    silently does nothing, leaving an integral of exactly 0.0 while the mass
+    still changes. Asserting the budget balances catches that.
+    """
+    for nm, d in zip(('mode 1', 'mode 2'), drained):
+        change, flux, disc = d.check_tracer_conservation('c')
+        assert change < -0.05 * d.get_tracer_mass('c'), \
+            '%s: too little tracer left for this to be a real test' % nm
+        assert flux != 0.0, '%s: boundary flux integral is exactly zero' % nm
+        assert abs(disc) < 1e-10 * abs(change), \
+            '%s: budget does not balance (change %g, flux %g)' % (nm, change, flux)
+
+
+def test_the_two_modes_agree_on_the_budget(drained):
+    cpu, gpu = drained
+    c1, f1, _ = cpu.check_tracer_conservation('c')
+    c2, f2, _ = gpu.check_tracer_conservation('c')
+    assert abs(c1 - c2) < 1e-10 * max(abs(c1), 1.0), 'mass change disagrees'
+    assert abs(f1 - f2) < 1e-10 * max(abs(f1), 1.0), 'flux integral disagrees'


### PR DESCRIPTION
Gives tracers the mass budget the water balance already has:

```
mass(t) - mass(0) == boundary_flux_integral(t)
```

### API

```python
domain.add_tracer('c', initial_value=1.0)
...
change, flux, disc = domain.check_tracer_conservation('c')
```

| method | returns |
|---|---|
| `get_tracer_mass(name)` | integral of `m = h*c` over owned cells, MPI-reduced |
| `get_tracer_boundary_flux_integral(name)` | net mass across the boundary since t=0, positive inward |
| `check_tracer_conservation(name)` | `(change, flux, discrepancy)` |

Nothing to set up: `add_tracer` registers the integrating operator itself.

### How the boundary flux is measured

Only the flux loop knows what actually crossed each boundary edge. The kernel already
switched on the sign of the water flux to pick the upwind concentration; the accounting
hooks into that same branch and accumulates `wflux * c_up` for real boundary edges of
owned cells, skipping ghosts so per-rank integrals sum to the whole-domain figure.

Two things worth review attention:

- **Per-cell accumulator, not a scalar.** The water version uses
  `reduction(+:boundary_flux_sum_substep)`. The tracer version would need a
  runtime-length *array* reduction, `reduction(+:t[0:ns])`, which is unproven on nvc
  GPU targets. Each cell writes only its own edges, so per-cell accumulation needs no
  reduction and no atomics; the per-substep totals are then formed by `ns` scalar
  reductions after the loop.
- **Base-pointer placement.** `tracer_boundary_flux` follows the convention documented
  in `core_kernels.c`: hoisted under `#ifndef CPU_ONLY_MODE`, loaded in-guard under
  `#ifdef CPU_ONLY_MODE`. I hit the documented trap while writing this — loading it off
  `D` inside the target region reads a host address on the device, and the accounting
  silently reports **zero** while the mass really does change. `test_tracers_gpu.py`
  now asserts the integral is non-zero and the budget balances, so that failure mode
  cannot come back green.

`tracer_flux_integral_operator` applies the timestepping method's own weights
(euler/rk2/rk3/ader2), exactly as `boundary_flux_integral_operator` does for water, and
is classified GPU-safe — mode 2 still reports *"All fractional operators are GPU-safe,
no GPU<->CPU sync needed"*.

### A baseline trap fixed along the way

Writing the tests turned up a sharp edge in the usual idiom:

```python
domain.add_tracer('c')
domain.set_tracer('c', field)      # spatially varying initial condition
```

The baseline stayed at the mass `add_tracer` seeded, so the initial condition itself was
reported as a conservation error. `set_tracer` now rebases the baseline when called
before the run starts — and deliberately **does not** mid-run, where a `set_tracer` is a
real intervention that should surface as a discrepancy rather than be absorbed.

### Verification

Draining domain, 24% of the tracer flushed out:

| mode | change | flux integral | \|disc\|/\|change\| |
|---|---|---|---|
| legacy (CPU) | -1.2000e+05 | -1.2000e+05 | 1.2e-16 |
| unified (GPU, RTX 5070) | -1.2000e+05 | -1.2000e+05 | 6.6e-14 |

Closed domains conserve exactly. Test runs:

- `test_tracers_conservation.py` — 8 new tests, all pass
- `test_tracers_gpu.py` — 9/9 via `anuga_run_isolated_tests` on a GPU-offload build
- `anuga/shallow_water/tests/` — 405 passed, 1 skipped
- `pytest --pyargs anuga --run-fast` — 2769 passed, 224 skipped

### Note for whoever merges second

Conflicts with #281 in `shallow_water_domain.py` — both branches add methods in the same
region, so it is a keep-both resolve, no logic overlap.
