### PR TITLE
Fix whole-domain erosion silently doing nothing, and the base erosion operator crashing under DE (#301, #302)

### DIFF
--- a/anuga/operators/erosion_operators.py
+++ b/anuga/operators/erosion_operators.py
@@ -124,37 +124,38 @@ class Erosion_operator(Operator, Region):
 
         updated = True
 
+        #--------------------------------------
+        # `indices is None` means the whole domain -- see __call__'s
+        # docstring. This used to be a separate branch that added 0.0 to the
+        # elevation, so whole-domain erosion silently did nothing.
+        #--------------------------------------
         if self.indices is None:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            self.elev_c[:] = self.elev_c + 0.0
-
+            ind = num.arange(self.domain.number_of_elements)
         else:
-
-            #--------------------------------------
-            # Update each cell
-            # associated with self.indices
-            #--------------------------------------
             ind = self.indices
-            m = num.sqrt(self.xmom_c[ind]**2 + self.ymom_c[ind]**2)
 
-            if self.domain.get_using_discontinuous_elevation():
-                m = num.where(m>self.threshold, m, 0.0)
+        m = num.sqrt(self.xmom_c[ind]**2 + self.ymom_c[ind]**2)
 
-                de = m*dt
-                height = self.stage_c[ind] - self.elev_c[ind]
-                self.elev_c[ind] = num.amax(num.maximum(self.elev_v[ind] - de, self.base), axis=1)
-                self.stage_c[ind] = self.elev_c[ind] + height
-            else:
-                m = num.vstack((m,m,m)).T  # Stack up m to apply to vertices
-                m = num.where(m>self.threshold, m, 0.0)
+        if self.domain.get_using_discontinuous_elevation():
+            #--------------------------------------
+            # Elevation lives at the centroid, so erode the centroid value.
+            # This used to subtract the per-cell `de`, shape (n,), from the
+            # (n, 3) vertex array, which cannot broadcast.
+            #--------------------------------------
+            m = num.where(m>self.threshold, m, 0.0)
 
-                de = m*dt
-                self.elev_v[ind] = num.amax(num.maximum(self.elev_v[ind] - de, self.base), axis=1)
+            de = m*dt
+            height = self.stage_c[ind] - self.elev_c[ind]
+            self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
+            self.stage_c[ind] = self.elev_c[ind] + height
+        else:
+            m = num.vstack((m,m,m)).T  # Stack up m to apply to vertices
+            m = num.where(m>self.threshold, m, 0.0)
 
-            self.max_change = num.max(de)
+            de = m*dt
+            self.elev_v[ind] = num.maximum(self.elev_v[ind] - de, self.base)
+
+        self.max_change = num.max(de)
 
         return updated
 
@@ -600,78 +601,73 @@ class Bed_shear_erosion_operator(Erosion_operator):
 
         updated = True
 
+        #--------------------------------------
+        # `indices is None` means the whole domain -- see __call__'s
+        # docstring. This used to be a separate branch that added 0.0 to the
+        # elevation, so whole-domain erosion silently did nothing.
+        #--------------------------------------
         if self.indices is None:
+            ind = num.arange(self.domain.number_of_elements)
+        else:
+            ind = self.indices
+        shear_factor = self.shear_factor
 
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            self.elev_v[:] = self.elev_v + 0.0
+        # These arrays, m,d and v will be shape (len(ids),1)
+        m = num.sqrt(self.xmom_c[ind]**2 + self.ymom_c[ind]**2)  # abs Momentum
+        d= (self.stage_c[ind]-self.elev_c[ind]) # Depth
+
+        v = m / (d + 1.0e-10)  # Velocity = Momentum/Depth
+
+        #  ---- NOTE SCOUR or EROSION usually is determined by
+        #  Shear Stress = density*gravity*depth*bed_slope
+
+        bedslope = num.sqrt(self.elev_gx[ind]**2 + self.elev_gy[ind]**2)
+        EN_slope = num.sqrt(self.WLev_gx[ind]**2 + self.WLev_gy[ind]**2)
+
+        # Implement  Bed Shear term based on BED SLOPE
+        es=EN_slope
+        bedshearBs=1000*9.81*d*bedslope  # ro*g*h*bedslope , { Bed Slope  or  Energy Slope ??} in N/m**2
+        bsbs = bedshearBs
+
+        # Implement Bed Shear term based on ENERGY SLOPE
+        bedshearEs=1000*9.81*d*EN_slope  # ro*g*h*EN_slope , { Energy Slope ??}
+        bses = bedshearEs
+        froude = v / num.sqrt(9.81*(d+1.0e-10))
+        froude = m / 9.81**0.5 / (d+1.0e-10)**1.5  # Check that these are the same ??
+        factor = 9.8*bedslope
+
+        # elevation change increment
+        de = (bses / shear_factor)*dt  # Works OK...  Energy SLope
+        #de = bsbs/100000.0*dt  # Works OK...  Bed Slope
+
+
+        if self.domain.get_using_discontinuous_elevation():
+            height = self.stage_c[ind] - self.elev_c[ind]
+
+            limiting = v
+            # de will have a value of 0.0 (and hence no effect) if limiting <= threshold
+            de = num.where(limiting > self.threshold, de, 0.0)
+
+            # Ensure we don't erode below self.base level
+            self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
+
+            self.stage_c[ind] = self.elev_c[ind] + height
 
         else:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-
-            ind = self.indices
-            shear_factor = self.shear_factor
-
-            # These arrays, m,d and v will be shape (len(ids),1)
-            m = num.sqrt(self.xmom_c[ind]**2 + self.ymom_c[ind]**2)  # abs Momentum
-            d= (self.stage_c[ind]-self.elev_c[ind]) # Depth
-
-            v = m / (d + 1.0e-10)  # Velocity = Momentum/Depth
-
-            #  ---- NOTE SCOUR or EROSION usually is determined by
-            #  Shear Stress = density*gravity*depth*bed_slope
-
-            bedslope = num.sqrt(self.elev_gx[ind]**2 + self.elev_gy[ind]**2)
-            EN_slope = num.sqrt(self.WLev_gx[ind]**2 + self.WLev_gy[ind]**2)
-
-            # Implement  Bed Shear term based on BED SLOPE
-            es=EN_slope
-            bedshearBs=1000*9.81*d*bedslope  # ro*g*h*bedslope , { Bed Slope  or  Energy Slope ??} in N/m**2
-            bsbs = bedshearBs
-
-            # Implement Bed Shear term based on ENERGY SLOPE
-            bedshearEs=1000*9.81*d*EN_slope  # ro*g*h*EN_slope , { Energy Slope ??}
-            bses = bedshearEs
-            froude = v / num.sqrt(9.81*(d+1.0e-10))
-            froude = m / 9.81**0.5 / (d+1.0e-10)**1.5  # Check that these are the same ??
-            factor = 9.8*bedslope
-
-            # elevation change increment
-            de = (bses / shear_factor)*dt  # Works OK...  Energy SLope
-            #de = bsbs/100000.0*dt  # Works OK...  Bed Slope
+            # v needs to be stacked to get the right shape (len(ids),3)
+            #m  = num.vstack((m,m,m)).T
+            v  = num.vstack((v,v,v)).T
+            #bses = num.vstack((bses,bses,bses)).T
+            #es = num.vstack((es,es,es)).T
+            de = num.vstack((de,de,de)).T
 
 
-            if self.domain.get_using_discontinuous_elevation():
-                height = self.stage_c[ind] - self.elev_c[ind]
+            limiting = v # Make the limiting trigger Velocity? or Momentum... or Shear ??
+            # de will have a value of 0.0 (and hence no effect) if limiting <= threshold
+            de = num.where(limiting > self.threshold, de, 0.0)
 
-                limiting = v
-                # de will have a value of 0.0 (and hence no effect) if limiting <= threshold
-                de = num.where(limiting > self.threshold, de, 0.0)
-
-                # Ensure we don't erode below self.base level
-                self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
-
-                self.stage_c[ind] = self.elev_c[ind] + height
-
-            else:
-                # v needs to be stacked to get the right shape (len(ids),3)
-                #m  = num.vstack((m,m,m)).T
-                v  = num.vstack((v,v,v)).T
-                #bses = num.vstack((bses,bses,bses)).T
-                #es = num.vstack((es,es,es)).T
-                de = num.vstack((de,de,de)).T
-
-
-                limiting = v # Make the limiting trigger Velocity? or Momentum... or Shear ??
-                # de will have a value of 0.0 (and hence no effect) if limiting <= threshold
-                de = num.where(limiting > self.threshold, de, 0.0)
-
-                # Ensure we don't erode below self.base level
-                self.elev_v[ind] = num.maximum(self.elev_v[ind] - de, self.base)
+            # Ensure we don't erode below self.base level
+            self.elev_v[ind] = num.maximum(self.elev_v[ind] - de, self.base)
 
 
         return updated
@@ -729,35 +725,30 @@ class Flat_slice_erosion_operator(Erosion_operator):
 
         updated = True
 
+        #--------------------------------------
+        # `indices is None` means the whole domain -- see __call__'s
+        # docstring. This used to be a separate branch that added 0.0 to the
+        # elevation, so whole-domain erosion silently did nothing.
+        #--------------------------------------
         if self.indices is None:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            self.elev_v[:] = self.elev_v + 0.0
-
+            ind = num.arange(self.domain.number_of_elements)
         else:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-
             ind = self.indices
 
-            if self.domain.get_using_discontinuous_elevation():
-                try:
-                    height = self.stage_c[ind] - self.elev_c[ind]
-                    value = self.elevation(t)
-                    self.elev_c[ind] = num.where(self.elev_c[ind] >  value, value, self.elev_c[ind])
-                    self.stage_c[ind] = self.elev_c[ind] + height
-                except Exception:
-                    pass
-            else:
-                try:
-                    value = self.elevation(t)
-                    self.elev_v[ind] = num.where(self.elev_v[ind] >  value, value, self.elev_v[ind])
-                except Exception:
-                    pass
+        if self.domain.get_using_discontinuous_elevation():
+            try:
+                height = self.stage_c[ind] - self.elev_c[ind]
+                value = self.elevation(t)
+                self.elev_c[ind] = num.where(self.elev_c[ind] >  value, value, self.elev_c[ind])
+                self.stage_c[ind] = self.elev_c[ind] + height
+            except Exception:
+                pass
+        else:
+            try:
+                value = self.elevation(t)
+                self.elev_v[ind] = num.where(self.elev_v[ind] >  value, value, self.elev_v[ind])
+            except Exception:
+                pass
 
 
         return updated
@@ -816,44 +807,39 @@ class Flat_fill_slice_erosion_operator(Erosion_operator):
 
         updated = True
 
+        #--------------------------------------
+        # `indices is None` means the whole domain -- see __call__'s
+        # docstring. This used to be a separate branch that added 0.0 to the
+        # elevation, so whole-domain erosion silently did nothing.
+        #--------------------------------------
         if self.indices is None:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            self.elev_v[:] = self.elev_v + 0.0
-
+            ind = num.arange(self.domain.number_of_elements)
         else:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-
             ind = self.indices
 
-            if self.domain.get_using_discontinuous_elevation():
+        if self.domain.get_using_discontinuous_elevation():
 
-                try:
-                    value = self.elevation(t)
-                    height = self.stage_c[ind] - self.elev_c[ind]
-                    if value > num.max(self.elev_c[ind]):
-                        self.elev_c[ind] = num.where(self.elev_c[ind] <  value, value, self.elev_c[ind])
-                    else:
-                        self.elev_c[ind] = num.where(self.elev_c[ind] >  value, value, self.elev_c[ind])
-                    self.stage_c[ind] = self.elev_c[ind] + height
-                except Exception:
-                    pass
+            try:
+                value = self.elevation(t)
+                height = self.stage_c[ind] - self.elev_c[ind]
+                if value > num.max(self.elev_c[ind]):
+                    self.elev_c[ind] = num.where(self.elev_c[ind] <  value, value, self.elev_c[ind])
+                else:
+                    self.elev_c[ind] = num.where(self.elev_c[ind] >  value, value, self.elev_c[ind])
+                self.stage_c[ind] = self.elev_c[ind] + height
+            except Exception:
+                pass
 
-            else:
-                try:
-                    value = self.elevation(t)
-                    print(value)
-                    if value > num.max(self.elev_v[ind]):
-                        self.elev_v[ind] = num.where(self.elev_v[ind] <  value, value, self.elev_v[ind])
-                    else:
-                        self.elev_v[ind] = num.where(self.elev_v[ind] >  value, value, self.elev_v[ind])
-                except Exception:
-                    pass
+        else:
+            try:
+                value = self.elevation(t)
+                print(value)
+                if value > num.max(self.elev_v[ind]):
+                    self.elev_v[ind] = num.where(self.elev_v[ind] <  value, value, self.elev_v[ind])
+                else:
+                    self.elev_v[ind] = num.where(self.elev_v[ind] >  value, value, self.elev_v[ind])
+            except Exception:
+                pass
 
 
         return updated

--- a/anuga/operators/tests/test_erosion_operators.py
+++ b/anuga/operators/tests/test_erosion_operators.py
@@ -14,6 +14,7 @@ from anuga.file_conversion.file_conversion import timefile2netcdf
 from anuga.config import time_format
 
 from anuga.operators.erosion_operators import Erosion_operator
+from anuga.operators.erosion_operators import Flat_slice_erosion_operator
 
 from pprint import pprint
 
@@ -181,6 +182,122 @@ class Test_circular_operators(unittest.TestCase):
             os.remove('domain.sww')
         except OSError:
             pass
+
+    # ------------------------------------------------------------------
+    # Regressions for #301 (whole-domain erosion was a silent no-op) and
+    # #302 (the base operator crashed under discontinuous elevation).
+    # ------------------------------------------------------------------
+
+    def _sloping_channel(self, name):
+        """A channel with flow, so an erosion operator has something to do."""
+        L, W = 100.0, 20.0
+        d = rectangular_cross_domain(30, 6, L, W, origin=(0.0, 0.0))
+        d.set_quantity('elevation', lambda x, y: 5.0 - 0.05 * x)
+        d.set_quantity('friction', 0.03)
+        d.set_quantity('stage', expression='elevation')
+        d.set_flow_algorithm('DE1')
+        d.set_datadir('.')
+        d.set_name(name)
+        d.set_quantities_to_be_stored(None)
+        d.set_boundary({'left': anuga.Dirichlet_boundary([5.5, 2.0, 0.0]),
+                        'right': anuga.Transmissive_boundary(d),
+                        'top': Reflective_boundary(d),
+                        'bottom': Reflective_boundary(d)})
+        return d
+
+    def test_polygonal_erosion_runs_under_discontinuous_elevation(self):
+        """#302: the base update_quantities subtracted a per-cell (n,) array
+        from the (n, 3) vertex array, which cannot broadcast. Every supported
+        flow algorithm uses discontinuous elevation, so this crashed always."""
+        from anuga.operators.erosion_operators import Polygonal_erosion_operator
+
+        d = self._sloping_channel('test_302')
+        self.assertTrue(d.get_using_discontinuous_elevation())
+        Polygonal_erosion_operator(
+            d, polygon=[[0.0, 0.0], [100.0, 0.0], [100.0, 20.0], [0.0, 20.0]])
+
+        z0 = d.quantities['elevation'].centroid_values.copy()
+        for t in d.evolve(yieldstep=30.0, finaltime=90.0):
+            pass
+        dz = d.quantities['elevation'].centroid_values - z0
+
+        assert dz.min() < -1.0e-3, 'the operator ran but eroded nothing'
+
+    def test_erosion_never_raises_the_bed(self):
+        """An erosion operator must not deposit.
+
+        Taking amax over the vertex values pulls the centroid up to its
+        highest vertex, which under discontinuous elevation can sit above the
+        centroid -- so the bed gains height where it should only lose it.
+
+        Runs to 180 s deliberately: with amax the bed still looks well behaved
+        at 120 s and only starts gaining height after that, so a shorter run
+        does not discriminate.
+        """
+        from anuga.operators.erosion_operators import Polygonal_erosion_operator
+
+        d = self._sloping_channel('test_302_rise')
+        Polygonal_erosion_operator(
+            d, polygon=[[0.0, 0.0], [100.0, 0.0], [100.0, 20.0], [0.0, 20.0]])
+
+        z0 = d.quantities['elevation'].centroid_values.copy()
+        for t in d.evolve(yieldstep=30.0, finaltime=180.0):
+            pass
+        dz = d.quantities['elevation'].centroid_values - z0
+
+        assert dz.max() <= 1.0e-10, (
+            'bed rose by %g m under an erosion operator' % dz.max())
+
+    def test_erosion_respects_the_base_level(self):
+        """Erosion stops at `base`, however long it runs."""
+        from anuga.operators.erosion_operators import Polygonal_erosion_operator
+
+        d = self._sloping_channel('test_302_base')
+        Polygonal_erosion_operator(
+            d, polygon=[[0.0, 0.0], [100.0, 0.0], [100.0, 20.0], [0.0, 20.0]],
+            base=1.0)
+
+        for t in d.evolve(yieldstep=30.0, finaltime=90.0):
+            pass
+
+        z = d.quantities['elevation'].centroid_values
+        assert z.min() >= 1.0 - 1.0e-10, 'eroded below base: %g' % z.min()
+
+    def _flat_slice_run(self, polygon, name):
+        d = rectangular_cross_domain(20, 6, 100.0, 20.0, origin=(0.0, 0.0))
+        d.set_quantity('elevation', 2.0)
+        d.set_quantity('stage', 4.0)
+        d.set_quantity('friction', 0.03)
+        d.set_flow_algorithm('DE1')
+        d.set_datadir('.')
+        d.set_name(name)
+        d.set_quantities_to_be_stored(None)
+        R = Reflective_boundary(d)
+        d.set_boundary({'left': R, 'right': R, 'top': R, 'bottom': R})
+        Flat_slice_erosion_operator(d, elevation=lambda t: 0.0, polygon=polygon)
+        for t in d.evolve(yieldstep=25.0, finaltime=50.0):
+            pass
+        return d.quantities['elevation'].centroid_values.mean()
+
+    def test_whole_domain_erosion_is_not_a_no_op(self):
+        """#301: `indices is None` is documented as "all triangles", but took
+        a branch that added 0.0 and returned, so the bed never moved."""
+        whole = self._flat_slice_run(None, 'test_301_none')
+        assert whole < 2.0 - 1.0e-6, (
+            'polygon=None left the bed at %g m -- whole-domain erosion did '
+            'nothing' % whole)
+
+    def test_whole_domain_erodes_at_least_as_much_as_a_polygon(self):
+        """The None path and an explicit covering polygon must agree in kind.
+
+        The polygon cannot beat the whole domain: it covers a subset.
+        """
+        whole = self._flat_slice_run(None, 'test_301_a')
+        poly = self._flat_slice_run(
+            [[1.0, 1.0], [99.0, 1.0], [99.0, 19.0], [1.0, 19.0]], 'test_301_b')
+        assert whole <= poly + 1.0e-10, (
+            'whole domain (%g m) eroded less than a polygon inside it (%g m)'
+            % (whole, poly))
 
     def test_circular_rate_operator(self):
         """Circular_rate_operator constructs and calls without raising."""


### PR DESCRIPTION
Fixes #301 and #302. Both reported by @Dr-Shoznum with clean reproductions, both confirmed exactly as described.

## #301 — whole-domain erosion was a silent no-op

`Erosion_operator.__call__` documents `indices is None` as *"all triangles are modified"*, but `update_quantities` took a separate branch that added `0.0` to the elevation and returned:

```python
if self.indices is None:
    self.elev_c[:] = self.elev_c + 0.0     # the comment says "update all three vertices"
else:
    ...                                     # the branch that actually erodes
```

No error, no warning, and a `.sww` whose bed is unchanged — indistinguishable from "the model said nothing eroded". Present in the base class and in the three subclasses that override `update_quantities`.

All four now resolve `None` to every triangle and run the same path as the polygon case. That is what `Sanddune_erosion_operator` already does, comment included:

```python
# None means "apply to the entire domain" (Region/Operator convention).
ind = num.arange(self.domain.number_of_elements)
```

Before / after, slicing a flat 2 m bed down to 0 m under still water:

| | before | after |
|---|---|---|
| `polygon=None` | 2.0000 → **2.0000 m** | 2.0000 → **0.0000 m** |
| explicit covering polygon | 2.0000 → 0.2167 m | 2.0000 → 0.2167 m |

## #302 — the base operator could not run at all

```
ValueError: operands could not be broadcast together with shapes (720,3) (720,)
```

`de` is per-cell, shape `(n,)`; it was subtracted from `self.elev_v[ind]`, shape `(n, 3)`.

This is broader than "under DE algorithms". Every algorithm this version offers is a DE algorithm — `DE0, DE1, DE2, DE0_7, DE1_7, DE_ader2` — and all six report `get_using_discontinuous_elevation() == True`. Forcing it off does not help either: `update_conserved_quantities` asserts on it. So the other branch is unreachable, and `Polygonal_erosion_operator` and `Circular_erosion_operator` could not run in **any** supported configuration.

### Why not the suggested `de[:, None]`

The issue suggests giving `de` a trailing axis and keeping the surrounding `num.amax(..., axis=1)`. That fixes the crash, but the `amax` is not a shape detail: it sets the centroid to the **highest of its three vertices**, which under discontinuous elevation can sit above the centroid. The bed then gains height.

Measured on the reporter’s own reproduction, 180 s:

| | max scour | max bed **rise** |
|---|---|---|
| `amax(elev_v - de[:, None])` | 0.6932 m | **+0.5083 m** |
| `elev_c - de` (this PR) | 4.9722 m | −0.0278 m (i.e. none) |

An erosion operator that deposits is worse than one that crashes. `elev_c - de` is also what three implementations already in the tree do: `Bed_shear_erosion_operator` in the same file, `Sanddune_erosion_operator`, and the override in `examples/operators/run_polygon_erosion.py`.

The same bogus `amax` was in the continuous branch, assigning an `(n,)` result into an `(n, 3)` array. Corrected to match, though that branch is unreachable and therefore untested.

## Why this went unnoticed

`examples/operators/run_polygon_erosion.py` subclasses `Polygonal_erosion_operator` and **overrides `update_quantities` with a working implementation**, so the shipped example never exercises the broken base method.

## Tests

Five regression tests in `test_erosion_operators.py`, each verified to fail against the code it pins — including against the issue’s suggested fix, not just against the original:

- whole-domain erosion is not a no-op, and is at least as strong as a polygon inside it (#301)
- the base operator runs and erodes under DE1 (#302)
- the bed never rises under an erosion operator
- `base` is respected

The bed-rise test runs to 180 s deliberately: with the `amax` the bed still looks well behaved at 120 s, so a shorter run does not discriminate.

## Verification

- 2998 passed, 254 skipped (fast); 242 passed, 11 skipped (slow)
- `ruff` clean
- all four `examples/operators/run_*_erosion.py` run to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)