### PR TITLE
GPU: hoist boundary_length out of the offloaded flux loop (fixes mode-2 tracer crash)

### DIFF
--- a/anuga/shallow_water/gpu/core_kernels.c
+++ b/anuga/shallow_water/gpu/core_kernels.c
@@ -2140,19 +2140,29 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
 //                 benchmark caught that; every correctness test passed.
 //   GPU build  -- the loops below are 'omp target' regions and D is NOT mapped
 //                 to the device, so a D->member load inside the region reads a
-//                 host address on the device. The tracer work then silently
-//                 does nothing: no crash, explicit_update stays zero on the
-//                 device, and m never moves. They must be loaded at function
-//                 scope so the pointer VALUES are captured as firstprivate
-//                 scalars and address-translated via the present table.
+//                 host address on the device. What happens next depends on
+//                 what is loaded. A POINTER member yields a garbage pointer
+//                 value, and the tracer work silently does nothing: no crash,
+//                 explicit_update stays zero on the device, and m never moves.
+//                 A SCALAR member is consumed as data, and the read itself
+//                 faults: boundary_length below, loaded in-loop, took the whole
+//                 process down with CUDA_ERROR_ILLEGAL_ADDRESS as soon as
+//                 n_tracers > 0 (the load ran for every edge, before any
+//                 inflow test). Everything read from D must be loaded at
+//                 function scope so the VALUES are captured as firstprivate
+//                 scalars and, for pointers, address-translated via the
+//                 present table.
 //
 // So: hoisted declarations under #ifndef CPU_ONLY_MODE, in-guard declarations
-// under #ifdef CPU_ONLY_MODE. The loop bodies are identical either way.
+// under #ifdef CPU_ONLY_MODE -- pointers AND the boundary_length scalar alike,
+// so the benchmarked CPU hot loop stays byte-identical. The loop bodies are
+// identical either way.
 #ifndef CPU_ONLY_MODE
     double * restrict t_eu = D->tracer_explicit_update;
     double * restrict t_ev = D->tracer_edge_values;
     double * restrict t_bv = D->tracer_boundary_values;
     double * restrict t_bf = D->tracer_boundary_flux;
+    const anuga_int t_bl = D->boundary_length;
 #endif
 
     // Reduction variables
