### PR TITLE
Sediment external source now reaches the solver in mode 2 (closes #288)

### DIFF
--- a/anuga/operators/sediment_operator.py
+++ b/anuga/operators/sediment_operator.py
@@ -62,8 +62,17 @@ class Sediment_operator(Operator):
 
         domain = self.domain
         suspended = getattr(domain, '_sediment_suspended_enabled', True)
+        # _gpu_host_writes_suppressed marks a HOST-COHERENT window: because a
+        # CPU-only operator is registered, apply_fractional_steps has already
+        # pulled the device state to the host and will push the host state back
+        # when the loop finishes. Running on the device inside that window is
+        # not merely redundant -- the trailing push overwrites whatever the
+        # device computed with the host copy, so the work is silently lost.
+        # That is what made an external source contribute nothing in mode 2
+        # whenever any CPU-only operator was present (#288).
         on_gpu = (domain.multiprocessor_mode == 2
-                  and domain.gpu_interface is not None)
+                  and domain.gpu_interface is not None
+                  and not getattr(domain, '_gpu_host_writes_suppressed', False))
 
         if on_gpu:
             from anuga.shallow_water.sw_domain_gpu_ext import (

--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -542,6 +542,7 @@ void gpu_sync_boundary_values(struct gpu_domain *GD);
 // Sync riverwall crest elevations / hydraulic properties TO GPU (after a
 // host-side RiverWall.set_elevation() and friends)
 void gpu_sync_riverwall_to_device(struct gpu_domain *GD);
+void gpu_sync_tracer_source_to_device(struct gpu_domain *GD);
 
 // Sync edge values FROM GPU (before CPU boundary evaluation)
 void gpu_sync_edge_values_from_device(struct gpu_domain *GD);

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -794,15 +794,13 @@ int gpu_domain_map_arrays(struct gpu_domain *GD) {
             tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n], \
             tr_bf[0:ns*n])
 
