### PR TITLE
Make tracers reachable: plot_utils, the sww GUI, and running maxima

### DIFF
--- a/anuga/file/sww.py
+++ b/anuga/file/sww.py
@@ -180,7 +180,8 @@ class SWW_file(Data_format):
             self.writer = Write_sww(static_quantities,
                                     dynamic_quantities,
                                     static_c_quantities,
-                                    dynamic_c_quantities)
+                                    dynamic_c_quantities,
+                                    tracer_names=self._tracer_names)
 
             self.writer.store_header(fid,
                                      domain.starttime,
@@ -581,7 +582,8 @@ class Write_sww(Write_sts):
                  static_quantities,
                  dynamic_quantities,
                  static_c_quantities=None,
-                 dynamic_c_quantities=None):
+                 dynamic_c_quantities=None,
+                 tracer_names=None):
         """Initialise Write_sww with two (or 4) list af quantity names:
 
         static_quantities (e.g. elevation or friction):
@@ -598,11 +600,21 @@ class Write_sww(Write_sts):
             Stored every timestep in a 2D array with
             dimensions number_of_triangles X number_of_timesteps
 
+        tracer_names (e.g. ['salinity', 'sand']):
+            Which of the dynamic_c_quantities are tracers. Recorded on the
+            file as a global attribute so a reader can tell `salinity_c`
+            from `stage_c` -- both are <name>_c and nothing else
+            distinguishes them. Written even when empty, so an old file
+            (no attribute at all) is distinguishable from a new one that
+            simply has no tracers.
+
         """
         self.static_quantities = static_quantities
         self.dynamic_quantities = dynamic_quantities
         self.static_c_quantities = static_c_quantities if static_c_quantities is not None else []
         self.dynamic_c_quantities = dynamic_c_quantities if dynamic_c_quantities is not None else []
+
+        self.tracer_names = list(tracer_names) if tracer_names else []
 
         self.store_centroids = False
         if static_c_quantities or dynamic_c_quantities:
@@ -637,6 +649,10 @@ class Write_sww(Write_sts):
 
         outfile.institution = institution
         outfile.description = description
+        # Which dynamic centroid variables are tracers (space separated, and
+        # '' when there are none). Lets a reader pick the tracers out without
+        # having to keep a list of every quantity name that is not one.
+        outfile.tracer_names = ' '.join(self.tracer_names)
 
         # For sww compatibility
         if smoothing is True:

--- a/anuga/operators/collect_max_quantities_operator.py
+++ b/anuga/operators/collect_max_quantities_operator.py
@@ -21,10 +21,24 @@ class Collect_max_quantities_operator(Operator):
     Maxima are updated every update_frequency timesteps [any integer >= 1],
     after t exceeds collection_start_time.
 
+    NOTE: the INITIAL condition is not sampled. Collection happens on the
+    fractional-step call, which first runs after the first update, so a cell
+    whose maximum is its starting value -- the reservoir behind a dam break,
+    the source cells of a plume that then washes out -- reports the first
+    post-step value instead. Long-standing behaviour for stage/depth/speed/uh;
+    the tracer maxima follow it so that every max_* variable in an sww means
+    the same thing.
+
     If store_to_sww=True the running maxima are written to the SWW file every
     yield step as centroid quantities max_stage_c, max_depth_c, max_speed_c,
     max_uh_c.  This avoids the need to compute maxima by scanning all timeslices
     of the SWW stage output after the run.
+
+    Every registered tracer -- and so every suspended sediment class, a
+    sediment class being a tracer -- is tracked the same way and stored as
+    max_<name>_c.  Register the tracers before creating this operator: the
+    names are fixed here, and an sww variable cannot appear after the file is
+    created.
 
     Velocity is zeroed below velocity_zero_height (defaults to
     minimum_allowed_height) to suppress spurious spikes in nearly-dry cells.
@@ -56,6 +70,19 @@ class Collect_max_quantities_operator(Operator):
         self.max_speed = num.zeros(n)
         self.max_uh    = num.zeros(n)
 
+        # Running max of each tracer's concentration -- and therefore of each
+        # suspended sediment class, which is a tracer. Zero rather than
+        # -max_float: a concentration is non-negative, so zero is the floor
+        # and not a sentinel.
+        #
+        # The names are fixed HERE. add_tracer reallocates the tracer block at
+        # a new width, and an sww variable cannot appear after the file is
+        # created, so a tracer registered later cannot be collected; __call__
+        # says so rather than quietly dropping it.
+        self._tracer_names = list(getattr(domain, 'get_tracer_names', list)())
+        self.max_tracer = num.zeros((len(self._tracer_names), n))
+        self._minimum_allowed_height = domain.minimum_allowed_height
+
         self.xy    = domain.centroid_coordinates
         self.stage = domain.quantities['stage']
         self.elev  = domain.quantities['elevation']
@@ -74,15 +101,12 @@ class Collect_max_quantities_operator(Operator):
 
         self.store_to_sww = store_to_sww
         if store_to_sww:
-            for qname in ('max_stage', 'max_depth', 'max_speed', 'max_uh'):
+            names = ['max_stage', 'max_depth', 'max_speed', 'max_uh']
+            names += ['max_' + t for t in self._tracer_names]
+            for qname in names:
                 Quantity(domain, name=qname, register=True, qty_type='centroid_only')
             # flag=4: centroid-only static variable overwritten each yield step
-            domain.quantities_to_be_stored.update({
-                'max_stage': 4,
-                'max_depth': 4,
-                'max_speed': 4,
-                'max_uh':    4,
-            })
+            domain.quantities_to_be_stored.update({qname: 4 for qname in names})
 
         self._gpu_initialized = False
 
@@ -166,6 +190,7 @@ class Collect_max_quantities_operator(Operator):
                             d.quantities['max_depth'].centroid_values[:] = self.max_depth
                             d.quantities['max_speed'].centroid_values[:] = self.max_speed
                             d.quantities['max_uh'].centroid_values[:]    = self.max_uh
+                            self._store_tracer_maxima_from_device(domain)
                         return
 
                 # ---- CPU / NumPy path --------------------------------
@@ -186,12 +211,66 @@ class Collect_max_quantities_operator(Operator):
                       * (depth > self.velocity_zero_height)
                 self.max_speed = num.maximum(self.max_speed, vel)
 
+                if self._tracer_names:
+                    self._check_tracers_unchanged(domain)
+                    # DERIVE c from the conserved m rather than reading
+                    # domain.tracer_centroid_values. c is only recomputed
+                    # during extrapolation, which runs at the START of a step,
+                    # so by the time a fractional-step operator is called it is
+                    # one step behind the m that update_conserved_quantities
+                    # has just written. Reading it would quietly miss every
+                    # new maximum reached on the final step -- max_stage does
+                    # not suffer this because stage IS a conserved variable.
+                    #
+                    # Same rule the kernel uses: dry cells carry no
+                    # concentration.
+                    inv_h = num.where(depth > self._minimum_allowed_height,
+                                      1.0 / num.maximum(depth, 1e-300), 0.0)
+                    num.maximum(self.max_tracer,
+                                domain.tracer_conserved_values * inv_h,
+                                out=self.max_tracer)
+
                 if self.store_to_sww:
                     d = self.domain
                     d.quantities['max_stage'].centroid_values[:] = self.max_stage
                     d.quantities['max_depth'].centroid_values[:] = self.max_depth
                     d.quantities['max_speed'].centroid_values[:] = self.max_speed
                     d.quantities['max_uh'].centroid_values[:]    = self.max_uh
