### PR TITLE
Add sympy to the conda environments, so the MMS tests actually run

### DIFF
--- a/environments/environment_3.10.yml
+++ b/environments/environment_3.10.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.10_intel.yml
+++ b/environments/environment_3.10_intel.yml
@@ -34,6 +34,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.11.yml
+++ b/environments/environment_3.11.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.11_intel.yml
+++ b/environments/environment_3.11_intel.yml
@@ -34,6 +34,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.12.yml
+++ b/environments/environment_3.12.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.12_intel.yml
+++ b/environments/environment_3.12_intel.yml
@@ -34,6 +34,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.13.yml
+++ b/environments/environment_3.13.yml
@@ -33,6 +33,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.13_intel.yml
+++ b/environments/environment_3.13_intel.yml
@@ -35,6 +35,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.14.yml
+++ b/environments/environment_3.14.yml
@@ -33,6 +33,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.14_intel.yml
+++ b/environments/environment_3.14_intel.yml
@@ -35,6 +35,7 @@ dependencies:
   - pytest
   - pytest-regressions
   - scipy
+  - sympy
   - utm
   - wheel
   - xarray

--- a/environments/environment_3.8.yml
+++ b/environments/environment_3.8.yml
@@ -29,6 +29,7 @@ dependencies:
   - pytest=8.3.4
   - pytest-regressions
   - scipy=1.10.1
+  - sympy
   - utm=0.7.0
   - wheel=0.45.1
   - xarray=2023.1.0

--- a/environments/environment_3.9.yml
+++ b/environments/environment_3.9.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest=8.4.1
   - pytest-regressions
   - scipy=1.13.1
+  - sympy
   - utm=0.7.0
   - wheel=0.45.1
   - xarray=2024.7.0


### PR DESCRIPTION
`test_sediment_mms_full.py` derives its manufactured source terms symbolically and guards
itself with

```python
sp = pytest.importorskip('sympy')
```

sympy was in **none** of the environment files, so that module was **skipped everywhere** —
locally and in CI. Five verification tests, including the one checking that the sediment
source converges at its design order, have never run in the build.

### Why that mattered

A test nobody runs is a test that cannot report. In #295 I changed when the sediment
operator gets registered, which reorders the fractional steps — and
`test_sediment_mms_full` is the only thing in the repository that depends on that order.
It was caught only because **ruff** flagged a stale local import in that file; confirming
the behaviour meant installing sympy by hand, where reverting the change drops the `c0`
convergence order from 1.03 to 0.85.

That should not have depended on a lint rule noticing.

### The change

`sympy` added directly after `scipy` in all **twelve** files, including the `_intel`
variants and the legacy 3.8/3.9 ones, so none is left odd.

**Unpinned**, deliberately: sympy is `noarch` on conda-forge, so it resolves on every
platform and Python version without constraining the solve. Pinning it in the two
version-pinned legacy files would add a constraint for no reason.

### Verified it enables rather than breaks

The risk with turning on previously-skipped tests is that they turn CI red. They do not —
on **plain develop**, with sympy available:

```
test_sediment_mms_full.py .....    5 passed
```

and the full suite moves by exactly that module:

| | passed | skipped |
|---|---|---|
| before | 3220 | 13 |
| after | 3224 | 12 |
