### PR TITLE
CI: stop testing every merge twice, and cancel superseded runs

### DIFF
--- a/.github/workflows/conda-setup.yml
+++ b/.github/workflows/conda-setup.yml
@@ -10,10 +10,14 @@ on:
       - develop_cupy
       - feat/sc26
 
+  # develop is deliberately absent: it only ever receives merges from pull
+  # requests, and the pull_request trigger above already tests the merge
+  # result -- so a push run there is the same commit tested twice, at 15 jobs
+  # a time. The branches below are worked on directly, without a PR, so push
+  # is their only coverage. develop is covered daily by scheduled-build.yml.
   push:
     branches:
       - main
-      - develop
       - develop_gpu
       - develop_cupy
       - jorge/unify_again
@@ -36,6 +40,19 @@ on:
         description: 'JSON list of runners. Lets a caller cover one OS more deeply than the others.'
         type: string
         default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+
+# One run per ref: updating a branch supersedes the run already going for it,
+# rather than leaving both to finish for a result nobody will read. Applies to
+# an open PR getting a fixup and to a directly-worked branch getting a second
+# push alike.
+#
+# Two things are never cancelled, because there is no later run coming to
+# replace them: a push to main, and a release publish (whose ref is the tag,
+# not main, so it needs saying separately).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'release' && github.ref != 'refs/heads/main' }}
 
 jobs:
   test_conda:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,28 @@ on:
     branches:
       - main
       - develop
+
+  # develop is deliberately NOT here: work reaches it through a pull request,
+  # and the pull_request check above already runs against the merge result, so
+  # a push run on merge is the same commit tested twice. main stays, being both
+  # rare and what releases are cut from. See also the nightly watchdog in
+  # scheduled-build.yml, which covers develop daily.
   push:
     branches:
       - main
-      - develop
+
+# One run per ref: updating a branch supersedes the run already going for it,
+# rather than leaving both to finish for a result nobody will read. Applies to
+# an open PR getting a fixup and to a directly-worked branch getting a second
+# push alike.
+#
+# Two things are never cancelled, because there is no later run coming to
+# replace them: a push to main, and a release publish (whose ref is the tag,
+# not main, so it needs saying separately).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'release' && github.ref != 'refs/heads/main' }}
 
 jobs:
   ruff:

--- a/.github/workflows/python-publish-pypi.yml
+++ b/.github/workflows/python-publish-pypi.yml
@@ -6,8 +6,11 @@
 name: Build and Publish to PyPI
 
 on:
+  # develop omitted: the pull_request trigger below already builds every wheel
+  # against the merge result, so building them again on merge is 21 jobs for
+  # an answer we have. Publishing is gated on the release event regardless.
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main, develop]
   release:
@@ -25,6 +28,19 @@ on:
         description: 'Version for this build, e.g. 4.0.0rc1. Required when publish_to=testpypi. Empty = derive from git describe.'
         type: string
         default: ''
+
+# One run per ref: updating a branch supersedes the run already going for it,
+# rather than leaving both to finish for a result nobody will read. Applies to
+# an open PR getting a fixup and to a directly-worked branch getting a second
+# push alike.
+#
+# Two things are never cancelled, because there is no later run coming to
+# replace them: a push to main, and a release publish (whose ref is the tag,
+# not main, so it needs saying separately).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'release' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Two sources of wasted CI, both visible in the run history from today's tracer merges.

### 1. Every merge was tested twice

Three workflows had `develop` on both `pull_request` and `push`. GitHub builds
`refs/pull/N/merge` for a pull request, so the PR check **already runs against the merge
result** — re-running on the push to develop tests the same commit again. That is 37 jobs
per merge:

| workflow | jobs |
|---|---|
| Conda Forge CI | 15 (5 Python × 3 OS) |
| Build and Publish to PyPI | 21 (20 wheels + source) |
| Lint | 1 |

Today's four tracer merges spent roughly 150 jobs re-answering questions the PR checks
had already answered.

`develop` therefore comes off the `push` trigger in all three. It keeps:

- **`pull_request`** — every change, before it lands
- **`scheduled-build.yml`** — nightly at 20:00 UTC, so a bad develop is waiting at the
  start of the next working day

**What stays on push, deliberately:**

- `main` in all three — rare, and what releases are cut from, so doubling up costs nothing.
- `develop_gpu`, `develop_cupy`, `jorge/unify_again`, `feat/sc26` in conda-setup — these
  are worked on **directly** rather than through pull requests, so push is their only
  coverage and removing it would leave them with none.

**The trade:** a direct push to develop that bypasses a PR is now caught by the nightly
rather than immediately. Worth naming; the nightly already exists precisely for this.

### 2. Superseded runs ran to completion

There was no `concurrency` block anywhere, so pushing a fixup to an open PR started a
second full round while the first was still going — and both finished. That happened on
#284 today.

Each workflow now gets one run per ref, cancelling the run it supersedes.

Cancellation is **not** universal, and the expression says so rather than relying on a
default: a push to `main` and a release publish are never cancelled, because no later run
is coming to replace them. A release needs naming separately, since `github.ref` on a
release event is the tag, not `main` — the obvious `github.ref != 'refs/heads/main'` on
its own would happily cancel a publish.

No branch protection rules require any of these checks, so nothing here changes what can
be merged.