+                    for s_idx, tname in enumerate(self._tracer_names):
+                        d.quantities['max_' + tname].centroid_values[:] = \
+                            self.max_tracer[s_idx]
+
+    def _check_tracers_unchanged(self, domain):
+        """A tracer added after this operator was built cannot be collected.
+
+        add_tracer reallocates the tracer block at a new width and the sww
+        file's variables are fixed when it is created, so there is nowhere for
+        a late tracer to go. Fail rather than silently record maxima for the
+        wrong tracers -- the arrays would still line up by index, so the
+        numbers would look entirely plausible.
+        """
+        current = list(domain.get_tracer_names())
+        if current != self._tracer_names:
+            raise RuntimeError(
+                'tracers changed after Collect_max_quantities_operator was '
+                'created (%r -> %r); register every tracer before collecting '
+                'maxima' % (self._tracer_names, current))
+
+    def _store_tracer_maxima_from_device(self, domain):
+        """Pull the device-side tracer maxima and hand them to the sww writer.
+
+        Only at yield steps, and only when storing: the maxima themselves are
+        updated on the device by gpu_max_quantities_update, so the running
+        collection stays sync-free.
+        """
+        if not (self._tracer_names and self.store_to_sww):
+            return
+        self._check_tracers_unchanged(domain)
+        from anuga.shallow_water.sw_domain_gpu_ext import get_max_tracers_gpu
+        get_max_tracers_gpu(domain.gpu_interface.gpu_dom, self.max_tracer)
+        for s_idx, tname in enumerate(self._tracer_names):
+            domain.quantities['max_' + tname].centroid_values[:] = \
+                self.max_tracer[s_idx]
 
     def parallel_safe(self):
         """Operator is applied independently on each cell and so is parallel safe."""

--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -394,6 +394,12 @@ struct max_quantities_info {
     double *max_depth;           // [n] device-resident running max depth
     double *max_speed;           // [n] device-resident running max speed
     double *max_uh;              // [n] device-resident running max ||(uh,vh)||
+    // Running max of each tracer's concentration, [n_tracers][n] flattened as
+    // max_tracer[s*n + i], the same layout the tracer arrays themselves use.
+    // NULL and n_tracers == 0 when the domain has no tracers, which is the
+    // common case and costs nothing.
+    double *max_tracer;
+    int n_tracers;
     int initialized;
     int mapped;
 };
@@ -645,6 +651,7 @@ void gpu_max_quantities_update(struct gpu_domain *GD);
 void gpu_max_quantities_get(struct gpu_domain *GD,
                             double *out_stage, double *out_depth,
                             double *out_speed, double *out_uh);
+void gpu_max_tracers_get(struct gpu_domain *GD, double *out_tracer);
 void gpu_max_quantities_finalize(struct gpu_domain *GD);
 
 // Ghost exchange - the key MPI function

--- a/anuga/shallow_water/gpu/gpu_max_quantities_operator.c
+++ b/anuga/shallow_water/gpu/gpu_max_quantities_operator.c
@@ -27,17 +27,28 @@ int gpu_max_quantities_init(struct gpu_domain *GD, int n, double velocity_zero_h
     MQ->n                   = n;
     MQ->velocity_zero_height = velocity_zero_height;
     MQ->mapped              = 0;
+    // Fixed at init: a tracer added later would need a differently-sized
+    // array, and could not get an sww variable anyway (the file's variables
+    // are defined when it is created). The Python operator refuses that case.
+    MQ->n_tracers           = (int)GD->D.number_of_tracers;
+    MQ->max_tracer          = NULL;
 
     MQ->max_stage = (double*)malloc(n * sizeof(double));
     MQ->max_depth = (double*)malloc(n * sizeof(double));
     MQ->max_speed = (double*)malloc(n * sizeof(double));
     MQ->max_uh    = (double*)malloc(n * sizeof(double));
 
-    if (!MQ->max_stage || !MQ->max_depth || !MQ->max_speed || !MQ->max_uh) {
+    if (MQ->n_tracers > 0) {
+        MQ->max_tracer = (double*)malloc((size_t)MQ->n_tracers * n * sizeof(double));
+    }
+
+    if (!MQ->max_stage || !MQ->max_depth || !MQ->max_speed || !MQ->max_uh
+            || (MQ->n_tracers > 0 && !MQ->max_tracer)) {
         fprintf(stderr, "ERROR: gpu_max_quantities_init: allocation failed\n");
         free(MQ->max_stage); free(MQ->max_depth);
-        free(MQ->max_speed); free(MQ->max_uh);
+        free(MQ->max_speed); free(MQ->max_uh); free(MQ->max_tracer);
         MQ->max_stage = MQ->max_depth = MQ->max_speed = MQ->max_uh = NULL;
+        MQ->max_tracer = NULL;
         return -1;
     }
 
@@ -49,6 +60,11 @@ int gpu_max_quantities_init(struct gpu_domain *GD, int n, double velocity_zero_h
         MQ->max_uh[i]    = 0.0;
     }
 
+    // Concentration is non-negative, so 0 is the floor rather than a sentinel.
+    for (int k = 0; k < MQ->n_tracers * n; k++) {
+        MQ->max_tracer[k] = 0.0;
+    }
+
     if (GD->gpu_initialized) {
         int ni = n;
         double *ms  = MQ->max_stage;
@@ -56,6 +72,11 @@ int gpu_max_quantities_init(struct gpu_domain *GD, int n, double velocity_zero_h
         double *msp = MQ->max_speed;
         double *mu  = MQ->max_uh;
         #pragma omp target enter data map(to: ms[0:ni], md[0:ni], msp[0:ni], mu[0:ni])
+        if (MQ->n_tracers > 0) {
+            double *mt = MQ->max_tracer;
+            int nt = MQ->n_tracers * ni;
+            #pragma omp target enter data map(to: mt[0:nt])
+        }
         MQ->mapped = 1;
     }
 
@@ -100,6 +121,35 @@ void gpu_max_quantities_update(struct gpu_domain *GD)
         if (d  > max_depth[i]) max_depth[i] = d;
         if (v  > max_speed[i]) max_speed[i] = v;
     }
+
+    // Tracers, in their own pass so the loop above is untouched when there
+    // are none. Base pointers are taken HERE, at function scope, not inside
+    // the target region: GD is not mapped to the device, so a GD->... load
+    // inside the region reads a host address and silently does nothing.
+    // Same rule as the tracer arrays in core_kernels.c.
+    const int ns = MQ->n_tracers;
+    if (ns > 0) {
+        // DERIVE c = m/h rather than reading tracer_centroid_values: that
+        // array is only refreshed during extrapolation, at the START of a
+        // step, so when this operator runs it is one step behind the
+        // conserved m. Mirrors the CPU path, and the kernel's own rule that
+        // a dry cell carries no concentration.
+        double * restrict t_cons     = GD->D.tracer_conserved_values;
+        double * restrict max_tracer = MQ->max_tracer;
+        const double mah = GD->D.minimum_allowed_height;
+        if (t_cons != NULL && max_tracer != NULL) {
+            OMP_PARALLEL_LOOP
+            for (int i = 0; i < n; i++) {
+                double d = stage_c[i] - bed_c[i];
+                if (d < 0.0) d = 0.0;
+                double inv_h = (d > mah) ? (1.0 / d) : 0.0;
+                for (int s = 0; s < ns; s++) {
+                    double c = t_cons[s * n + i] * inv_h;
+                    if (c > max_tracer[s * n + i]) max_tracer[s * n + i] = c;
+                }
+            }
+        }
+    }
 }
 
 // Sync the four max arrays from device to host, then copy into caller-supplied
@@ -127,6 +177,24 @@ void gpu_max_quantities_get(struct gpu_domain *GD,
     memcpy(out_uh,    MQ->max_uh,    n * sizeof(double));
 }
 
+// Sync the per-tracer maxima from device to host and copy them out.
+// out_tracer must hold n_tracers * n doubles, laid out as [s*n + i].
+// Separate from the call above so a domain with no tracers never pays for it.
+void gpu_max_tracers_get(struct gpu_domain *GD, double *out_tracer)
+{
+    struct max_quantities_info *MQ = &GD->max_qty;
+    if (!MQ->initialized || MQ->n_tracers <= 0 || MQ->max_tracer == NULL) return;
+
+    int nt = MQ->n_tracers * MQ->n;
+
+    if (MQ->mapped) {
+        double *mt = MQ->max_tracer;
+        #pragma omp target update from(mt[0:nt])
+    }
+
+    memcpy(out_tracer, MQ->max_tracer, (size_t)nt * sizeof(double));
+}
+
 // Unmap device arrays, free host memory.
 void gpu_max_quantities_finalize(struct gpu_domain *GD)
 {
@@ -140,6 +208,11 @@ void gpu_max_quantities_finalize(struct gpu_domain *GD)
         double *msp = MQ->max_speed;
         double *mu  = MQ->max_uh;
         #pragma omp target exit data map(delete: ms[0:n], md[0:n], msp[0:n], mu[0:n])
+        if (MQ->n_tracers > 0 && MQ->max_tracer != NULL) {
+            double *mt = MQ->max_tracer;
+            int nt = MQ->n_tracers * n;
+            #pragma omp target exit data map(delete: mt[0:nt])
+        }
         MQ->mapped = 0;
     }
 
@@ -147,8 +220,11 @@ void gpu_max_quantities_finalize(struct gpu_domain *GD)
     free(MQ->max_depth);
     free(MQ->max_speed);
     free(MQ->max_uh);
+    free(MQ->max_tracer);
 
     MQ->max_stage = MQ->max_depth = MQ->max_speed = MQ->max_uh = NULL;
+    MQ->max_tracer  = NULL;
+    MQ->n_tracers   = 0;
     MQ->n           = 0;
     MQ->initialized = 0;
 }

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -903,6 +903,20 @@ class Domain(Generic_Domain):
             raise ValueError(
                 'a tracer named %r is already registered (index %d)'
                 % (name, self._tracer_names.index(name)))
