### PR TITLE
Pin the direct-kernel tracer flux tests to legacy compute mode

### DIFF
--- a/anuga/shallow_water/tests/test_tracers.py
+++ b/anuga/shallow_water/tests/test_tracers.py
@@ -183,6 +183,31 @@ def _dam_break_domain(nxy=20, names=('c',), beta=1.0, algorithm='DE0'):
     return d
 
 
+def _host_kernel_domain(*args, **kwargs):
+    """A dam-break domain pinned to legacy, for the direct-kernel tests below.
+
+    The tests that use this call the mode-1 flux kernel themselves --
+    compute_fluxes_ext_central -- and then assert on the host arrays. Under
+    ANUGA_DEFAULT_COMPUTE_MODE=unified that is not a meaningful thing to do:
+    the domain evolves on the DEVICE, so the host centroids still hold the
+    initial condition, and distribute_to_vertices_and_edges() never fills the
+    host tracer EDGE values. The host kernel then computes a real stage flux
+    from real stage edges and a ZERO tracer flux from zero tracer edges, and
+    the identities below fail -- or worse, hold vacuously.
+
+    They are mode-1 statements about the flux kernel's algebra, so they are
+    pinned rather than made mode-aware. Mode 2 is covered by
+    test_tracers_gpu.py, which compares the two modes end to end.
+
+    Only the direct-kernel tests use this. The tests that merely evolve a
+    domain and check the result keep the unpinned fixture, so they still
+    exercise whichever mode the suite is run in.
+    """
+    d = _dam_break_domain(*args, **kwargs)
+    d.set_compute_mode('legacy')
+    return d
+
+
 def _prime(d, finaltime=2.0):
     """Advance far enough that there is real flow through interior edges.
 
@@ -217,7 +242,7 @@ def _seed_uniform(d, value, slot=0):
 
 def test_flux_consistency_c_equal_one_reproduces_the_stage_tendency():
     """With c = 1 everywhere, m = h, so dm/dt must equal dh/dt exactly."""
-    d = _prime(_dam_break_domain())
+    d = _prime(_host_kernel_domain())
     _seed_uniform(d, 1.0)
     stage_eu, tracer_eu = _fluxes(d)
     scale = max(np.abs(stage_eu).max(), 1e-30)
@@ -225,7 +250,7 @@ def test_flux_consistency_c_equal_one_reproduces_the_stage_tendency():
 
 
 def test_flux_is_linear_in_concentration():
-    d = _prime(_dam_break_domain())
+    d = _prime(_host_kernel_domain())
     K = 0.375
     _seed_uniform(d, K)
     stage_eu, tracer_eu = _fluxes(d)
@@ -235,7 +260,7 @@ def test_flux_is_linear_in_concentration():
 
 def test_flux_is_conservative_on_a_closed_domain():
     """Reflective everywhere, so the area-weighted tendency must sum to zero."""
-    d = _prime(_dam_break_domain())
+    d = _prime(_host_kernel_domain())
     rng = np.random.default_rng(42)
     _seed_uniform(d, 0.0)
     h = (d.quantities['stage'].centroid_values
@@ -252,7 +277,7 @@ def test_flux_is_conservative_on_a_closed_domain():
 
 def test_transport_is_upwinded():
     """Cold cells ahead of the front stay cold; cells at the front gain."""
-    d = _prime(_dam_break_domain())
+    d = _prime(_host_kernel_domain())
     xc = d.centroid_coordinates[:, 0]
     h = (d.quantities['stage'].centroid_values
          - d.quantities['elevation'].centroid_values)
@@ -271,7 +296,7 @@ def test_transport_is_upwinded():
 
 def test_two_tracers_are_indexed_and_do_not_alias():
     """The tracer-major (ns, ...) layout is indexed as s*n / s*3n."""
-    d = _prime(_dam_break_domain(names=('a', 'b')))
+    d = _prime(_host_kernel_domain(names=('a', 'b')))
     _seed_uniform(d, 1.0, slot=0)
     _seed_uniform(d, 0.375, slot=1)
     stage_eu, tracer_eu = _fluxes(d)


### PR DESCRIPTION
Under `ANUGA_DEFAULT_COMPUTE_MODE=unified` on a GPU-offload build, four tests in
`test_tracers.py` failed and a fifth passed for the wrong reason. Neither had anything to
do with the solver.

### Why they failed

Five tests bypass `evolve` and call the mode-1 flux kernel themselves —
`compute_fluxes_ext_central` — then assert an identity on the host arrays. In mode 2 that
is not a meaningful thing to do, and I traced it step by step:

| step | host state |
|---|---|
| after `_prime()` evolves 2 s | `stage_c` still **0.5 .. 2.0** — the *untouched initial* dam break |
| after `_seed_uniform(d, K)` | `c = 0.375`, `m = h·c` — correct, written on the host |
| after `distribute_to_vertices_and_edges()` | stage edges 0.5 .. 2.0, **tracer edges 0.0 .. 0.0** |

The evolution happens on the **device** and mode 2 does not sync back, so the host
centroids still hold the initial condition; and `distribute_to_vertices_and_edges()` never
fills the host *tracer edge* array. The host kernel then computes a real stage flux from
real stage edges and a **zero** tracer flux from zero tracer edges, so
`tracer_eu == K · stage_eu` cannot hold.

### The one that was worse

`test_flux_is_conservative_on_a_closed_domain` asserts

```python
assert abs(total) < 1e-12 * max(scale, 1e-30)
```

With every tracer flux zero that reads `0 < 1e-42`, which is **true**. It was passing
vacuously, in the mode it was least able to check. Measured:

| | `sum |flux|·area` | residual |
|---|---|---|
| unpinned | **0.0** — nothing to conserve | 0.0 |
| pinned | 1.58e+03 | 8.5e-14 |

### The fix

These are mode-1 statements about the flux kernel's algebra, so they are pinned rather
than made mode-aware, via a named `_host_kernel_domain()` whose docstring carries the
reason. Mode 2 is covered by `test_tracers_gpu.py`, which compares the modes end to end.

**Only the five direct-kernel tests are pinned.** Three other tests share the same fixture
but merely evolve a domain and check the result — those keep the unpinned version, so they
still exercise whichever mode the suite runs in. Pinning the shared fixture wholesale
would have quietly dropped that mode-2 coverage.

### Verification

- `test_tracers.py` — 26 pass in **both** modes
- `anuga.shallow_water` under `-cm unified`, whole suite — the four failures are gone
  (740 passed, 2 skipped, 3 failed; the remaining three are the sediment MMS tests, fixed
  separately by #289, which I confirmed takes them 3 → 0)
- Legacy full suite including slow and parallel — 3212 passed, 13 skipped
- `ruff check anuga` clean
