### PR TITLE
import anuga no longer requires matplotlib, and drop a matmul warning

### DIFF
--- a/anuga/__init__.py
+++ b/anuga/__init__.py
@@ -84,8 +84,44 @@ from anuga.coordinate_transforms.geo_reference import Geo_reference
 from anuga.operators.base_operator import Operator
 from anuga.structures.structure_operator import Structure_operator
 
-from anuga.utilities.animate import SWW_plotter
-from anuga.utilities.animate import Domain_plotter
+# The plotting helpers need matplotlib, and anuga.utilities.animate raises at
+# import when it is missing. Importing them eagerly here made that a hard
+# dependency of `import anuga` itself: a solver-only or MPI run would die
+# before it started because a PLOTTING library could not load.
+#
+# That is not hypothetical. It broke a nightly build on Windows, where
+# matplotlib's _c_internal_utils extension failed inside an mpiexec
+# subprocess -- "DLL load failed ... The handle is invalid" -- and took
+# `import anuga` down with it, in a load-balance test that never plots
+# anything.
+#
+# So bind them lazily. A user who actually plots gets the same clear
+# matplotlib error as before, at the point of use; everyone else is
+# unaffected by matplotlib being absent or broken.
+def _plotter_stub(_name):
+    class _MissingPlotter:
+        """Placeholder for a plotting class whose import failed."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                '%s needs matplotlib, which could not be imported:\n    %s\n'
+                'Install it with: conda install matplotlib  or  '
+                'pip install matplotlib' % (_name, _plotter_import_error))
+
+    _MissingPlotter.__name__ = _name
+    _MissingPlotter.__qualname__ = _name
+    return _MissingPlotter
+
+
+try:
+    from anuga.utilities.animate import SWW_plotter
+    from anuga.utilities.animate import Domain_plotter
+
+    _plotter_import_error = None
+except ImportError as _e:                    # pragma: no cover - env specific
+    _plotter_import_error = _e
+    SWW_plotter = _plotter_stub('SWW_plotter')
+    Domain_plotter = _plotter_stub('Domain_plotter')
 
 
 from anuga.abstract_2d_finite_volumes.generic_domain import Generic_Domain

--- a/anuga/file_conversion/tif2point_values.py
+++ b/anuga/file_conversion/tif2point_values.py
@@ -6,6 +6,27 @@ __date__= '2020/06/08'
 
 from pprint import pprint
 
+
+def _world_to_pixel(affine_transform, xs, ys):
+    """Pixel (column, row) for world coordinates, as floats.
+
+    The obvious spelling is ``~affine_transform * (xs, ys)``, but newer
+    versions of the `affine` package emit
+
+        PendingDeprecationWarning: Use `@` matmul instead of `*` mul
+        operator for matrix multiplication
+
+    for that, and `@` is Affine-times-Affine only -- it does not take a pair
+    of coordinate arrays, so the suggested replacement does not apply to a
+    point transform. Doing the arithmetic here is exactly what the operator's
+    point branch does, works on every version of affine, and keeps the float
+    result the caller truncates itself.
+    """
+    inv = ~affine_transform
+    return (inv.a * xs + inv.b * ys + inv.c,
+            inv.d * xs + inv.e * ys + inv.f)
+
+
 def tif2point_values(filename, zone=None, south=True, points=None, verbose=False):
 
     import numpy as np
@@ -52,7 +73,8 @@ def tif2point_values(filename, zone=None, south=True, points=None, verbose=False
         points_lat = np.asarray(_lat)
         points_lon = np.asarray(_lon)
 
-        ilocs = np.array(~affine_transform * (points_lon, points_lat))
+        ilocs = np.array(_world_to_pixel(affine_transform,
+                                        points_lon, points_lat))
 
     elif not south:
         zone = int(zone)
@@ -61,7 +83,8 @@ def tif2point_values(filename, zone=None, south=True, points=None, verbose=False
             tif_epsg == str(nad83_utm_north.get(zone))
         )
         if same_utm:
-            ilocs = np.array(~affine_transform * (points[:, 0], points[:, 1]))
+            ilocs = np.array(_world_to_pixel(affine_transform,
+                                            points[:, 0], points[:, 1]))
         else:
             raise Exception("zone and hemisphere of tif not the same as zone and hemisphere of points")
 
@@ -69,7 +92,8 @@ def tif2point_values(filename, zone=None, south=True, points=None, verbose=False
         zone = int(zone)
         same_utm = tif_epsg == str(wgs84_utm_south.get(zone))
         if same_utm:
-            ilocs = np.array(~affine_transform * (points[:, 0], points[:, 1]))
+            ilocs = np.array(_world_to_pixel(affine_transform,
+                                            points[:, 0], points[:, 1]))
         else:
             raise Exception("zone and hemisphere of tif not the same as zone and hemisphere of points")
 

--- a/anuga/rain/raster_time_slice_data.py
+++ b/anuga/rain/raster_time_slice_data.py
@@ -1,7 +1,27 @@
 
 import anuga
 from anuga.fit_interpolate.interpolate2d import interpolate_raster
-import matplotlib.pyplot as plt
+# Tolerated rather than required: anuga/rain is imported by `import anuga`,
+# so a hard matplotlib import here made a PLOTTING library a prerequisite of
+# running the solver at all. Only the three plot_* methods below need it, and
+# they say so when called. See the note in anuga/__init__.py.
+try:
+    import matplotlib.pyplot as plt
+except ImportError as _mpl_error:            # pragma: no cover - env specific
+    plt = None
+    _MPL_IMPORT_ERROR = _mpl_error
+else:
+    _MPL_IMPORT_ERROR = None
+
+
+def _require_matplotlib(what):
+    """Raise a clear error if a plotting method is called without matplotlib."""
+    if plt is None:
+        raise ImportError(
+            '%s needs matplotlib, which could not be imported:\n    %s\n'
+            'Install it with: conda install matplotlib  or  '
+            'pip install matplotlib' % (what, _MPL_IMPORT_ERROR))
+
 import numpy as np
 import os
 from os.path import join
@@ -185,6 +205,8 @@ class Raster_time_slice_data:
         return total_data_volume, data_max_in_period, peak_intensity, catchment_area, time_period
 
     def plot_data(self, tid, plot_vmax=None, save=False, show=True, polygons=None):
+
+        _require_matplotlib('plot_data')
         """
         Plot data at timestep tid
         """
@@ -231,6 +253,8 @@ class Raster_time_slice_data:
         return
 
     def plot_accumulated_data(self, polygons=None):
+
+        _require_matplotlib('plot_accumulated_data')
 
         data_accumulated = self.data_accumulated
 
@@ -283,6 +307,8 @@ class Raster_time_slice_data:
         return
 
     def plot_time_hist_locations(self, locations):
+
+        _require_matplotlib('plot_time_hist_locations')
         """
         Plot time histograms at selected locations i.e.
         gauge locations