+        # A tracer is written to the sww as <name>_c, which is exactly the
+        # variable a quantity's centroid values go to. A tracer named 'stage'
+        # would therefore OVERWRITE the stage in the output -- no error, and a
+        # file whose stage is silently something else. Reserve the names.
+        if name in self.quantities:
+            raise ValueError(
+                'a tracer cannot be named %r: that is a quantity on this '
+                'domain, and both are written to the sww as %s_c, so the '
+                'tracer would overwrite it' % (name, name))
+        if name.startswith('max_'):
+            raise ValueError(
+                "a tracer cannot be named %r: names beginning 'max_' are "
+                'reserved for the running maxima that '
+                'Collect_max_quantities_operator writes' % name)
 
         if beta is not None:
             beta = float(beta)

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -156,6 +156,8 @@ cdef extern from "gpu_domain.h" nogil:
         double *max_depth
         double *max_speed
         double *max_uh
+        double *max_tracer
+        int n_tracers
         int initialized
         int mapped
 
@@ -385,6 +387,7 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_max_quantities_get(gpu_domain *GD,
                                 double *out_stage, double *out_depth,
                                 double *out_speed, double *out_uh)
+    void gpu_max_tracers_get(gpu_domain *GD, double *out_tracer)
     void gpu_max_quantities_finalize(gpu_domain *GD)
 
     # FLOP counters (Gordon Bell performance profiling)
