### PR TITLE
Tracers: push boundary concentrations to the device after every host write

### DIFF
--- a/anuga/shallow_water/gpu/gpu_domain.h
+++ b/anuga/shallow_water/gpu/gpu_domain.h
@@ -543,6 +543,7 @@ void gpu_sync_boundary_values(struct gpu_domain *GD);
 // host-side RiverWall.set_elevation() and friends)
 void gpu_sync_riverwall_to_device(struct gpu_domain *GD);
 void gpu_sync_tracer_source_to_device(struct gpu_domain *GD);
+void gpu_sync_tracer_boundary_to_device(struct gpu_domain *GD);
 
 // Sync edge values FROM GPU (before CPU boundary evaluation)
 void gpu_sync_edge_values_from_device(struct gpu_domain *GD);

--- a/anuga/shallow_water/gpu/gpu_domain_core.c
+++ b/anuga/shallow_water/gpu/gpu_domain_core.c
@@ -1364,6 +1364,30 @@ void gpu_sync_tracer_source_to_device(struct gpu_domain *GD)
     #pragma omp target update to(tr_es[0:ns*n])
 }
 
+// Push the tracer boundary concentrations to the device on their own.
+//
+// set_tracer_boundary() and update_tracer_boundary_values() write the HOST
+// array.  The device copy is made once, when the arrays are mapped, and
+// gpu_sync_boundary_values() (the per-step push the boundary evaluators use)
+// carries only the hydrodynamic boundary values -- so without this a value
+// set after the interface exists, or re-evaluated for a later time, is never
+// seen by the flux kernel and every inflow edge keeps injecting the mapped
+// (t = 0, or zero-filled) concentration.  One small array, like the source.
+void gpu_sync_tracer_boundary_to_device(struct gpu_domain *GD)
+{
+    if (!GD->gpu_initialized) return;
+    if (GD->D.number_of_tracers <= 0) return;
+
+    anuga_int nb = GD->D.boundary_length;
+    if (nb <= 0) return;   /* not mapped either; see gpu_domain_map_arrays */
+
+    double *tr_bv = GD->D.tracer_boundary_values;
+    if (tr_bv == NULL) return;
+
+    anuga_int ns = GD->D.number_of_tracers;
+    #pragma omp target update to(tr_bv[0:ns*nb])
+}
+
 void gpu_domain_sync_from_device(struct gpu_domain *GD) {
     // Sync centroid values from GPU (use at yieldstep for Python I/O)
     if (!GD->gpu_initialized) return;

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -2094,6 +2094,22 @@ class Domain(Generic_Domain):
         else:
             self._tracer_boundary_functions.pop((s, tag), None)
             self._apply_tracer_boundary(s, idx, value, tag)
+        self._push_tracer_boundary_to_device()
+
+    def _push_tracer_boundary_to_device(self):
+        """Mirror the host tracer boundary array to the device, if there is one.
+
+        The device copy is made once when the arrays are mapped, and the
+        per-step boundary push carries only the hydrodynamic values, so every
+        host write to tracer_boundary_values has to be followed by this or the
+        flux kernel keeps reading the mapped copy. Same reasoning as the
+        external source in set_tracer_source. A no-op off the GPU path.
+        """
+        if (self.multiprocessor_mode == MULTIPROCESSOR_GPU
+                and self.gpu_interface is not None):
+            from anuga.shallow_water.sw_domain_gpu_ext import (
+                sync_tracer_boundary_to_device)
+            sync_tracer_boundary_to_device(self.gpu_interface.gpu_dom)
 
     def _apply_tracer_boundary(self, s, idx, value, tag):
         """Write one tracer's boundary values for the edges of one tag."""
@@ -2121,6 +2137,7 @@ class Domain(Generic_Domain):
         for (s, tag), f in self._tracer_boundary_functions.items():
             idx = num.asarray(self.tag_boundary_cells[tag], dtype=num.intp)
             self._apply_tracer_boundary(s, idx, f(t), tag)
+        self._push_tracer_boundary_to_device()
 
     def get_tracer_boundary(self, name, tag):
         """Return the boundary concentrations of `name` on `tag`."""

--- a/anuga/shallow_water/sw_domain_gpu_ext.pyx
+++ b/anuga/shallow_water/sw_domain_gpu_ext.pyx
@@ -240,6 +240,7 @@ cdef extern from "gpu_domain.h" nogil:
     void gpu_sync_boundary_values(gpu_domain *GD)
     void gpu_sync_riverwall_to_device(gpu_domain *GD)
     void gpu_sync_tracer_source_to_device(gpu_domain *GD)
+    void gpu_sync_tracer_boundary_to_device(gpu_domain *GD)
     void gpu_sync_edge_values_from_device(gpu_domain *GD)
     int gpu_boundary_edge_sync_init(gpu_domain *GD, int num_boundary_cells, int *boundary_cell_ids)
     void gpu_boundary_edge_sync_finalize(gpu_domain *GD)
@@ -1444,6 +1445,16 @@ def sync_tracer_source_to_device(GPUDomain gpu_dom):
     array, not the whole state. #288
     """
     gpu_sync_tracer_source_to_device(&gpu_dom.GD)
+
+
+def sync_tracer_boundary_to_device(GPUDomain gpu_dom):
+    """Push the tracer boundary concentrations to the device.
+
+    set_tracer_boundary writes the host array, and a callable boundary is
+    re-evaluated every step; the per-step boundary push carries only the
+    hydrodynamic values, so this one has its own. One small array.
+    """
+    gpu_sync_tracer_boundary_to_device(&gpu_dom.GD)
 
 
 def sync_edge_values_from_device(GPUDomain gpu_dom):

--- a/anuga/shallow_water/tests/meson.build
+++ b/anuga/shallow_water/tests/meson.build
@@ -24,6 +24,7 @@ python_sources = [
 'test_tracers_distribute.py',
 'test_tracers_gpu.py',
 'test_tracers_gpu_boundary.py',
+'test_tracers_gpu_boundary_sync.py',
 'test_sediment_paths.py',
 'test_sediment_rdycore_erosion.py',
 'test_sediment_rdycore_benchmarks.py',

--- a/anuga/shallow_water/tests/test_tracers_gpu_boundary_sync.py
+++ b/anuga/shallow_water/tests/test_tracers_gpu_boundary_sync.py
@@ -1,0 +1,65 @@
+"""A tracer boundary value set AFTER the GPU interface exists reaches the device.
+
+The device copy of ``tracer_boundary_values`` is made once, when the arrays
+are mapped, and the per-step boundary push carries only the hydrodynamic
+values.  ``set_tracer_boundary`` wrote the host array and nothing else, so a
+concentration prescribed after ``set_multiprocessor_mode(2)`` was never seen
+by the flux kernel: every inflow edge kept injecting the zero-filled mapped
+copy, and mode 2 silently disagreed with mode 1 depending purely on call
+order.
+
+Only an offload build can show it -- on a CPU build the "device" array is the
+host array -- so this is a mode-1 vs mode-2 oracle in the style of
+test_tracers_gpu.py, with the same per-process isolation rule.
+"""
+
+import os
+import warnings
+
+import numpy as np
+import pytest
+
+import anuga
+from anuga import Dirichlet_boundary, Reflective_boundary, rectangular_cross_domain
+
+pytest.importorskip("anuga.shallow_water.sw_domain_gpu_ext")
+
+if anuga.gpu_offload_supported() and not os.environ.get("ANUGA_GPU_TESTS_ISOLATED"):
+    _skip_reason = (
+        "GPU-offload build: run this file via anuga_run_isolated_tests (one fresh "
+        "process per test); running it in one process aborts the NVHPC runtime."
+    )
+    warnings.warn(_skip_reason, stacklevel=1)
+    pytest.skip(_skip_reason, allow_module_level=True)
+
+
+def _run(mode):
+    d = rectangular_cross_domain(10, 10, len1=100.0, len2=100.0)
+    d.set_flow_algorithm("DE0")
+    d.store = False
+    d.set_quantity("elevation", 0.0)
+    d.set_quantity("stage", 1.0)
+    Br = Reflective_boundary(d)
+    d.set_boundary({"left": Dirichlet_boundary([1.5, 0.0, 0.0]), "right": Br, "top": Br, "bottom": Br})
+    d.add_tracer("c", beta=1.0)
+    d.set_tracer("c", 0.0)
+    # The interface is built here, with the boundary array still zero-filled.
+    d.set_multiprocessor_mode(mode)
+    assert d.multiprocessor_mode == mode, "mode %d did not engage" % mode
+    # ...and the concentration is prescribed only afterwards.
+    d.set_tracer_boundary("c", "left", 1.0)
+    m0 = d.get_tracer_mass("c")
+    for _ in d.evolve(yieldstep=0.5, finaltime=2.0):
+        pass
+    return d, d.get_tracer_mass("c") - m0
+
+
+def test_a_boundary_value_set_after_the_interface_exists_reaches_the_device():
+    cpu, gained_cpu = _run(1)
+    gpu, gained_gpu = _run(2)
+    assert gained_cpu > 0.0, "no tracer entered in mode 1"
+    # With the bug the device keeps the zero-filled copy and nothing enters.
+    assert gained_gpu > 0.5 * gained_cpu, "tracer inflow lost on the device: %r vs %r" % (gained_gpu, gained_cpu)
+    ma = cpu.tracer_conserved_values[0]
+    mb = gpu.tracer_conserved_values[0]
+    assert np.abs(ma - mb).max() < 1e-10


### PR DESCRIPTION
`set_tracer_boundary()` wrote the host `tracer_boundary_values` array and nothing else. The device
copy is made once, when the arrays are mapped, and `gpu_sync_boundary_values()` — the per-step push
the boundary evaluators use — carries only the hydrodynamic values. So a concentration prescribed
after the GPU interface existed was never seen by the flux kernel: every inflow edge kept injecting
the zero-filled mapped copy, and mode 2 silently disagreed with mode 1 depending purely on whether
`set_tracer_boundary()` ran before or after `set_multiprocessor_mode(2)`. (`add_tracer()` tears the
interface down and `set_tracer_source()` pushes; this one did neither.)

**Fix:** add `gpu_sync_tracer_boundary_to_device()` — one small array, mirroring the external-source
push — with its pyx wrapper, and call it from `Domain._push_tracer_boundary_to_device()` after every
host write: the end of `set_tracer_boundary()`, and the end of `update_tracer_boundary_values()` so
a re-evaluated callable reaches the device on the paths that call `update_boundary()`. A no-op off
the GPU path and on a domain without tracers.

**Test:** `test_tracers_gpu_boundary_sync.py` prescribes the inflow concentration *after*
`set_multiprocessor_mode(2)` and requires the mode-2 tracer field to match mode 1 to 1e-10. On the
unfixed build the device run gains exactly 0.0 tracer mass against 182.6 in mode 1.

Only visible on an offload build (on a CPU build the "device" array *is* the host array), hence the
same isolation rule as `test_tracers_gpu.py`.

---

**Second of three stacked PRs.** Based on `fix/gpu-tracer-boundary-length` so the diff shows only
this commit; GitHub retargets it to `develop` when that one merges.