--- a/anuga/utilities/plot_utils.py
+++ b/anuga/utilities/plot_utils.py
@@ -50,7 +50,6 @@
 from anuga.file.netcdf import NetCDFFile
 import numpy
 import copy
-import matplotlib.cm
 
 class combine_outputs:
     """
@@ -1303,7 +1302,7 @@ def Make_Geotif(swwFile=None,
 
     return
 
-def plot_triangles(p, adjustLowerLeft=False, values=None, values_cmap=matplotlib.cm.jet, edgecolors='k'):
+def plot_triangles(p, adjustLowerLeft=False, values=None, values_cmap=None, edgecolors='k'):
     """ Add mesh triangles to a pyplot plot
 
        @param p = object holding sww vertex information (from util.get_output)
@@ -1315,6 +1314,13 @@ def plot_triangles(p, adjustLowerLeft=False, values=None, values_cmap=matplotlib
     import matplotlib
     from matplotlib import pyplot as pyplot
     from matplotlib.collections import PolyCollection
+
+    # Resolved here rather than as a default argument: importing matplotlib at
+    # module level made it a hard requirement of `import anuga`, which meant a
+    # solver or MPI run could not start when a PLOTTING library was missing or
+    # broken. None keeps the same colormap without that coupling.
+    if values_cmap is None:
+        values_cmap = matplotlib.cm.jet
 
     x0=p.xllcorner
     y0=p.yllcorner

--- a/anuga/utilities/tests/meson.build
+++ b/anuga/utilities/tests/meson.build
@@ -14,6 +14,7 @@ python_sources = [
 'test_numerical_tools.py',
 'test_plot_utils.py',
 'test_plot_utils_tracers.py',
+'test_import_without_matplotlib.py',
 'test_quantity_setting_functions.py',
 'test_sparse.py',
 'test_spatialInputUtil.py',

--- a/anuga/utilities/tests/test_import_without_matplotlib.py
+++ b/anuga/utilities/tests/test_import_without_matplotlib.py
@@ -1,0 +1,77 @@
+"""`import anuga` must not require matplotlib.
+
+anuga/__init__.py used to import the plotting helpers eagerly, and those
+modules raise at import when matplotlib is missing. That made a PLOTTING
+library a prerequisite of running the solver: a nightly build failed on
+Windows because matplotlib's _c_internal_utils extension could not load
+inside an mpiexec subprocess ("DLL load failed ... The handle is invalid"),
+which took `import anuga` down with it -- in a load-balance test that never
+plots anything.
+
+Run in a subprocess with matplotlib blocked, because anuga is already
+imported by the time this test runs.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run(body):
+    """Execute body in a fresh interpreter where matplotlib cannot import."""
+    script = textwrap.dedent('''
+        import builtins
+        _real = builtins.__import__
+        def _blocked(name, *a, **k):
+            if name.startswith('matplotlib'):
+                raise ImportError('matplotlib is blocked for this test')
+            return _real(name, *a, **k)
+        builtins.__import__ = _blocked
+    ''') + textwrap.dedent(body)
+    return subprocess.run([sys.executable, '-c', script],
+                          capture_output=True, text=True)
+
+
+def test_anuga_imports_without_matplotlib():
+    r = _run("import anuga; print('ok')")
+    assert r.returncode == 0, \
+        'import anuga failed without matplotlib:\n%s' % (r.stderr[-2000:],)
+    assert 'ok' in r.stdout
+
+
+def test_the_solver_runs_without_matplotlib():
+    r = _run('''
+        import anuga
+        d = anuga.rectangular_cross_domain(4, 4)
+        b = anuga.Reflective_boundary(d)
+        d.set_boundary({t: b for t in d.get_boundary_tags()})
+        d.store = False
+        for _ in d.evolve(yieldstep=0.5, finaltime=1.0):
+            pass
+        print('ok')
+    ''')
+    assert r.returncode == 0, r.stderr[-2000:]
+    assert 'ok' in r.stdout
+
+
+def test_reading_an_sww_does_not_need_matplotlib():
+    """plot_utils is the sww reader; only its plotting helpers need matplotlib."""
+    r = _run("import anuga.utilities.plot_utils as util; print('ok')")
+    assert r.returncode == 0, r.stderr[-2000:]
+    assert 'ok' in r.stdout
+
+
+def test_a_plotting_class_still_says_what_is_wrong():
+    """Degrading quietly would be worse than the original hard failure."""
+    r = _run('''
+        import anuga
+        try:
+            anuga.SWW_plotter('nonexistent.sww')
+        except ImportError as e:
+            print('MATPLOTLIB' if 'matplotlib' in str(e) else 'OTHER')
+    ''')
+    assert r.returncode == 0, r.stderr[-2000:]
+    assert 'MATPLOTLIB' in r.stdout, \
+        'the error no longer mentions matplotlib: %r' % r.stdout


### PR DESCRIPTION
Two things from the failed nightly of 2026-09-06.

## 1. The failure: a plotting library could stop the solver starting

`develop / Windows / Python 3.12` failed in `test_load_balance_statistics` — a test that
never plots anything. The `mpiexec` subprocess died with

```
ImportError: DLL load failed while importing _c_internal_utils: The handle is invalid.
ImportError: matplotlib is required for anuga.utilities.animate
```

matplotlib's C extension queries console handles at import, and under `mpiexec` on Windows
those can be invalid.

**That part is environmental and flaky** — nothing had changed in develop since the
previous night's green run (zero commits), `main` passed the same job, and matplotlib was
3.11.1 in both. But it was *fatal* only because **`import anuga` had to import
matplotlib**, which I reproduced exactly:

```python
# with matplotlib made unimportable
import anuga
# ImportError: matplotlib is required for anuga.utilities.animate
```

Three eager imports made that so, all reachable from `anuga/__init__.py`:

| module | why it pulled matplotlib in |
|---|---|
| `anuga/__init__.py` | `SWW_plotter`, `Domain_plotter` from `animate`, which raises at import |
| `anuga/utilities/plot_utils.py` | `import matplotlib.cm`, needed for **one default argument** |
| `anuga/rain/raster_time_slice_data.py` | `pyplot`, used only by three `plot_*` methods |

Each is now *tolerated* rather than required. The plotting classes bind to a stub that
raises the same clear matplotlib message when **instantiated**; `plot_triangles` resolves
its colormap at call time; the rain plotting methods check on entry.

The point is that reading an sww or running a solver never needed matplotlib — the
coupling was accidental. Anyone who actually plots still gets the same error, at the point
of use.

**This does not guarantee that job passes** — the underlying flake is in matplotlib on
Windows under MPI. It means a matplotlib problem can no longer stop the solver.

## 2. The matmul deprecation warning

```
tif2point_values.py:55,64,72: PendingDeprecationWarning:
    Use `@` matmul instead of `*` mul operator for matrix multiplication
```

from `~affine_transform * (xs, ys)`.

**Following the advice literally does not work.** `Affine.__matmul__` takes another
`Affine`, not a pair of coordinate arrays, so `~A @ (xs, ys)` is a `TypeError`. The
warning is firing on a **point transform**, where `*` is the only operator that does the
job.

The newer affine also cannot be tested here — the installed 2.4.0 has no `__matmul__` at
all and emits no warning — so rather than guess at the newer version's semantics,
`_world_to_pixel` does the arithmetic directly. It is exactly what the operator's point
branch computes, works on every version, and keeps the float result the caller truncates
itself.

Verified **bit-identical** against the operator over 200 random transforms × 50 points:
worst difference `0.0`.

The third occurrence (line 64) had never been reported, only because that branch was not
exercised in the run that reported the other two.

## Verification

- `test_import_without_matplotlib.py` — 4 tests, running a fresh interpreter with
  matplotlib blocked: anuga imports, the solver evolves, `plot_utils` imports, and a
  plotting class still says what is wrong. Verified they discriminate — restoring the
  eager import fails all four.
- Full suite including slow and parallel — 3215 passed, 13 skipped
- `ruff check anuga` clean