@@ -2309,6 +2312,21 @@ def get_max_quantities_gpu(GPUDomain gpu_dom,
     gpu_max_quantities_get(&gpu_dom.GD,
                            &max_stage[0], &max_depth[0],
                            &max_speed[0], &max_uh[0])
+
+
+def get_max_tracers_gpu(GPUDomain gpu_dom,
+                        np.ndarray[double, ndim=2, mode="c"] max_tracer):
+    """
+    Sync the per-tracer running maxima from device to host.
+
+    max_tracer must be (n_tracers, number_of_elements) and C-contiguous --
+    the same layout the tracer arrays use, which is what the kernel writes.
+    Like get_max_quantities_gpu this is a device-to-host transfer; call it
+    only at yield steps or on export.
+    """
+    if max_tracer.shape[0] == 0:
+        return
+    gpu_max_tracers_get(&gpu_dom.GD, &max_tracer[0, 0])
 
 
 def finalize_max_quantities_gpu(GPUDomain gpu_dom):

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -19,6 +19,7 @@ python_sources = [
 'test_tracers_boundary.py',
 'test_tracers_sww.py',
 'test_tracers_conservation.py',
+'test_tracers_max.py',
 'test_tracers_reorder.py',
 'test_tracers_distribute.py',
 'test_tracers_gpu.py',

--- a/anuga/shallow_water/tests/test_tracers.py
+++ b/anuga/shallow_water/tests/test_tracers.py
@@ -436,15 +436,18 @@ def test_set_tracer_accepts_a_scalar_or_a_field():
 
 
 def test_the_api_rejects_mistakes():
+    # Deliberately not 'x'/'y': those are quantities on every domain, and a
+    # tracer may not take a quantity's name -- see
+    # test_a_tracer_cannot_be_named_after_a_quantity.
     d = _small_domain()
-    d.add_tracer('x', beta=1.0)
+    d.add_tracer('a', beta=1.0)
     with pytest.raises(ValueError):
-        d.add_tracer('x')                       # duplicate name
+        d.add_tracer('a')                       # duplicate name
     with pytest.raises(ValueError):
-        d.set_tracer('x', np.zeros(len(d) + 1))  # wrong length
+        d.set_tracer('a', np.zeros(len(d) + 1))  # wrong length
     with pytest.raises(ValueError):
         d.set_tracer('nope', 1.0)               # unknown name
     with pytest.raises(ValueError):
         # beta is shared by every tracer, so a conflicting value must be
         # refused rather than silently applied to all of them.
-        d.add_tracer('y', beta=0.0)
+        d.add_tracer('b', beta=0.0)

--- a/anuga/shallow_water/tests/test_tracers_gpu.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu.py
@@ -270,3 +270,70 @@ def test_a_reordered_domain_gives_the_same_answer_on_the_device():
     assert np.ptp(a) > 1e-6, 'field too flat to discriminate'
     assert np.abs(a - b).max() < 1e-10, \
         'reordering changed the answer on the device'
+
+
+def _build_for_max(mode, seed=5):
+    """A plume that washes out, so the running max differs from the final field."""
+    d = rectangular_cross_domain(NXY, NXY, len1=LEN, len2=LEN)
+    d.set_flow_algorithm('DE0')
+    d.set_low_froude(0)
+    d.store = False
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', DRAIN_DEPTH)
+    d.set_quantity('xmomentum', DRAIN_DEPTH * DRAIN_SPEED)
+    Br = Reflective_boundary(d)
+    Bt = anuga.Transmissive_boundary(d)
+    d.set_boundary({'left': anuga.Dirichlet_boundary(
+                        [DRAIN_DEPTH, DRAIN_DEPTH * DRAIN_SPEED, 0.0]),
+                    'top': Br, 'bottom': Br, 'right': Bt})
+    d.add_tracer('c', beta=1.0)
+    x = d.centroid_coordinates[:, 0]
+    d.set_tracer('c', np.where(x < LEN / 4, 1.0, 0.0))
+    d.set_tracer_boundary('c', 'left', 0.0)
+    from anuga.operators.collect_max_quantities_operator import (
+        Collect_max_quantities_operator)
+    op = Collect_max_quantities_operator(d)
+    d.set_multiprocessor_mode(mode)
+    return d, op
+
+
+def test_the_tracer_maxima_agree_between_the_modes():
+    """The max kernel derives c = m/h on the device, as the host path does.
+
+    Reading tracer_centroid_values there would be doubly wrong: stale by a
+    step, and -- since D is not mapped inside an omp target region -- a host
+    address on the device.
+    """
+    if not gpu_available():
+        pytest.skip('GPU OpenMP interface not available: %s' % _gpu_error)
+
+    cpu, cpu_op = _build_for_max(1)
+    cpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+
+    gpu, gpu_op = _build_for_max(2)
+    if getattr(gpu, 'multiprocessor_mode', None) != 2:
+        pytest.fail('mode 2 did not engage: multiprocessor_mode=%r'
+                    % getattr(gpu, 'multiprocessor_mode', None))
+    from anuga.shallow_water.sw_domain_gpu_ext import (sync_to_device,
+                                                       get_max_tracers_gpu)
+    sync_to_device(gpu.gpu_interface.gpu_dom)
+    gpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+    get_max_tracers_gpu(gpu.gpu_interface.gpu_dom, gpu_op.max_tracer)
+
+    a, b = cpu_op.max_tracer[0], gpu_op.max_tracer[0]
+    assert np.ptp(a) > 1e-6, 'the maximum field is flat; this proves nothing'
+    assert np.abs(a - b).max() < 1e-10, \
+        'the modes disagree on the tracer maximum by %g' % np.abs(a - b).max()
+
+
+def test_the_device_maximum_is_never_below_the_final_field():
+    if not gpu_available():
+        pytest.skip('GPU OpenMP interface not available: %s' % _gpu_error)
+
+    gpu, op = _build_for_max(2)
+    from anuga.shallow_water.sw_domain_gpu_ext import (sync_to_device,
+                                                       get_max_tracers_gpu)
+    sync_to_device(gpu.gpu_interface.gpu_dom)
+    gpu.evolve_to_end(finaltime=DRAIN_FINALTIME)
+    get_max_tracers_gpu(gpu.gpu_interface.gpu_dom, op.max_tracer)
+    assert np.all(op.max_tracer[0] >= gpu.get_tracer('c') - 1e-12)

--- a/anuga/shallow_water/tests/test_tracers_max.py
+++ b/anuga/shallow_water/tests/test_tracers_max.py
@@ -1,0 +1,162 @@
+"""Running maxima of the tracers, alongside the water ones.
+
+Collect_max_quantities_operator tracks max stage/depth/speed/uh; a tracer --
+and so a suspended sediment class -- gets the same treatment, stored as
+max_<name>_c.
+
+The subtlety these tests exist for: the operator must DERIVE c = m/h rather
+than read domain.tracer_centroid_values. c is only recomputed during
+extrapolation, at the START of a step, so by the time a fractional-step
+operator runs it is one step behind the conserved m that was just written.
+max_stage has no such problem, stage being conserved itself.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+from anuga.operators.collect_max_quantities_operator import (
+    Collect_max_quantities_operator)
+
+netCDF4 = pytest.importorskip('netCDF4')
+
+
+def _domain(n=6):
+    """A plume that washes out, so the max and the final value differ."""
+    d = anuga.rectangular_cross_domain(n, n, len1=60.0, len2=60.0)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    d.set_quantity('xmomentum', 2.0)
+    Br = anuga.Reflective_boundary(d)
+    Bt = anuga.Transmissive_boundary(d)
+    d.set_boundary({'left': anuga.Dirichlet_boundary([1.0, 2.0, 0.0]),
+                    'top': Br, 'bottom': Br, 'right': Bt})
+    d.add_tracer('salinity')
+    x = d.centroid_coordinates[:, 0]
+    d.set_tracer('salinity', num.where(x < 20.0, 1.0, 0.0))
+    d.set_tracer_boundary('salinity', 'left', 0.0)   # clean water follows
+    d.store = False
+    return d
+
+
+def _run(d, finaltime=5.0):
+    for _ in d.evolve(yieldstep=0.5, finaltime=finaltime):
+        pass
+
+
+def test_no_tracers_means_no_tracer_maxima():
+    d = anuga.rectangular_cross_domain(4, 4)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    op = Collect_max_quantities_operator(d)
+    assert op.max_tracer.shape == (0, len(d))
+
+
+def test_the_maximum_is_never_below_the_current_value():
+    """The property the whole thing rests on, and the one the stale-c bug broke."""
+    d = _domain()
+    op = Collect_max_quantities_operator(d)
+    _run(d)
+    c = d.get_tracer('salinity')
+    assert num.all(op.max_tracer[0] >= c - 1e-12), \
+        'the running maximum is below the final concentration in %d cells' \
+        % int((c > op.max_tracer[0] + 1e-12).sum())
+
+
+def test_the_maximum_records_a_plume_that_has_passed():
+    """Otherwise it is just a copy of the final state."""
+    d = _domain()
+    op = Collect_max_quantities_operator(d)
+    _run(d)
+    c = d.get_tracer('salinity')
+    assert num.any(op.max_tracer[0] > c + 1e-3), \
+        'the maximum never exceeds the final value, so nothing was tracked'
+
+
+def test_it_beats_sampling_at_yield_steps():
+    """The operator runs every timestep, so it cannot be lower than this.
+
+    Sampling starts after the FIRST yield: the operator collects on the
+    fractional-step call, which does not run before the initial state, so
+    the initial condition is outside what either side is measuring here.
+    That exclusion is documented on the operator and is how the existing
+    max_stage has always behaved.
+    """
+    d = _domain()
+    op = Collect_max_quantities_operator(d)
+    sampled = None
+    for _ in d.evolve(yieldstep=0.5, finaltime=5.0):
+        if sampled is None:
+            sampled = num.zeros(len(d))     # skip the t=0 yield
+            continue
+        sampled = num.maximum(sampled, d.get_tracer('salinity'))
+    assert num.all(op.max_tracer[0] >= sampled - 1e-12)
+
+
+def test_the_initial_condition_is_not_sampled():
+    """Pins the documented limitation, so a change to it is deliberate."""
+    d = _domain()
+    c0 = d.get_tracer('salinity').copy()
+    op = Collect_max_quantities_operator(d)
+    _run(d)
+    # Some cell started at 1.0 and washed out before the first collection.
+    assert num.any(c0 > op.max_tracer[0] + 1e-3), \
+        'the initial condition now IS sampled -- update the operator docstring'
+
+
+def test_a_dry_cell_carries_no_concentration():
+    """Same rule the kernel uses when it derives c from m."""
+    d = anuga.rectangular_cross_domain(6, 6, len1=60.0, len2=60.0)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 0.0)               # dry everywhere
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    d.add_tracer('salinity', initial_value=1.0)
+    d.store = False
+    op = Collect_max_quantities_operator(d)
+    _run(d, finaltime=1.0)
+    assert num.allclose(op.max_tracer[0], 0.0), \
+        'a dry cell reported a concentration'
+
+
+def test_two_tracers_are_tracked_separately():
+    d = _domain()
+    d.add_tracer('dye', initial_value=0.25)
+    op = Collect_max_quantities_operator(d)
+    _run(d)
+    assert not num.allclose(op.max_tracer[0], op.max_tracer[1]), \
+        'the two tracers share a row'
+    # dye starts uniform at 0.25 and is diluted by the clean inflow, so its
+    # maximum is at most the starting value and above zero away from the inlet.
+    assert op.max_tracer[1].max() <= 0.25 + 1e-9
+    assert op.max_tracer[1].max() > 0.2
+
+
+def test_a_tracer_added_afterwards_is_refused():
+    """Its array would be the wrong width and it could get no sww variable."""
+    d = _domain()
+    op = Collect_max_quantities_operator(d)
+    d.add_tracer('late')
+    with pytest.raises(RuntimeError, match='tracers changed'):
+        _run(d, finaltime=1.0)
+
+
+# --- and into the file ------------------------------------------------------
+
+def test_the_maxima_reach_the_sww(tmp_path):
+    d = _domain()
+    op = Collect_max_quantities_operator(d, store_to_sww=True)
+    assert d.quantities_to_be_stored['max_salinity'] == 4, \
+        'stored as flag 4, i.e. overwritten each yield step'
+    d.store = True
+    d.set_name('maxtr')
+    d.set_datadir(str(tmp_path))
+    _run(d)
+
+    with netCDF4.Dataset(str(tmp_path / 'maxtr.sww'), 'r') as fid:
+        assert 'max_salinity_c' in fid.variables, \
+            'the tracer maximum is missing from the sww'
+        stored = num.array(fid.variables['max_salinity_c'][:])
+    # Flag 4 is written without a time dimension: one slice, the final maximum.
+    assert stored.shape == (len(d),)
+    assert num.allclose(stored, op.max_tracer[0], atol=1e-6)

--- a/anuga/shallow_water/tests/test_tracers_max.py
+++ b/anuga/shallow_water/tests/test_tracers_max.py
@@ -9,6 +9,12 @@ than read domain.tracer_centroid_values. c is only recomputed during
 extrapolation, at the START of a step, so by the time a fractional-step
 operator runs it is one step behind the conserved m that was just written.
 max_stage has no such problem, stage being conserved itself.
+
+These are white-box tests: they read op.max_tracer, which is HOST state. In
+mode 2 the maxima live on the device and that array is only filled when the
+operator stores to the sww, so every domain here pins itself to legacy -- the
+pattern CLAUDE.md describes for tests that inspect internal update arrays. The
+mode-2 path is covered in test_tracers_gpu.py, which syncs first.
 """
 
 import numpy as num
@@ -36,6 +42,7 @@ def _domain(n=6):
     d.set_tracer('salinity', num.where(x < 20.0, 1.0, 0.0))
     d.set_tracer_boundary('salinity', 'left', 0.0)   # clean water follows
     d.store = False
+    d.set_compute_mode('legacy')     # reads host-side operator state
     return d
 
 
@@ -48,6 +55,7 @@ def test_no_tracers_means_no_tracer_maxima():
     d = anuga.rectangular_cross_domain(4, 4)
     b = anuga.Reflective_boundary(d)
     d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    d.set_compute_mode('legacy')
     op = Collect_max_quantities_operator(d)
     assert op.max_tracer.shape == (0, len(d))
 
@@ -113,6 +121,7 @@ def test_a_dry_cell_carries_no_concentration():
     d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
     d.add_tracer('salinity', initial_value=1.0)
     d.store = False
+    d.set_compute_mode('legacy')
     op = Collect_max_quantities_operator(d)
     _run(d, finaltime=1.0)
     assert num.allclose(op.max_tracer[0], 0.0), \

--- a/anuga/utilities/animate.py
+++ b/anuga/utilities/animate.py
@@ -2,6 +2,7 @@
 A module to allow interactive plotting in a Jupyter notebook of quantities and mesh
 associated with an ANUGA domain and SWW file.
 """
+import functools
 import warnings
 import numpy as np
 import os
@@ -846,6 +847,31 @@ class SWW_plotter:
 
         self.time = p.variables['time'][:]
 
+        # Tracers -- and suspended sediment classes, which are tracers -- are
+        # stored one dynamic centroid variable each. The file names them in a
+        # tracer_names attribute, since <name>_c is indistinguishable from
+        # stage_c otherwise.
+        from anuga.utilities.plot_utils import _tracer_names_from
+        self.tracers = {}
+        self.max_tracers = {}
+        self._tracer_frame_count = {}
+        for _tname in _tracer_names_from(p):
+            if _tname + '_c' not in p.variables:
+                continue
+            self.tracers[_tname] = p.variables[_tname + '_c'][:]
+            self._tracer_frame_count[_tname] = 0
+            # Named attribute and bound save method per tracer, so a caller
+            # that drives this class by attribute name -- anuga_sww_gui does
+            # -- reaches a tracer the same way it reaches stage.
+            setattr(self, 'tracer_' + _tname, self.tracers[_tname])
+            setattr(self, 'save_tracer_%s_frame' % _tname,
+                    functools.partial(self._save_tracer_frame, _tname))
+            if 'max_' + _tname + '_c' in p.variables:
+                self.max_tracers[_tname] = p.variables['max_' + _tname + '_c'][:]
+                setattr(self, 'max_tracer_' + _tname, self.max_tracers[_tname])
+                setattr(self, 'save_max_tracer_%s_frame' % _tname,
+                        functools.partial(self._save_max_tracer_frame, _tname))
+
         # Load precomputed max quantities if stored by Collect_max_quantities_operator
         pvars = p.variables
         self._max_depth_c      = pvars['max_depth_c'][:] if 'max_depth_c' in pvars else None
@@ -891,6 +917,69 @@ class SWW_plotter:
     # Frame rendering helpers (figure reuse)
     #------------------------------------------
 
+
+    #------------------------------------------
+    # Tracer procedures
+    #
+    # One pair of methods for every tracer rather than a hand-written pair
+    # per name: a tracer is user-defined, so there is no fixed list to write
+    # out. __init__ binds `save_tracer_<name>_frame` for each.
+    #------------------------------------------
+    def _tracer_frame(self, tracer, frame, figsize, dpi, vmin, vmax,
+                      cmap='viridis', basemap=False, alpha=1.0,
+                      basemap_provider=BASEMAP_DEFAULT,
+                      xlim=None, ylim=None, smooth=False,
+                      show_elev=False, elev_levels=10, show_mesh=False):
+        return self._animated_frame(
+            frame, 'tracer_' + tracer, self.tracers[tracer][frame, :],
+            tracer, figsize, dpi, vmin, vmax, cmap, basemap, alpha,
+            basemap_provider, xlim=xlim, ylim=ylim, smooth=smooth,
+            show_elev=show_elev, elev_levels=elev_levels, show_mesh=show_mesh)
+
+    def _save_tracer_frame(self, tracer, frame=-1, figsize=(10, 6), dpi=160,
+                           vmin=0.0, vmax=1.0, cmap='viridis', basemap=False,
+                           alpha=1.0, basemap_provider=BASEMAP_DEFAULT,
+                           xlim=None, ylim=None, smooth=False,
+                           show_elev=False, elev_levels=10, show_mesh=False):
+        frame_num = self._tracer_frame_count[tracer]
+        fig, ax = self._tracer_frame(tracer, frame, figsize, dpi, vmin, vmax,
+                                     cmap, basemap, alpha, basemap_provider,
+                                     xlim=xlim, ylim=ylim, smooth=smooth,
+                                     show_elev=show_elev,
+                                     elev_levels=elev_levels,
+                                     show_mesh=show_mesh)
+        fname = '%s_tracer_%s_%010d.png' % (self.name, tracer, frame_num)
+        if self.plot_dir is None:
+            fig.savefig(fname)
+        else:
+            fig.savefig(os.path.join(self.plot_dir, fname))
+        plt.close(fig)
+        self._tracer_frame_count[tracer] += 1
+
+    def _save_max_tracer_frame(self, tracer, frame=None, figsize=(10, 6),
+                               dpi=160, vmin=0.0, vmax=1.0, cmap='viridis',
+                               basemap=False, alpha=1.0,
+                               basemap_provider=BASEMAP_DEFAULT,
+                               xlim=None, ylim=None, smooth=False,
+                               show_elev=False, elev_levels=10,
+                               show_mesh=False):
+        """The running maximum, if the run stored one. Time-independent, so
+        `frame` is accepted and ignored, as for the other max quantities."""
+        data = self.max_tracers[tracer]
+        # Stored flag-4, i.e. overwritten each yield step: the last slice is
+        # the maximum over the whole run.
+        values = data[-1, :] if data.ndim == 2 else data
+        fig, ax = self._animated_frame(
+            -1, 'max_tracer_' + tracer, values, 'Max ' + tracer,
+            figsize, dpi, vmin, vmax, cmap, basemap, alpha, basemap_provider,
+            xlim=xlim, ylim=ylim, smooth=smooth, show_elev=show_elev,
+            elev_levels=elev_levels, show_mesh=show_mesh)
+        fname = self.name + '_max_tracer_%s_0000000000.png' % tracer
+        if self.plot_dir is None:
+            fig.savefig(fname)
+        else:
+            fig.savefig(os.path.join(self.plot_dir, fname))
+        plt.close(fig)
 
     def _animated_frame(self, frame, qty_name, qty_data, qty_label,
                         figsize, dpi, vmin, vmax, cmap, basemap, alpha,

--- a/anuga/utilities/plot_utils.py
+++ b/anuga/utilities/plot_utils.py
@@ -155,7 +155,8 @@ class get_output:
         self.x, self.y, self.time, self.vols, self.stage, \
                 self.height, self.elev, self.friction, self.xmom, self.ymom, \
                 self.xvel, self.yvel, self.vel, self.minimum_allowed_height,\
-                self.xllcorner, self.yllcorner, self.timeSlices, self.starttime = \
+                self.xllcorner, self.yllcorner, self.timeSlices, self.starttime, \
+                self.tracers = \
                 _read_output(filename, minimum_allowed_height, copy.copy(timeSlices))
         self.filename = filename
         self.verbose = verbose
@@ -204,6 +205,64 @@ def getInds(varIn, timeSlices, absMax=False):
     return var
 
 ############################################################################
+
+# Quantities whose centroid variable is <name>_c but which are NOT tracers.
+# Only consulted for sww files written before the tracer_names attribute
+# existed; a current file states its tracers outright.
+_NON_TRACER_C_VARIABLES = frozenset((
+    'stage', 'elevation', 'friction', 'xmomentum', 'ymomentum',
+    'height', 'xvelocity', 'yvelocity', 'velocity',
+    'max_stage', 'max_depth', 'max_speed', 'max_uh',
+))
+
+
+def get_tracer_names(filename):
+    """Names of the tracers stored in an sww file, in the order written.
+
+    Tracers -- and therefore suspended sediment classes, which are tracers
+    with settling parameters -- are stored as one dynamic centroid variable
+    `<name>_c` each. That looks exactly like `stage_c`, so the writer records
+    which ones they are as a global `tracer_names` attribute and this reads it.
+
+    Files written before that attribute existed fall back to "every `<name>_c`
+    variable whose base is not a known quantity", which is right for every
+    such file but cannot stay right as quantities are added -- hence the
+    attribute.
+    """
+    fid = NetCDFFile(filename)
+    try:
+        return _tracer_names_from(fid)
+    finally:
+        fid.close()
+
+
+def _tracer_names_from(fid):
+    """As get_tracer_names, on an already-open file."""
+    names = getattr(fid, 'tracer_names', None)
+    if names is not None:
+        # Written by every current file, '' when there are no tracers.
+        if isinstance(names, bytes):
+            names = names.decode()
+        return [n for n in str(names).split() if n]
+
+    # Older file: infer, and accept that a quantity added after this list was
+    # written would be misread as a tracer.
+    found = []
+    for v in fid.variables.keys():
+        if v.endswith('_c') and v[:-2] not in _NON_TRACER_C_VARIABLES:
+            found.append(v[:-2])
+    return sorted(found)
+
+
+def _read_tracers(fid, inds):
+    """{name: array} of the tracer concentrations at the given time slices."""
+    tracers = {}
+    for name in _tracer_names_from(fid):
+        var = name + '_c'
+        if var in fid.variables:
+            tracers[name] = getInds(fid.variables[var], timeSlices=inds)
+    return tracers
+
 
 def _read_output(filename, minimum_allowed_height, timeSlices):
     """
@@ -321,10 +380,13 @@ def _read_output(filename, minimum_allowed_height, timeSlices):
         xmom = getInds(xmom, timeSlices=inds,absMax=True)
         ymom = getInds(ymom, timeSlices=inds,absMax=True)
 
+    tracers = _read_tracers(fid, inds)
+
     fid.close()
 
     return x, y, time, vols, stage, height, elev, friction, xmom, ymom,\
-           xvel, yvel, vel, minimum_allowed_height, xllcorner,yllcorner, inds, starttime
+           xvel, yvel, vel, minimum_allowed_height, xllcorner,yllcorner, inds, starttime,\
+           tracers
 
 ######################################################################################
 
@@ -348,13 +410,18 @@ class get_centroids:
           array.
           But as a hack for the time being the elevation from the file
           is available via elev_orig
+
+    Tracers -- and suspended sediment classes, which are tracers -- are in
+    the `tracers` dict, keyed by name, e.g. pc.tracers['salinity']. A dict
+    rather than attributes so a tracer cannot shadow `stage` or `vel`.
     """
     def __init__(self, p, velocity_extrapolation=False, verbose=False,
                  timeSlices=None, minimum_allowed_height=1.0e-03):
 
         self.time, self.x, self.y, self.stage, self.xmom,\
             self.ymom, self.height, self.elev, self.elev_orig, self.friction, self.xvel,\
-            self.yvel, self.vel, self.xllcorner, self.yllcorner, self.timeSlices= \
+            self.yvel, self.vel, self.xllcorner, self.yllcorner, self.timeSlices,\
+            self.tracers = \
                 _get_centroid_values(p, velocity_extrapolation,\
                                      timeSlices=copy.copy(timeSlices),\
                                      minimum_allowed_height=minimum_allowed_height,\
@@ -639,11 +706,20 @@ def _get_centroid_values(p, velocity_extrapolation, verbose, timeSlices,
         xvel_cent = getInds(xvel_cent, timeSlices=inds, absMax=True)
         yvel_cent = getInds(yvel_cent, timeSlices=inds, absMax=True)
 
+    # Tracers are centroid quantities to begin with -- there is no vertex
+    # variable to fall back on -- so this is the path that matters for them.
+    tracers_cent = {}
+    for _tname in _tracer_names_from(fid):
+        if _tname + '_c' in fid.variables:
+            tracers_cent[_tname] = _getCentVar(fid, _tname + '_c',
+                                               time_indices=inds, vols=vols)
+
     fid.close()
 
     return time, x_cent, y_cent, stage_cent, xmom_cent,\
              ymom_cent, height_cent, elev_cent, elev_cent_orig, friction_cent,\
-             xvel_cent, yvel_cent, vel_cent, xllcorner, yllcorner, inds
+             xvel_cent, yvel_cent, vel_cent, xllcorner, yllcorner, inds,\
+             tracers_cent
 
 
 def animate_1D(time, var, x, ylab=' '):

--- a/anuga/utilities/tests/meson.build
+++ b/anuga/utilities/tests/meson.build
@@ -13,6 +13,7 @@ python_sources = [
 'run_create_culvert_bridge_operator.py',
 'test_numerical_tools.py',
 'test_plot_utils.py',
+'test_plot_utils_tracers.py',
 'test_quantity_setting_functions.py',
 'test_sparse.py',
 'test_spatialInputUtil.py',

--- a/anuga/utilities/tests/test_plot_utils_tracers.py
+++ b/anuga/utilities/tests/test_plot_utils_tracers.py
@@ -1,0 +1,133 @@
+"""Tracers must be reachable from the sww, not just present in it.
+
+#276 got tracers written; they arrived as `<name>_c`, which is exactly what a
+quantity's centroid variable looks like, so `plot_utils` -- which reads a fixed
+list of quantities -- could not surface them. The data was in the file and
+invisible to ANUGA's own reader.
+
+The file now names its tracers in a `tracer_names` attribute rather than
+leaving every reader to guess from a suffix.
+"""
+
+import numpy as num
+import pytest
+
+import anuga
+import anuga.utilities.plot_utils as util
+
+netCDF4 = pytest.importorskip('netCDF4')
+
+
+def _run(tmp_path, tracers=(('salinity', 0.03), ('dye', 0.5)), name='tr'):
+    d = anuga.rectangular_cross_domain(6, 6, len1=60.0, len2=60.0)
+    d.set_quantity('elevation', 0.0)
+    d.set_quantity('stage', 1.0)
+    b = anuga.Reflective_boundary(d)
+    d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+    for tname, value in tracers:
+        d.add_tracer(tname, initial_value=value)
+    d.set_name(name)
+    d.set_datadir(str(tmp_path))
+    for _ in d.evolve(yieldstep=0.5, finaltime=1.0):
+        pass
+    return d, str(tmp_path / (name + '.sww'))
+
+
+# --- the file says what its tracers are ------------------------------------
+
+def test_the_file_records_its_tracer_names(tmp_path):
+    _, sww = _run(tmp_path)
+    with netCDF4.Dataset(sww, 'r') as fid:
+        assert fid.tracer_names == 'salinity dye', \
+            'the writer did not record the tracer names in order'
+
+
+def test_a_file_with_no_tracers_records_an_empty_list(tmp_path):
+    """Empty, not absent: it distinguishes "none" from "written before this"."""
+    _, sww = _run(tmp_path, tracers=(), name='notr')
+    with netCDF4.Dataset(sww, 'r') as fid:
+        assert fid.tracer_names == ''
+    assert util.get_tracer_names(sww) == []
+
+
+def test_get_tracer_names_reads_them_in_order(tmp_path):
+    _, sww = _run(tmp_path)
+    assert util.get_tracer_names(sww) == ['salinity', 'dye']
+
+
+def test_an_old_file_without_the_attribute_still_works(tmp_path):
+    """Falls back to "every <name>_c that is not a known quantity"."""
+    _, sww = _run(tmp_path)
+    with netCDF4.Dataset(sww, 'a') as fid:
+        del fid.tracer_names
+    assert sorted(util.get_tracer_names(sww)) == ['dye', 'salinity']
+
+
+def test_the_fallback_does_not_mistake_a_quantity_for_a_tracer(tmp_path):
+    """stage_c and friends are <name>_c too -- the reason for the attribute."""
+    _, sww = _run(tmp_path, tracers=(), name='q')
+    with netCDF4.Dataset(sww, 'a') as fid:
+        del fid.tracer_names
+    assert util.get_tracer_names(sww) == [], \
+        'a quantity was reported as a tracer'
+
+
+# --- and the readers surface them ------------------------------------------
+
+def test_get_centroids_exposes_the_tracers(tmp_path):
+    """The path that matters: tracers are centroid quantities."""
+    d, sww = _run(tmp_path)
+    pc = util.get_centroids(sww)
+    assert sorted(pc.tracers) == ['dye', 'salinity']
+    assert num.allclose(pc.tracers['salinity'][-1], d.get_tracer('salinity'))
+    assert num.allclose(pc.tracers['dye'][-1], d.get_tracer('dye'))
+
+
+def test_get_output_exposes_the_tracers(tmp_path):
+    d, sww = _run(tmp_path)
+    p = util.get_output(sww)
+    assert sorted(p.tracers) == ['dye', 'salinity']
+    assert num.allclose(p.tracers['salinity'][-1], d.get_tracer('salinity'))
+
+
+def test_the_tracers_are_a_dict_not_attributes(tmp_path):
+    """So a tracer name can never shadow stage, vel or timeSlices."""
+    _, sww = _run(tmp_path)
+    pc = util.get_centroids(sww)
+    assert isinstance(pc.tracers, dict)
+    assert not hasattr(pc, 'salinity'), \
+        'tracers were set as attributes, where they could collide'
+
+
+def test_a_tracer_cannot_be_named_after_a_quantity():
+    """Both go to <name>_c, so the tracer would overwrite it in the sww.
+
+    Found by writing these tests: a tracer called 'stage' really did replace
+    the stage in the output, with no error.
+    """
+    d = anuga.rectangular_cross_domain(4, 4)
+    with pytest.raises(ValueError, match='quantity'):
+        d.add_tracer('stage')
+    with pytest.raises(ValueError, match='quantity'):
+        d.add_tracer('elevation')
+
+
+def test_a_tracer_cannot_take_a_reserved_max_name():
+    d = anuga.rectangular_cross_domain(4, 4)
+    with pytest.raises(ValueError, match='reserved'):
+        d.add_tracer('max_depth')
+
+
+@pytest.mark.parametrize('slices', ['all', 'last', 'max'])
+def test_the_time_slicing_options_work(tmp_path, slices):
+    _, sww = _run(tmp_path)
+    pc = util.get_centroids(sww, timeSlices=slices)
+    assert sorted(pc.tracers) == ['dye', 'salinity']
+    for v in pc.tracers.values():
+        assert v.shape[0] >= 1
+
+
+def test_no_tracers_means_an_empty_dict(tmp_path):
+    _, sww = _run(tmp_path, tracers=(), name='none')
+    assert util.get_centroids(sww).tracers == {}
+    assert util.get_output(sww).tracers == {}

--- a/scripts/anuga_sww_gui.py
+++ b/scripts/anuga_sww_gui.py
@@ -121,6 +121,19 @@ _QTY_TITLE = {
 }
 
 
+# Tracers are user-defined, so unlike everything above they cannot be listed
+# here: which ones exist is a property of the SWW file being opened. Loading a
+# file appends its tracers (and their maxima, when the run stored them) to this
+# list and to the five tables above, keyed 'tracer_<name>' / 'max_tracer_<name>'.
+# Everything downstream then treats a tracer exactly like stage or depth.
+_TRACER_QUANTITIES = []
+
+
+def _all_quantities():
+    """The fixed quantities plus whatever tracers the open file carries."""
+    return tuple(_QUANTITIES) + tuple(_TRACER_QUANTITIES)
+
+
 _CMAPS = ['viridis', 'plasma', 'inferno', 'magma', 'cividis',
           'Blues', 'Greens', 'Oranges', 'Reds', 'YlOrRd',
           'RdBu_r', 'coolwarm', 'seismic', 'jet', 'turbo',
@@ -163,7 +176,7 @@ def _apply_config_to_gui(data, gui):
         if not isinstance(v, dict):
             cfg[k] = v
 
-    if 'qty' in cfg and cfg['qty'] in _QUANTITIES:
+    if 'qty' in cfg and cfg['qty'] in _all_quantities():
         gui._qty_var.set(cfg['qty'])
     if 'vmin' in cfg:
         gui._vmin_var.set(str(cfg['vmin']))
@@ -287,7 +300,7 @@ class SWWAnimationGUI:
         self._build_ui()
 
         # Apply render-tab params (independent of SWW file)
-        if initial_qty and initial_qty in _QUANTITIES:
+        if initial_qty and initial_qty in _all_quantities():
             self._qty_var.set(initial_qty)
         if initial_vmin is not None:
             self._vmin_var.set(str(initial_vmin))
@@ -416,8 +429,10 @@ class SWWAnimationGUI:
         ttk.Label(rA, text='Quantity:').pack(side=tk.LEFT)
         self._qty_var = tk.StringVar(value='depth')
         qty_combo = ttk.Combobox(rA, textvariable=self._qty_var,
-                                 values=list(_QUANTITIES), width=13,
+                                 values=list(_all_quantities()), width=13,
                                  state='readonly')
+        # Kept so a newly loaded file can add its tracers to the list.
+        self._qty_combo = qty_combo
         qty_combo.pack(side=tk.LEFT, padx=(2, 8))
         qty_combo.bind('<<ComboboxSelected>>', lambda _e: self._on_qty_change())
 
@@ -793,7 +808,52 @@ class SWWAnimationGUI:
         epsg_val = self._splotter.epsg
         self._epsg_var.set(str(epsg_val) if epsg_val is not None else '')
 
+        self._register_tracer_quantities()
+
         self._refresh_basemap_state()
+
+    def _register_tracer_quantities(self):
+        """Add the open file's tracers to the quantity menu.
+
+        Called after the plotter is built, which is where the tracer names and
+        data become known. SWW_plotter has already bound a `tracer_<name>`
+        attribute and a `save_tracer_<name>_frame` method for each, so the
+        existing lookup tables are all that need filling in.
+        """
+        global _TRACER_QUANTITIES
+
+        # Rebuild rather than append: opening a second file must not leave the
+        # first file's tracers in the menu.
+        for key in _TRACER_QUANTITIES:
+            for table in (_QTY_DEFAULTS, _QTY_DATA_ATTR, _QTY_SAVE_METHOD,
+                          _QTY_CBAR_LABEL, _QTY_TITLE):
+                table.pop(key, None)
+        _TRACER_QUANTITIES = []
+
+        splotter = self._splotter
+        for name in getattr(splotter, 'tracers', {}):
+            for key, attr, label in (
+                    ('tracer_' + name, 'tracer_' + name, name),
+                    ('max_tracer_' + name, 'max_tracer_' + name, 'Max ' + name)):
+                data = getattr(splotter, attr, None)
+                if data is None:
+                    continue          # no stored maximum for this tracer
+                _TRACER_QUANTITIES.append(key)
+                # A concentration's scale is the model's business -- sediment
+                # runs at 1e-2, a normalised tracer at 1 -- so take the range
+                # from the data rather than guessing a default.
+                _QTY_DEFAULTS[key] = dict(vmin=float(data.min()),
+                                          vmax=float(data.max()))
+                _QTY_DATA_ATTR[key] = attr
+                _QTY_SAVE_METHOD[key] = 'save_%s_frame' % key
+                _QTY_CBAR_LABEL[key] = '%s (concentration)' % label
+                _QTY_TITLE[key] = label
+
+        if getattr(self, '_qty_combo', None) is not None:
+            self._qty_combo.config(values=list(_all_quantities()))
+            # A tracer selected for the previous file may not exist in this one.
+            if self._qty_var.get() not in _all_quantities():
+                self._qty_var.set('depth')
 
     def _refresh_basemap_state(self):
         """Enable/disable the basemap checkbox based on current EPSG + contextily."""


### PR DESCRIPTION
#276 got tracers *written* to the sww. They arrive as `<name>_c` — exactly what a
quantity's centroid variable looks like — so `plot_utils`, which reads a fixed list of
quantities, could not surface them, and neither could anything built on it. The data was
in the file and invisible to ANUGA's own reader.

### The file now says what its tracers are

`Write_sww` records a `tracer_names` global attribute instead of leaving every reader to
guess from a suffix. Written even when empty, so "no tracers" is distinguishable from
"written before this existed"; older files fall back to *every `<name>_c` whose base is
not a known quantity*, which is right for every such file but cannot stay right as
quantities are added — hence the attribute.

### Readers

`get_output` and `get_centroids` both gain a `tracers` dict:

```python
pc = plot_utils.get_centroids('run.sww')
pc.tracers['salinity']          # (ntimes, ncells)
plot_utils.get_tracer_names('run.sww')
```

A **dict, not attributes**, so a tracer can never shadow `stage`, `vel` or `timeSlices`.
The centroid path is the one that matters — tracers are centroid quantities, with no
vertex variable to fall back on — and both honour `timeSlices`, including `'max'`.

`SWW_plotter` loads them and binds a `tracer_<name>` attribute and a
`save_tracer_<name>_frame` method per tracer, generated rather than hand-written since
which tracers exist is a property of the file.

### The GUI

Picks them up from the plotter on load and adds them to the quantity menu as
`tracer_<name>` / `max_tracer_<name>`, filling the same five lookup tables the fixed
quantities use — so everything downstream (auto-ranging, static-vs-animated, frame
export) treats a tracer exactly like stage. vmin/vmax defaults come from the data, since
a concentration's scale is the model's business: sediment runs at 1e-2, a normalised
tracer at 1. Loading a second file replaces the first file's tracers rather than
accumulating them.

### Running maxima

`Collect_max_quantities_operator` now tracks every tracer alongside stage/depth/speed/uh,
stored as `max_<name>_c`.

**The subtlety, and the reason for the C change.** The operator must *derive* `c = m/h`
rather than read `tracer_centroid_values`. `c` is only recomputed during extrapolation,
which runs at the **start** of a step, so by the time a fractional-step operator is called
it is one step behind the conserved `m` just written. Reading it silently missed every
maximum reached on a final step — measured at **42 of 144 cells, deficit up to 7.6e-2** on
a washing-out plume. `max_stage` has no such problem, stage being conserved itself.

Both the host path and the device kernel derive it, so mode 2 still reports *"All
fractional operators are GPU-safe, no GPU↔CPU sync needed"*: the running collection stays
device-resident and only a yield-step store transfers. The two modes agree to 6.7e-16.

### Two things the tests turned up

**A tracer could be named after a quantity.** Both are written as `<name>_c`, so
`add_tracer('stage')` **overwrote the stage in the output** — no error, and a file whose
stage is silently something else. `add_tracer` now refuses a quantity's name, and `max_`
as a prefix. Note `x` and `y` *are* quantities on every domain, which is why
`test_tracers.py`'s `'x'`/`'y'` tracers become `'a'`/`'b'`.

**The maxima never sample the initial condition.** Collection happens on the
fractional-step call, which first runs after the first update, so a cell whose maximum is
its starting value reports the first post-step value. That is long-standing behaviour for
stage/depth/speed/uh — I have *not* changed it, since that would alter existing
`max_stage` output — but it is now documented on the operator and pinned by a test rather
than left to be discovered. **Worth a decision:** should the operator sample at
construction so "maximum over the run" includes t=0? It would be a small change and a
better definition, but it changes existing outputs.

### Verification

- `test_plot_utils_tracers.py` — 14 tests, including the old-file fallback and the
  quantity-name collision
- `test_tracers_max.py` — 9 tests, including the stale-`c` property and the dry-cell rule
- `test_tracers_gpu.py` — 12/12 via the isolated runner on an nvc GPU-offload build
- Full suite **including slow and parallel**: 3046 passed, 11 skipped
- `ruff check anuga` clean