@@ -2341,8 +2351,8 @@ double core_compute_fluxes_central(struct domain *D, int substep_count, int time
                 double * restrict t_bv = D->tracer_boundary_values;
                 double * restrict t_eu = D->tracer_explicit_update;
                 double * restrict t_bf = D->tracer_boundary_flux;
-#endif
                 const anuga_int t_bl = D->boundary_length;
+#endif
                 const double wflux = edgeflux[0];
                 const int    inflow = (wflux > 0.0);
                 /* Conservation accounting: record what crosses a DOMAIN boundary edge,

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -23,6 +23,7 @@ python_sources = [
 'test_tracers_reorder.py',
 'test_tracers_distribute.py',
 'test_tracers_gpu.py',
+'test_tracers_gpu_boundary.py',
 'test_sediment_paths.py',
 'test_sediment_rdycore_erosion.py',
 'test_sediment_rdycore_benchmarks.py',

--- a/anuga/shallow_water/tests/test_tracers_gpu_boundary.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu_boundary.py
@@ -1,0 +1,89 @@
+"""A tracer carried in across a boundary must not fault the device in mode 2.
+
+Regression test for a host-struct dereference inside the offloaded flux loop:
+the tracer advection block read ``D->boundary_length`` inside the
+``omp target`` element loop, and ``D`` is a host pointer that is never mapped,
+so on a real GPU-offload build the read faulted with
+``CUDA_ERROR_ILLEGAL_ADDRESS`` as soon as a tracer was registered, and the
+NVHPC runtime aborted the whole process.
+
+That abort cannot be caught in-process, which is also why the fault was never
+seen: the mode-1 vs mode-2 oracles were only ever run on the CPU build, where
+the target region executes on the host and a ``D->`` load is harmless.  So
+the evolve runs in a CHILD process and the assertion is on its exit status.
+
+The child drives water (and tracer) IN through a Dirichlet boundary with a
+prescribed concentration, so the inflow branch that indexes the boundary
+array with ``boundary_length`` is exercised on every step, and it checks the
+mode-2 tracer field against a mode-1 run of the same problem: a wrong hoist
+(the right type, the wrong member) would index the wrong slot and disagree,
+where a mere "did not crash" check would pass.
+
+Only meaningful on an offload build with a device in use, so it skips
+elsewhere rather than passing vacuously.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import anuga
+
+pytest.importorskip("anuga.shallow_water.sw_domain_gpu_ext")
+
+CHILD = textwrap.dedent("""
+    import numpy as np
+    import anuga
+    from anuga import Dirichlet_boundary, Reflective_boundary
+    from anuga import rectangular_cross_domain
+
+    def run(mode):
+        d = rectangular_cross_domain(10, 10, len1=100.0, len2=100.0)
+        d.set_flow_algorithm('DE0')
+        d.store = False
+        d.set_quantity('elevation', 0.0)
+        d.set_quantity('stage', 1.0)
+        # Higher stage on the left: water flows IN there for the whole run,
+        # carrying the prescribed concentration; walls elsewhere.
+        Br = Reflective_boundary(d)
+        d.set_boundary({'left': Dirichlet_boundary([1.5, 0.0, 0.0]),
+                        'right': Br, 'top': Br, 'bottom': Br})
+        d.add_tracer('c', beta=1.0)
+        d.set_tracer('c', 0.0)
+        d.set_tracer_boundary('c', 'left', 1.0)
+        d.set_multiprocessor_mode(mode)
+        if d.multiprocessor_mode != mode:
+            raise SystemExit('mode %d did not engage' % mode)
+        m0 = d.get_tracer_mass('c')
+        for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+            pass
+        return d, d.get_tracer_mass('c') - m0
+
+    cpu, gained_cpu = run(1)
+    gpu, gained_gpu = run(2)
+    if not gained_cpu > 0.0:
+        raise SystemExit('no tracer entered in mode 1: %r' % gained_cpu)
+    ma = cpu.tracer_conserved_values[0]
+    mb = gpu.tracer_conserved_values[0]
+    err = float(np.abs(ma - mb).max())
+    if not err < 1e-10:
+        raise SystemExit('mode 2 tracer disagrees with mode 1: max |dm| = %g'
+                         % err)
+    print('OK')
+""")
+
+
+@pytest.mark.skipif(not anuga.gpu_offload_supported(), reason="needs a GPU-offload build with a device")
+def test_a_tracer_carried_in_across_a_boundary_does_not_fault_the_device():
+    env = dict(os.environ, OMP_NUM_THREADS="1")
+    # An inherited 'disabled' would run the target regions on the host and
+    # make the whole check vacuous.
+    env.pop("OMP_TARGET_OFFLOAD", None)
+    proc = subprocess.run([sys.executable, "-c", CHILD], capture_output=True, text=True, timeout=180, env=env)
+    assert proc.returncode == 0, "mode-2 evolve with a tracer inflow failed (rc=%d):\n%s" % (
+        proc.returncode,
+        (proc.stdout + proc.stderr)[-2000:],
+    )


### PR DESCRIPTION
On a GPU-offload build **every mode-2 evolve with a registered tracer aborts the process**:

```
Accelerator Fatal Error: call to cuMemcpyDtoHAsync returned error 700
(CUDA_ERROR_ILLEGAL_ADDRESS)  Function: core_compute_fluxes_central
```

The tracer advection block read `D->boundary_length` inside the element loop. That loop is an
`omp target teams distribute parallel for` region and `D` is a host pointer that is never mapped,
so the load dereferences a host address on the device. The tracer *pointers* were already hoisted
for exactly that reason; the scalar was missed because it was added inside the `n_tracers > 0`
guard next to the CPU-build in-guard pointer loads. A pointer member read this way yields a
garbage pointer and the work silently no-ops; a scalar member is consumed as data and the read
itself faults, for every edge, as soon as `n_tracers > 0`.

**Fix:** the scalar takes the same two-way form as the pointers — hoisted under
`#ifndef CPU_ONLY_MODE`, in-guard under `#ifdef CPU_ONLY_MODE` — so the benchmarked CPU hot loop
stays byte-identical.

Reproduced on develop `d933d600` (nvc 25.9, V100): all 26 tests in `test_tracers_gpu.py`,
`test_sediment_gpu.py` and `test_sediment_source_gpu_invalidation.py` crashed this way. The
mode-1 vs mode-2 oracles were evidently only ever run on the CPU build, where the `omp target`
regions execute on the host and a `D->` load is harmless.

**Test:** new `test_tracers_gpu_boundary.py` drives water and a prescribed tracer concentration in
through a Dirichlet boundary in mode 1 and mode 2 in a child process and requires the tracer
fields to agree to 1e-10, so the inflow branch that indexes the boundary array with
`boundary_length` runs on every step and a wrong hoist would be caught, not just a crash. The
parent asserts on the child's exit status, turning the runtime abort into an ordinary failure.
Skips unless `gpu_offload_supported()`, and drops an inherited `OMP_TARGET_OFFLOAD` so it cannot
pass vacuously on the host. Fails on the unfixed kernel, passes with the hoist.

**First of three stacked PRs.** Without this hoist no mode-2 tracer run can even start on a GPU
build, so the other two would crash rather than fail.