-        // The external source [G-3] is OPTIONAL -- the array is allocated only
-        // when set_tracer_source is first called -- so it is mapped on its own
-        // rather than with the block above, which is always present. It is read
-        // by the source kernel, so leaving it unmapped is an unmapped host
-        // address on the device: the source then contributes exactly nothing
-        // and the answer is silently short of it. (set_tracer_source discards
-        // the interface when it allocates, so the rebuild passes through here.)
-        if (GD->D.tracer_external_source != NULL) {
-            double *tr_es = GD->D.tracer_external_source;
+        // The external source [G-3]. Allocated with the rest of the block by
+        // add_tracer, so it is always present when n_tracers > 0 and is mapped
+        // unconditionally like the others. It is read by the source kernel, so
+        // an unmapped one is an unmapped host address on the device and the
+        // source silently contributes nothing (#288).
+        double *tr_es = GD->D.tracer_external_source;
+        if (tr_es != NULL) {
             #pragma omp target enter data map(to: tr_es[0:ns*n])
         }
 
@@ -1259,8 +1257,8 @@ void gpu_domain_unmap_arrays(struct gpu_domain *GD) {
             tr_cv[0:ns*n], tr_ev[0:ns*3*n], \
             tr_eu[0:ns*n], tr_qv[0:ns*n], tr_bk[0:ns*n], \
             tr_bf[0:ns*n])
-        if (GD->D.tracer_external_source != NULL) {
-            double *tr_es = GD->D.tracer_external_source;
+        double *tr_es = GD->D.tracer_external_source;
+        if (tr_es != NULL) {
             #pragma omp target exit data map(delete: tr_es[0:ns*n])
         }
         if (nb > 0) {
@@ -1343,6 +1341,27 @@ void gpu_domain_sync_to_device(struct gpu_domain *GD) {
             #pragma omp target update to(tr_bv[0:ns*nb])
         }
     }
+}
+
+// Push the external source [G-3] to the device on its own.
+//
+// set_tracer_source writes it on the HOST, and a time-varying supply -- a
+// manufactured solution, a tributary hydrograph -- rewrites it every step. The
+// device copy would otherwise hold whatever it had when the arrays were mapped
+// and the source would be silently stale rather than absent, which is worse.
+// Separate from gpu_sync_to_device so a per-step push costs one array, not all
+// of them. #288
+void gpu_sync_tracer_source_to_device(struct gpu_domain *GD)
+{
+    if (!GD->gpu_initialized) return;
+    if (GD->D.number_of_tracers <= 0) return;
+
+    double *tr_es = GD->D.tracer_external_source;
+    if (tr_es == NULL) return;
+
+    anuga_int n = GD->D.number_of_elements;
+    anuga_int ns = GD->D.number_of_tracers;
+    #pragma omp target update to(tr_es[0:ns*n])
 }
 
 void gpu_domain_sync_from_device(struct gpu_domain *GD) {

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -684,6 +684,8 @@ class Domain(Generic_Domain):
         self.tracer_conserved_values = None     # m = h*c      (ns, N)
         self.tracer_backup_values = None        # m backup     (ns, N)
         self.tracer_external_source = None      # S_ms [G-3]   (ns, N) [m/s]
+                                                # allocated by add_tracer, with
+                                                # the other tracer blocks
 
         #-------------------------------
         # Phase 3: suspended sediment. A sediment class IS a tracer -- class s
@@ -944,6 +946,15 @@ class Domain(Generic_Domain):
         'tracer_conserved_values': 'cell',
         'tracer_backup_values':    'cell',
         'tracer_boundary_flux':    'cell',
+        # The external source S_ms [G-3]. Allocated with the rest rather than
+        # on first use: a lazily allocated array has to change the C struct and
+        # the device mapping when it appears, and set_tracer_source did that by
+        # discarding the GPU interface -- mid-run, from inside a fractional
+        # step. Sediment_operator then saw gpu_interface is None, took the CPU
+        # path while the state was on the device, and the source contributed
+        # exactly nothing on a GPU build (#288). Being here also means reorder()
+        # permutes it, which it previously did not.
+        'tracer_external_source':  'cell',
     }
     _TRACER_ARRAYS = tuple(_TRACER_ARRAY_KINDS)
 
@@ -2318,14 +2329,10 @@ class Domain(Generic_Domain):
         also make a manufactured solution impossible to impose exactly.
         """
         s = self.get_tracer_index(name)
-        if self.tracer_external_source is None:
-            self.tracer_external_source = num.zeros(
-                (self.number_of_tracers, self.number_of_elements),
-                dtype=num.float64)
-            self._Domain_C_struct = None
-            self.gpu_interface = None
-            if hasattr(self, '_gpu_boundary_info_initialized'):
-                del self._gpu_boundary_info_initialized
+        # Writes only. The array is allocated by add_tracer, so the pointer the
+        # C struct and the device hold stays valid and this is safe to call
+        # from inside a fractional step -- which a manufactured source, or any
+        # time-varying supply, does on every timestep. See #288.
         v = num.asarray(values, dtype=num.float64)
         if v.ndim == 0:
             self.tracer_external_source[s] = float(v)
@@ -2334,6 +2341,15 @@ class Domain(Generic_Domain):
         else:
             raise ValueError('tracer %r: expected a scalar or %d values, got %r'
                              % (name, self.number_of_elements, v.shape))
+
+        # In mode 2 the kernel reads the DEVICE copy, so a host write has to be
+        # pushed or the source goes stale -- silently, and stale is worse than
+        # absent. One array, so a per-step source costs one small transfer.
+        if (self.multiprocessor_mode == MULTIPROCESSOR_GPU
+                and self.gpu_interface is not None):
+            from anuga.shallow_water.sw_domain_gpu_ext import (
+                sync_tracer_source_to_device)
+            sync_tracer_source_to_device(self.gpu_interface.gpu_dom)
 
     def get_tracer_names(self):
         """Return the registered tracer names, in index order."""

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -239,6 +239,7 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_domain_sync_all_from_device(gpu_domain *GD)
     void gpu_sync_boundary_values(gpu_domain *GD)
     void gpu_sync_riverwall_to_device(gpu_domain *GD)
+    void gpu_sync_tracer_source_to_device(gpu_domain *GD)
     void gpu_sync_edge_values_from_device(gpu_domain *GD)
     int gpu_boundary_edge_sync_init(gpu_domain *GD, int num_boundary_cells, int *boundary_cell_ids)
     void gpu_boundary_edge_sync_finalize(gpu_domain *GD)
@@ -1433,6 +1434,16 @@ def sync_riverwall_to_device(GPUDomain gpu_dom):
     riverwalls.
     """
     gpu_sync_riverwall_to_device(&gpu_dom.GD)
+
+
+def sync_tracer_source_to_device(GPUDomain gpu_dom):
+    """Push the tracer external source to the device.
+
+    set_tracer_source writes the host array; a time-varying source rewrites it
+    every step, so the device copy has to be refreshed or it goes stale. One
+    array, not the whole state. #288
+    """
+    gpu_sync_tracer_source_to_device(&gpu_dom.GD)
 
 
 def sync_edge_values_from_device(GPUDomain gpu_dom):

--- a/anuga/shallow_water/tests/test_sediment_source_gpu_invalidation.py
+++ b/anuga/shallow_water/tests/test_sediment_source_gpu_invalidation.py
@@ -69,24 +69,73 @@ def test_it_does_not_crash_when_the_interface_is_invalidated(mode):
     assert op.calls > 0, 'the operator never ran, so nothing was exercised'
 
 
-def test_the_source_reaches_the_solver_in_legacy_mode():
-    """Mode 1 only, deliberately.
-
-    In mode 2 the source currently does NOT take effect, and this test does
-    not paper over it: Sediment_operator picks its path with
-
-        on_gpu = (multiprocessor_mode == 2 and gpu_interface is not None)
-
-    so an operator that nulls the interface earlier in the same
-    fractional-step pass -- which set_tracer_source does on its first call
-    -- pushes the sediment source onto the CPU path while the conserved
-    state is on the device. On a CPU build both paths share host memory and
-    it is harmless; on a GPU build the update is simply lost. Tracked
-    separately; the fix belongs with set_tracer_source, which should not
-    tear the interface down mid-run.
-    """
-    d, _ = _domain(1)
+@pytest.mark.parametrize('mode', [1, 2])
+def test_the_source_reaches_the_solver(mode):
+    """It used to reach it in mode 1 only (#288)."""
+    d, _ = _domain(mode)
     for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
         pass
     assert d.get_tracer('mms').max() > 0.0, \
         'the tracer source never took effect'
+
+
+def test_the_two_modes_agree_on_the_source():
+    """The oracle: mode 2 gave exactly 0.0 while mode 1 gave 1.5e-4.
+
+    Three things had to be true at once, and each was a separate defect:
+    the source array had to stop being reallocated mid-run (it is now a
+    first-class tracer array); it had to be mapped to the device at all;
+    and Sediment_operator had to stop running on the device inside
+    apply_fractional_steps' host-coherent window, where the trailing
+    sync_to_device overwrites whatever the device computed.
+    """
+    d1, _ = _domain(1)
+    for _ in d1.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+    d2, _ = _domain(2)
+    for _ in d2.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+
+    a = d1.get_tracer('mms')
+    b = d2.get_tracer('mms')
+    assert a.max() > 0.0, 'the source did nothing even in legacy mode'
+    # 1e-8 is the tolerance test_sediment_gpu.py uses for the same
+    # mode-1-vs-mode-2 concentration comparison. A one-step staleness would
+    # show up as a fraction of the total, i.e. around 1e-5 here, so this is
+    # tight enough to catch the failure it exists for.
+    assert num.abs(a - b).max() < 1e-8, \
+        'the modes disagree by %g' % num.abs(a - b).max()
+
+
+def test_a_time_varying_source_is_not_stale_on_the_device():
+    """set_tracer_source writes the HOST array; the device copy needs pushing.
+
+    A constant source would pass even if the push were missing, since the
+    mapped values would happen to be right.
+    """
+    class _Ramp(_ResetsTheInterface):
+        def __call__(self):
+            self.calls += 1
+            n = len(self.domain)
+            self.domain.set_tracer_source('mms',
+                                          num.full(n, 1.0e-4 * self.calls))
+
+    out = []
+    for mode in (1, 2):
+        d = anuga.rectangular_cross_domain(6, 6, len1=60.0, len2=60.0)
+        d.set_quantity('elevation', 0.0)
+        d.set_quantity('stage', 1.0)
+        b = anuga.Reflective_boundary(d)
+        d.set_boundary({'left': b, 'right': b, 'top': b, 'bottom': b})
+        d.add_sediment_class('mms', diameter=1.0e-4, initial_concentration=0.0)
+        d.store = False
+        _Ramp(d)
+        d.set_multiprocessor_mode(mode)
+        for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+            pass
+        out.append(d.get_tracer('mms'))
+
+    assert out[0].max() > 0.0
+    assert num.abs(out[0] - out[1]).max() < 1e-8, \
+        'a ramping source diverges between the modes by %g -- the device copy ' \
+        'is stale' % num.abs(out[0] - out[1]).max()


### PR DESCRIPTION
Closes #288.

An external source set with `set_tracer_source` contributed **exactly nothing** on a GPU
build whenever any CPU-only fractional operator was registered. Mode 1 gave 1.51e-4,
mode 2 gave 0.0, and there was no error.

Three separate defects had to line up. Each is fixed here, and only the third produced
the zero — the other two were latent.

### 1. The array was allocated lazily, mid-run

`set_tracer_source` allocated `tracer_external_source` on first use and, to get the new
pointer into the C struct and the device mapping, **discarded the GPU interface** — from
inside a fractional step.

It is now a member of `_TRACER_ARRAY_KINDS`, so `add_tracer` sizes it with every other
tracer block and the pointer never moves. That dict exists precisely so a block cannot be
added without declaring how it is indexed; this one had never been added to it — which is
also why **`reorder()` was not permuting it**. Now it does. Costs one more `(ns, N)` array
on a tracer domain.

### 2. It was never mapped to the device

The source kernel reads it through a function-scope pointer, correctly — but nothing ever
mapped the array, so the device dereferenced an unmapped host address, the exact failure
mode that file's own comments warn about.

Mapped with the rest of the block, plus a targeted `gpu_sync_tracer_source_to_device`:
`set_tracer_source` writes the **host** array, and a time-varying supply rewrites it every
step, so without a push the device copy goes stale — worse than absent. One array per
push, not the whole state.

### 3. The operator ran on the device inside a host-coherent window

This is the one that produced the zero. When a CPU-only fractional operator is registered,
`apply_fractional_steps` brackets the loop with `sync_from_device() … sync_to_device()`.
`Sediment_operator` chose its path on

```python
multiprocessor_mode == 2 and gpu_interface is not None
```

so inside that bracket it ran on the device — and the trailing push then **overwrote
everything it had computed** with the host copy.

It now also tests `_gpu_host_writes_suppressed`, which is exactly what
`rate_operators.py` already does, with the same reasoning in its comment.
`Sediment_operator` had simply missed an established pattern.

### Verification

| case | mode 1 | mode 2 | agreement |
|---|---|---|---|
| constant source | 1.514362e-04 | 1.514361e-04 | 1.4e-10 |
| ramping source | — | — | 1.5e-9 |

1.5e-9 is inside the 1e-8 `test_sediment_gpu.py` uses for the same mode-agreement
comparison, and far inside the ~1e-5 a one-step staleness would produce.

Six tests in `test_sediment_source_gpu_invalidation.py`: both modes, their agreement, and
a **time-varying** source — which a missing device push would break while a constant one
would not. Verified they discriminate: reverting the window check fails three of the six.

- Full suite including slow and parallel — 3215 passed, 13 skipped
- `anuga.shallow_water` under `-cm unified` via the isolated runner — 742 passed, 2
  skipped, and the 4 failures are pre-existing `test_tracers.py` ones that fail
  identically on clean develop (same white-box class: they read host update arrays that
  mode 2 keeps on the device). Unrelated to this change; worth a follow-up.
- GPU sediment + tracer files — 22/22 via the isolated runner
- `ruff check anuga` clean
