### PR TITLE
reorder() permutes the tracer arrays (#277)

### DIFF
--- a/anuga/abstract_2d_finite_volumes/generic_domain.py
+++ b/anuga/abstract_2d_finite_volumes/generic_domain.py
@@ -551,6 +551,14 @@ class Generic_Domain:
         # mesh.reorder() calls build_boundary_neighbours() internally, which
         # creates NEW boundary_cells/edges/enumeration/tag_boundary_cells objects
         # on the mesh.  The domain caches these from __init__ — rebind after.
+        #
+        # A boundary index is a position in the sorted (triangle, edge) order,
+        # so renumbering triangles renumbers the boundary edges too. Anything
+        # indexed by boundary edge and NOT recomputed each timestep has to be
+        # permuted to match, and that needs the old enumeration -- capture it
+        # before it is thrown away.
+        old_boundary_enumeration = dict(self.mesh.boundary_enumeration)
+
         self.mesh.reorder(new_order, in_place=True)
         self.boundary_enumeration = self.mesh.boundary_enumeration
         self.boundary_cells       = self.mesh.boundary_cells
@@ -561,17 +569,16 @@ class Generic_Domain:
         self.tri_full_flag = self.tri_full_flag[new_order]
         self.number_of_full_triangles = int(num.sum(self.tri_full_flag))
 
-        # Tracers are not Quantity objects, so the loop below cannot see them
-        # and their (ns, N) / (ns, 3N) blocks would keep the OLD ordering while
-        # the mesh moved underneath -- cell k's concentration landing on
-        # whichever triangle used to be at k. Silent, and wrong. Refuse until
-        # #277 implements the permutation.
-        if getattr(self, 'number_of_tracers', 0) > 0:
-            raise NotImplementedError(
-                'reorder() cannot yet permute tracer arrays, so reordering a '
-                'domain with %d tracer(s) would silently misalign them with '
-                'the mesh. See issue #277. Reorder before adding tracers, or '
-                'do not reorder.' % self.number_of_tracers)
+        # --- tracers ---
+        # Tracers are not Quantity objects, so the loop below cannot see them:
+        # they live in contiguous (ns, N) / (ns, 3N) blocks so the C kernel can
+        # stride them. Without this hook their blocks would keep the OLD
+        # ordering while the mesh moved underneath -- cell k's concentration
+        # landing on whichever triangle used to be at k, silently. The shallow
+        # water domain knows the layout, so it does the permuting.
+        reorder_tracers = getattr(self, '_reorder_tracer_arrays', None)
+        if reorder_tracers is not None:
+            reorder_tracers(new_order, inv_order, old_boundary_enumeration)
 
         # --- quantities ---
         # Reorder centroid_values and any cached per-triangle arrays.

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -841,10 +841,28 @@ class Domain(Generic_Domain):
     #------------------------------------------------
     # Generic passive tracers
     #------------------------------------------------
-    _TRACER_ARRAYS = ('tracer_centroid_values', 'tracer_edge_values',
-                      'tracer_boundary_values', 'tracer_explicit_update',
-                      'tracer_conserved_values', 'tracer_backup_values',
-                      'tracer_boundary_flux')
+    # Every tracer block, and how it is INDEXED -- which is what fixes both its
+    # shape and the way reorder() has to permute it:
+    #
+    #   'cell'      one value per triangle       -> (ns, N)
+    #   'edge'      three values per triangle    -> (ns, 3N)
+    #   'boundary'  one value per boundary edge  -> (ns, boundary_length)
+    #
+    # Single source of truth on purpose: add_tracer sizes the arrays from this
+    # and _reorder_tracer_arrays permutes from it, so a new block cannot be
+    # added without declaring how it is indexed. Tracers are deliberately not
+    # Quantity objects (#276), which means anything walking domain.quantities
+    # misses them -- #277 was exactly that omission, in reorder().
+    _TRACER_ARRAY_KINDS = {
+        'tracer_centroid_values':  'cell',
+        'tracer_edge_values':      'edge',
+        'tracer_boundary_values':  'boundary',
+        'tracer_explicit_update':  'cell',
+        'tracer_conserved_values': 'cell',
+        'tracer_backup_values':    'cell',
+        'tracer_boundary_flux':    'cell',
+    }
+    _TRACER_ARRAYS = tuple(_TRACER_ARRAY_KINDS)
 
     def add_tracer(self, name, beta=None, initial_value=0.0):
         """Register a passive tracer named `name` and return its index.
@@ -875,7 +893,7 @@ class Domain(Generic_Domain):
 
         Notes
         -----
-        Registering a tracer **reallocates** all six tracer arrays, so any
+        Registering a tracer **reallocates** every tracer array, so any
         reference held to one of them beforehand becomes stale.  Add every
         tracer before seeding values, or re-fetch via `get_tracer`.
         """
@@ -901,15 +919,9 @@ class Domain(Generic_Domain):
 
         N = self.number_of_elements
         ns = self.number_of_tracers
-        shapes = {
-            'tracer_centroid_values':  (ns + 1, N),
-            'tracer_edge_values':      (ns + 1, 3 * N),
-            'tracer_boundary_values':  (ns + 1, self.boundary_length),
-            'tracer_explicit_update':  (ns + 1, N),
-            'tracer_conserved_values': (ns + 1, N),
-            'tracer_backup_values':    (ns + 1, N),
-            'tracer_boundary_flux':    (ns + 1, N),
-        }
+        widths = {'cell': N, 'edge': 3 * N, 'boundary': self.boundary_length}
+        shapes = {attr: (ns + 1, widths[kind])
+                  for attr, kind in self._TRACER_ARRAY_KINDS.items()}
 
         # Grow each array by one row, preserving the tracers already there.
         # The kernels index these as centroid[s*N + k] etc., so they must stay
@@ -1126,6 +1138,91 @@ class Domain(Generic_Domain):
         change = self.get_tracer_mass(name) - self._tracer_initial_mass[s]
         flux = self.get_tracer_boundary_flux_integral(name)
         return change, flux, change - flux
+
+    def _reorder_tracer_arrays(self, new_order, inv_order,
+                               old_boundary_enumeration):
+        """Permute the tracer blocks onto a reordered mesh (issue #277).
+
+        Called by `Generic_Domain.reorder` after the mesh has been renumbered
+        but while `inv_order` and the pre-reorder boundary enumeration are
+        still available. A no-op on a domain with no tracers.
+
+        Permutes IN PLACE. The C domain struct holds raw pointers into these
+        buffers, so rebinding the attributes would leave the struct addressing
+        the old memory.
+        """
+        ns = self.number_of_tracers
+        if ns == 0:
+            return
+
+        N = self.number_of_elements
+        new_order = num.asarray(new_order, dtype=int)
+
+        # Belt and braces: a block added to _TRACER_ARRAYS without a kind would
+        # otherwise be skipped here and silently keep the old ordering, which
+        # is the exact failure #277 was.
+        unclassified = [a for a in self._TRACER_ARRAYS
+                        if a not in self._TRACER_ARRAY_KINDS]
+        if unclassified:
+            raise NotImplementedError(
+                'tracer array(s) %s have no entry in _TRACER_ARRAY_KINDS, so '
+                'reorder() does not know how to permute them; classify them '
+                'as cell/edge/boundary' % ', '.join(sorted(unclassified)))
+
+        bperm = None
+
+        for attr in self._TRACER_ARRAYS:
+            arr = getattr(self, attr, None)
+            if arr is None:
+                continue
+            kind = self._TRACER_ARRAY_KINDS[attr]
+
+            if kind == 'cell':
+                # new[:, i] = old[:, new_order[i]], matching the convention the
+                # quantities use. Fancy indexing copies before the assignment,
+                # so this does not alias.
+                arr[:] = arr[:, new_order]
+            elif kind == 'edge':
+                # (ns, 3N) -> (ns, N, 3), permute triangles, flatten back. The
+                # same reshape-permute-ravel the (3N,) arrays get in reorder().
+                arr[:] = arr.reshape(ns, N, 3)[:, new_order, :].reshape(ns, 3 * N)
+            elif kind == 'boundary':
+                if bperm is None:
+                    bperm = self._boundary_permutation(old_boundary_enumeration,
+                                                       inv_order)
+                arr[:] = arr[:, bperm]
+            else:
+                raise NotImplementedError(
+                    'unknown tracer array kind %r for %r' % (kind, attr))
+
+    def _boundary_permutation(self, old_boundary_enumeration, inv_order):
+        """Map each NEW boundary index to the old index of the same edge.
+
+        `build_boundary_neighbours` numbers boundary edges by their position in
+        the sorted (triangle, edge) order, so renumbering triangles renumbers
+        the boundary as well. Quantities do not care -- `update_boundary`
+        refills their boundary values from the Boundary objects every timestep
+        -- but `tracer_boundary_values` is written once by
+        `set_tracer_boundary` and then just read, so it has to be carried
+        across by hand.
+
+        Returns an index array `bperm` with `bperm[new_j] = old_j`, so that
+        `new_values = old_values[bperm]`.
+        """
+        new_boundary_enumeration = self.mesh.boundary_enumeration
+        M = len(new_boundary_enumeration)
+        if len(old_boundary_enumeration) != M:
+            raise RuntimeError(
+                'boundary edge count changed during reorder (%d -> %d); the '
+                'tracer boundary values cannot be carried across'
+                % (len(old_boundary_enumeration), M))
+
+        bperm = num.empty(M, dtype=int)
+        for (old_id, edge), old_j in old_boundary_enumeration.items():
+            # The same physical edge, addressed by the triangle's new number.
+            new_j = new_boundary_enumeration[int(inv_order[old_id]), edge]
+            bperm[new_j] = old_j
+        return bperm
 
     def get_tracer_index(self, name):
         """Return the row index of tracer `name`."""

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -20,6 +20,7 @@ python_sources = [
 'test_tracers_sww.py',
 'test_tracers_unsupported_paths.py',
 'test_tracers_conservation.py',
+'test_tracers_reorder.py',
 'test_tracers_gpu.py',
 'test_forcing.py',
 'test_friction.py',

--- a/anuga/shallow_water/tests/test_tracers_gpu.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu.py
@@ -158,8 +158,18 @@ DRAIN_DEPTH = 2.0
 DRAIN_SPEED = 2.0
 
 
-def _build_draining(mode):
-    """Same problem, but the right wall is open so tracer leaves the domain."""
+def _drain_wedge(d):
+    """A tracer field that varies in space, so a permutation cannot hide in it."""
+    return 0.2 + 0.8 * d.centroid_coordinates[:, 0] / LEN
+
+
+def _build_draining(mode, field=None):
+    """Same problem, but the right wall is open so tracer leaves the domain.
+
+    `field` gives a spatially varying initial concentration; the default is
+    uniform, which is what the budget tests want (the total is what matters)
+    but useless for anything comparing cell by cell.
+    """
     d = rectangular_cross_domain(NXY, NXY, len1=LEN, len2=LEN)
     d.set_flow_algorithm('DE0')
     d.set_low_froude(0)
@@ -172,7 +182,7 @@ def _build_draining(mode):
     Bt = anuga.Transmissive_boundary(d)
     d.set_boundary({'left': Br, 'top': Br, 'bottom': Br, 'right': Bt})
     d.add_tracer('c', beta=1.0)
-    d.set_tracer('c', 1.0)
+    d.set_tracer('c', 1.0 if field is None else field(d))
     d.set_multiprocessor_mode(mode)
     return d
 
@@ -219,3 +229,44 @@ def test_the_two_modes_agree_on_the_budget(drained):
     c2, f2, _ = gpu.check_tracer_conservation('c')
     assert abs(c1 - c2) < 1e-10 * max(abs(c1), 1.0), 'mass change disagrees'
     assert abs(f1 - f2) < 1e-10 * max(abs(f1), 1.0), 'flux integral disagrees'
+
+
+def _build_reordered(mode, seed=3):
+    """As _build_draining, but with the triangles renumbered first (#277).
+
+    reorder() permutes the tracer blocks in place; the device mapping happens
+    afterwards, at evolve time, so mode 2 must see the permuted data.
+    """
+    # A varying field, and mode set below -- after the reorder.
+    d = _build_draining(mode=1, field=_drain_wedge)
+    rng = np.random.default_rng(seed)
+    d.reorder(rng.permutation(len(d)))
+    d.set_multiprocessor_mode(mode)
+    return d
+
+
+def _sorted_by_centroid(d):
+    xy = d.centroid_coordinates
+    return d.get_tracer('c')[np.lexsort((xy[:, 1], xy[:, 0]))]
+
+
+def test_a_reordered_domain_gives_the_same_answer_on_the_device():
+    if not gpu_available():
+        pytest.skip('GPU OpenMP interface not available: %s' % _gpu_error)
+
+    ref = _build_draining(1, field=_drain_wedge)
+    ref.evolve_to_end(finaltime=DRAIN_FINALTIME)
+
+    gpu = _build_reordered(2)
+    if getattr(gpu, 'multiprocessor_mode', None) != 2:
+        pytest.fail('mode 2 did not engage: multiprocessor_mode=%r'
+                    % getattr(gpu, 'multiprocessor_mode', None))
+    from anuga.shallow_water.sw_domain_gpu_ext import sync_to_device
+    sync_to_device(gpu.gpu_interface.gpu_dom)
+    gpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+
+    a = _sorted_by_centroid(ref)
+    b = _sorted_by_centroid(gpu)
+    assert np.ptp(a) > 1e-6, 'field too flat to discriminate'
+    assert np.abs(a - b).max() < 1e-10, \
+        'reordering changed the answer on the device'

--- a/anuga/shallow_water/tests/test_tracers_reorder.py
+++ b/anuga/shallow_water/tests/test_tracers_reorder.py
@@ -1,0 +1,225 @@
+"""Tracer fields survive a mesh reorder (issue #277).
+
+`reorder()` renumbers the triangles for cache locality. Quantities are permuted
+by the loop over `domain.quantities`, but tracers are deliberately not Quantity
+objects -- they live in contiguous (ns, N) / (ns, 3N) blocks so the C kernel can
+stride them -- so they need permuting explicitly.
+
+The failure this guards against is silent: cell k's concentration ends up on
+whichever triangle used to be at k, with no error and a plausible-looking field.
+So the tests check the property that actually matters -- a reordered run gives
+the same answer as an unreordered one -- rather than just that the call returns.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+
+
+def _domain(n=6):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    return d
+
+
+def _wedge(d):
+    """A spatially varying field, so a permutation cannot hide in it."""
+    x = d.centroid_coordinates[:, 0]
+    y = d.centroid_coordinates[:, 1]
+    return 0.25 + 0.5 * x + 0.25 * y
+
+
+def _shuffled(n, seed=7):
+    rng = num.random.default_rng(seed)
+    return rng.permutation(n)
+
+
+def test_reorder_with_tracers_no_longer_refuses():
+    d = _domain()
+    d.add_tracer('salinity', initial_value=0.02)
+    d.reorder(_shuffled(len(d)))           # used to raise NotImplementedError
+    assert num.allclose(d.get_tracer('salinity'), 0.02)
+
+
+def test_the_concentration_follows_its_triangle():
+    d = _domain()
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+    before = d.get_tracer('c').copy()
+
+    order = _shuffled(len(d))
+    d.reorder(order)
+
+    # new[i] == old[order[i]] -- the same convention the quantities use.
+    assert num.allclose(d.get_tracer('c'), before[order])
+
+
+def test_the_concentration_still_matches_its_own_centroid():
+    """The strongest statement of alignment: c is a known function of (x, y)."""
+    d = _domain()
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+
+    d.reorder(_shuffled(len(d)))
+
+    # centroid_coordinates has moved with the mesh; recompute from it.
+    assert num.allclose(d.get_tracer('c'), _wedge(d))
+
+
+def test_the_conserved_variable_moves_with_the_concentration():
+    d = _domain()
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+    d.reorder(_shuffled(len(d)))
+
+    h = (d.quantities['stage'].centroid_values
+         - d.quantities['elevation'].centroid_values)
+    assert num.allclose(d.tracer_conserved_values[0], h * d.get_tracer('c')), \
+        'm = h*c is inconsistent after reorder'
+
+
+def test_two_tracers_do_not_get_swapped():
+    d = _domain()
+    d.add_tracer('a')
+    d.add_tracer('b')
+    d.set_tracer('a', _wedge(d))
+    d.set_tracer('b', 1.0 - _wedge(d))
+
+    d.reorder(_shuffled(len(d)))
+
+    assert num.allclose(d.get_tracer('a'), _wedge(d))
+    assert num.allclose(d.get_tracer('b'), 1.0 - _wedge(d))
+
+
+def test_the_arrays_stay_contiguous_for_the_kernel():
+    """The C kernel indexes these as centroid[s*N + k]; a strided view breaks it."""
+    d = _domain()
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+    d.reorder(_shuffled(len(d)))
+
+    for attr in d._TRACER_ARRAYS:
+        arr = getattr(d, attr)
+        assert arr.flags['C_CONTIGUOUS'], '%s is no longer C-contiguous' % attr
+        assert arr.dtype == num.float64, '%s changed dtype' % attr
+
+
+# --------------------------------------------------------------------------
+# Boundary values: indexed by boundary edge, which reorder() also renumbers.
+# --------------------------------------------------------------------------
+
+def _tagged_domain(n=6):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    Br = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': Br, 'right': Br, 'top': Br, 'bottom': Br})
+    return d
+
+
+def _boundary_edge_midpoints(d, tag):
+    """(x, y) of each boundary edge of `tag`, in that tag's own order."""
+    idx = num.asarray(d.tag_boundary_cells[tag], dtype=int)
+    cells = d.boundary_cells[idx]
+    edges = d.boundary_edges[idx]
+    return num.column_stack((d.edge_coordinates[3 * cells + edges, 0],
+                             d.edge_coordinates[3 * cells + edges, 1]))
+
+
+def test_boundary_values_follow_their_edge():
+    """The subtle half: boundary indices are renumbered by reorder() too.
+
+    Quantities do not notice, because update_boundary refills their boundary
+    values every timestep from the Boundary objects. tracer_boundary_values is
+    written once by set_tracer_boundary and then only read, so it has to be
+    carried across explicitly.
+    """
+    d = _tagged_domain()
+    d.add_tracer('c')
+
+    # A distinct value per edge, keyed to position so a mismatch is visible.
+    mid = _boundary_edge_midpoints(d, 'left')
+    d.set_tracer_boundary('c', 'left', 1.0 + mid[:, 1])
+    d.set_tracer_boundary('c', 'right', 5.0)
+
+    d.reorder(_shuffled(len(d)))
+
+    new_mid = _boundary_edge_midpoints(d, 'left')
+    assert num.allclose(d.get_tracer_boundary('c', 'left'), 1.0 + new_mid[:, 1]), \
+        'boundary concentrations no longer sit on the edges they were set for'
+    assert num.allclose(d.get_tracer_boundary('c', 'right'), 5.0)
+
+
+def test_untouched_boundaries_stay_zero():
+    d = _tagged_domain()
+    d.add_tracer('c')
+    d.set_tracer_boundary('c', 'left', 3.0)
+    d.reorder(_shuffled(len(d)))
+
+    assert num.allclose(d.get_tracer_boundary('c', 'left'), 3.0)
+    for tag in ('right', 'top', 'bottom'):
+        assert num.allclose(d.get_tracer_boundary('c', tag), 0.0), \
+            'tag %r picked up values from another boundary' % tag
+
+
+# --------------------------------------------------------------------------
+# The property that actually matters: same answer, reordered or not.
+# --------------------------------------------------------------------------
+
+def _run(reorder, finaltime=2.0, n=8, seed=3):
+    d = anuga.rectangular_cross_domain(n, n)
+    d.set_quantity('elevation', lambda x, y: -0.2 * x)
+    d.set_quantity('stage', lambda x, y: num.maximum(0.4 - 0.2 * x, 0.05))
+    Br = anuga.Reflective_boundary(d)
+    Bt = anuga.Transmissive_boundary(d)
+    d.set_boundary({'left': Br, 'top': Br, 'bottom': Br, 'right': Bt})
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+    d.set_tracer_boundary('c', 'left', 0.9)
+
+    if reorder:
+        d.reorder(_shuffled(len(d), seed=seed))
+
+    for _ in d.evolve(yieldstep=0.5, finaltime=finaltime):
+        pass
+
+    # Sort by centroid so the two runs can be compared cell for cell.
+    coords = d.centroid_coordinates
+    idx = num.lexsort((coords[:, 1], coords[:, 0]))
+    return d, d.get_tracer('c')[idx], coords[idx]
+
+
+def test_a_reordered_run_gives_the_same_tracer_field():
+    ref_d, ref_c, ref_xy = _run(reorder=False)
+    new_d, new_c, new_xy = _run(reorder=True)
+
+    assert num.allclose(ref_xy, new_xy), 'meshes are not comparable'
+    # Not a trivially uniform field, or the comparison proves nothing.
+    assert num.ptp(ref_c) > 1e-3, 'the tracer field is too flat to discriminate'
+    assert num.allclose(ref_c, new_c, atol=1e-12), \
+        'reordering changed the tracer solution'
+
+
+def test_conservation_still_balances_after_a_reorder():
+    d, _, _ = _run(reorder=True)
+    change, flux, disc = d.check_tracer_conservation('c')
+    assert abs(change) > 0.0
+    assert abs(disc) < 1e-10 * abs(change), \
+        'the boundary accounting lost track of the mesh: %g vs %g' % (change, flux)
+
+
+@pytest.mark.parametrize('method', ['hilbert', 'morton'])
+def test_reorder_domain_helper_handles_tracers(method):
+    """The path that actually calls reorder() in practice."""
+    from anuga.parallel.partitioning import reorder_domain
+
+    d = _domain()
+    d.add_tracer('c')
+    d.set_tracer('c', _wedge(d))
+    reorder_domain(d, method=method)
+
+    assert num.allclose(d.get_tracer('c'), _wedge(d))

--- a/anuga/shallow_water/tests/test_tracers_unsupported_paths.py
+++ b/anuga/shallow_water/tests/test_tracers_unsupported_paths.py
@@ -1,15 +1,16 @@
-"""The two paths that would silently mishandle tracers must refuse instead.
+"""The paths that would silently mishandle tracers must refuse instead.
 
-Both stem from the same root: tracers are not Quantity objects, so machinery
-that walks `domain.quantities` does not see them.
+Tracers are not Quantity objects, so machinery that walks `domain.quantities`
+does not see them:
 
-  reorder()    permutes every quantity but no tracer array, leaving the tracer
-               fields misaligned with the mesh (#277)
   distribute() copies state by walking quantities, so the sub-domains would be
                built with no tracers at all (#278)
 
-Until those are implemented, both raise. These tests exist so the guards cannot
-be removed without replacing them.
+It raises until that is implemented. This test exists so the guard cannot be
+removed without replacing it.
+
+reorder() had the same problem (#277) and now permutes the tracer blocks
+properly -- see test_tracers_reorder.py.
 """
 
 import numpy as num
@@ -34,25 +35,6 @@ def test_reorder_without_tracers_still_works():
     order = num.arange(n - 1, -1, -1)      # reverse
     d.reorder(order)                        # must not raise
     assert len(d) == n
-
-
-def test_reorder_with_tracers_refuses():
-    d = _domain()
-    d.add_tracer('salinity', initial_value=0.02)
-    order = num.arange(len(d) - 1, -1, -1)
-    with pytest.raises(NotImplementedError) as e:
-        d.reorder(order)
-    msg = str(e.value)
-    assert '277' in msg, 'the error should name the issue'
-    assert 'misalign' in msg
-
-
-def test_reorder_error_counts_the_tracers():
-    d = _domain()
-    d.add_tracer('a')
-    d.add_tracer('b')
-    with pytest.raises(NotImplementedError, match='2 tracer'):
-        d.reorder(num.arange(len(d) - 1, -1, -1))
 
 
 def test_distribute_with_tracers_refuses():


### PR DESCRIPTION
Closes #277.

`reorder()` renumbers triangles for cache locality and permutes every quantity by
walking `domain.quantities`. Tracers are deliberately **not** `Quantity` objects — they
live in contiguous `(ns, N)` / `(ns, 3N)` blocks so the C kernel can stride them (#276) —
so that loop never saw them, and a reordered domain had its tracer fields silently
misaligned with the mesh. The interim guard that raised on this path is replaced by the
permutation.

`Generic_Domain.reorder()` calls a `_reorder_tracer_arrays` hook when the domain provides
one, keeping the generic layer free of tracer knowledge while the shallow water domain,
which owns the layout, does the work.

### Three index spaces

| kind | shape | permutation |
|---|---|---|
| cell | `(ns, N)` | `arr[:, new_order]` |
| edge | `(ns, 3N)` | reshape `(ns, N, 3)`, permute, flatten |
| boundary | `(ns, boundary_length)` | via the boundary permutation below |

**The boundary case is the subtle one.** `build_boundary_neighbours` numbers boundary
edges by their position in the sorted `(triangle, edge)` order, so renumbering triangles
renumbers the boundary as well. Quantities don't notice — `update_boundary` refills their
boundary values from the `Boundary` objects every timestep — but `tracer_boundary_values`
is written once by `set_tracer_boundary` and then only read, so it has to be carried
across by hand. `reorder()` now captures the enumeration before `mesh.reorder()` discards
it, and matches the same physical edge by addressing its triangle's new number.

Permutations are done **in place**: the C domain struct holds raw pointers into these
buffers, so rebinding the attributes would leave the struct addressing the old memory.

### Root cause, not just the symptom

`_TRACER_ARRAY_KINDS` is now the single source of truth for how each block is indexed —
`add_tracer` sizes the arrays from it and the reorder permutes from it — so a new block
cannot be added without declaring how it is indexed. That is what actually went wrong
here: a block was added and nothing forced anyone to say how `reorder` should treat it.

### The tests discriminate

12 new tests in `test_tracers_reorder.py`. I verified they catch the bug rather than just
exercising the call: with the permutation stubbed out, **8 of the 12 fail**, including
both boundary-value tests and the end-to-end *"a reordered run gives the same tracer
field"* comparison. The four that still pass are permutation-invariant by nature (mass
sums, contiguity) and are kept as regression guards, not as evidence.

`test_tracers_gpu.py` gains a reordered mode-2 run checked against an unreordered mode-1
one — they agree to 3.6e-15. Writing it exposed that the draining fixture seeded a
**uniform** tracer, which cannot discriminate a permutation error at all; it now takes an
optional field, and the comparison asserts the field actually varies before trusting
itself.

### Runs

- `test_tracers_reorder.py` — 12 passed
- `test_tracers_gpu.py` — 10/10 via `anuga_run_isolated_tests` on a GPU-offload build
- `anuga/shallow_water/tests/` — 428 passed, 1 skipped
- `parallel/tests/test_reorder_domain.py` — 6 passed
- `pytest --pyargs anuga --run-fast` — 2792 passed, 224 skipped

Two of the three `test_tracers_unsupported_paths.py` guard tests are removed, since the
path they guarded now works; the #278 `distribute()` guard stays.
