### PR TITLE
base must limit erosion, not lift a bed that starts below it (#305)

### DIFF
--- a/anuga/operators/erosion_operators.py
+++ b/anuga/operators/erosion_operators.py
@@ -146,14 +146,18 @@ class Erosion_operator(Operator, Region):
 
             de = m*dt
             height = self.stage_c[ind] - self.elev_c[ind]
-            self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
+            self.elev_c[ind] = num.minimum(
+                self.elev_c[ind],
+                num.maximum(self.elev_c[ind] - de, self.base))
             self.stage_c[ind] = self.elev_c[ind] + height
         else:
             m = num.vstack((m,m,m)).T  # Stack up m to apply to vertices
             m = num.where(m>self.threshold, m, 0.0)
 
             de = m*dt
-            self.elev_v[ind] = num.maximum(self.elev_v[ind] - de, self.base)
+            self.elev_v[ind] = num.minimum(
+                self.elev_v[ind],
+                num.maximum(self.elev_v[ind] - de, self.base))
 
         self.max_change = num.max(de)
 
@@ -649,7 +653,9 @@ class Bed_shear_erosion_operator(Erosion_operator):
             de = num.where(limiting > self.threshold, de, 0.0)
 
             # Ensure we don't erode below self.base level
-            self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
+            self.elev_c[ind] = num.minimum(
+                self.elev_c[ind],
+                num.maximum(self.elev_c[ind] - de, self.base))
 
             self.stage_c[ind] = self.elev_c[ind] + height
 
@@ -667,7 +673,9 @@ class Bed_shear_erosion_operator(Erosion_operator):
             de = num.where(limiting > self.threshold, de, 0.0)
 
             # Ensure we don't erode below self.base level
-            self.elev_v[ind] = num.maximum(self.elev_v[ind] - de, self.base)
+            self.elev_v[ind] = num.minimum(
+                self.elev_v[ind],
+                num.maximum(self.elev_v[ind] - de, self.base))
 
 
         return updated

--- a/anuga/operators/sanddune_erosion_operator.py
+++ b/anuga/operators/sanddune_erosion_operator.py
@@ -234,8 +234,11 @@ class Sanddune_erosion_operator(Operator, Region)  :
             # no scour though if Tau_bed < Tau_crit ie if de is <= 0
             de = num.where(de > 0.0, de, 0.0)                                    # de=de whenever de>0 vector
 
-            # Also ensure we don't erode below the base surface level
-            self.elev_c[ind] = num.maximum(elev_c_ind - de, base_ind )
+            # Also ensure we don't erode below the base surface level.
+            # The outer minimum keeps this a LIMIT on erosion: without it a bed
+            # that already sits below base_ind is lifted up to it.
+            self.elev_c[ind] = num.minimum(
+                elev_c_ind, num.maximum(elev_c_ind - de, base_ind))
 
             #-------------------------------------------------------------------------------------------
             # Reduce triangles elevations in any area where erosion has created unstable face slopes, so

--- a/anuga/operators/tests/test_erosion_operators.py
+++ b/anuga/operators/tests/test_erosion_operators.py
@@ -249,7 +249,12 @@ class Test_circular_operators(unittest.TestCase):
             'bed rose by %g m under an erosion operator' % dz.max())
 
     def test_erosion_respects_the_base_level(self):
-        """Erosion stops at `base`, however long it runs."""
+        """Erosion stops at `base`, however long it runs.
+
+        Only cells that START above `base` are constrained by it. This channel
+        runs from 5 m down to 0 m, so its downstream end begins below
+        `base=1.0`; those cells must be left where they are, not lifted (#305).
+        """
         from anuga.operators.erosion_operators import Polygonal_erosion_operator
 
         d = self._sloping_channel('test_302_base')
@@ -257,11 +262,17 @@ class Test_circular_operators(unittest.TestCase):
             d, polygon=[[0.0, 0.0], [100.0, 0.0], [100.0, 20.0], [0.0, 20.0]],
             base=1.0)
 
+        z0 = d.quantities['elevation'].centroid_values.copy()
         for t in d.evolve(yieldstep=30.0, finaltime=90.0):
             pass
-
         z = d.quantities['elevation'].centroid_values
-        assert z.min() >= 1.0 - 1.0e-10, 'eroded below base: %g' % z.min()
+
+        above = z0 >= 1.0
+        assert above.any() and (~above).any(), 'the case must cover both sides'
+        assert z[above].min() >= 1.0 - 1.0e-10, (
+            'eroded below base: %g' % z[above].min())
+        assert num.allclose(z[~above], z0[~above]), (
+            'cells starting below base were moved')
 
     def _flat_slice_run(self, polygon, name):
         d = rectangular_cross_domain(20, 6, 100.0, 20.0, origin=(0.0, 0.0))
@@ -298,6 +309,48 @@ class Test_circular_operators(unittest.TestCase):
         assert whole <= poly + 1.0e-10, (
             'whole domain (%g m) eroded less than a polygon inside it (%g m)'
             % (whole, poly))
+
+    def test_base_does_not_lift_a_bed_that_starts_below_it(self):
+        """#305: `base` limits erosion -- "Allow erosion down to base level".
+
+        Applied as a bare maximum it also LIFTS a bed that starts below it, so
+        the operator deposits on its first call with no flow involved.
+        """
+        from anuga.operators.erosion_operators import (
+            Polygonal_erosion_operator, Circular_erosion_operator,
+            Bed_shear_erosion_operator)
+
+        poly = [[2.0, 2.0], [18.0, 2.0], [18.0, 8.0], [2.0, 8.0]]
+        makers = [
+            ('Polygonal', lambda d: Polygonal_erosion_operator(
+                d, base=0.0, polygon=poly)),
+            ('Circular', lambda d: Circular_erosion_operator(
+                d, base=0.0, center=(10.0, 5.0), radius=5.0)),
+            ('Bed_shear', lambda d: Bed_shear_erosion_operator(
+                d, base=0.0, polygon=poly)),
+        ]
+
+        for name, make in makers:
+            d = rectangular_cross_domain(20, 10, 20.0, 10.0)
+            d.set_quantity('elevation', -0.5)      # everywhere BELOW base
+            d.set_quantity('stage', 1.0)
+            d.set_quantity('friction', 0.03)
+            d.set_flow_algorithm('DE1')
+            d.set_datadir('.')
+            d.set_name('test_305_' + name)
+            d.set_quantities_to_be_stored(None)
+            R = Reflective_boundary(d)
+            d.set_boundary({'left': R, 'right': R, 'top': R, 'bottom': R})
+            make(d)
+
+            z0 = d.quantities['elevation'].centroid_values.copy()
+            for t in d.evolve(yieldstep=2.0, finaltime=4.0):
+                pass
+            dz = d.quantities['elevation'].centroid_values - z0
+
+            assert dz.max() <= 1.0e-10, (
+                '%s raised a bed already below base by %g m'
+                % (name, dz.max()))
 
     def test_circular_rate_operator(self):
         """Circular_rate_operator constructs and calls without raising."""

--- a/anuga/operators/tests/test_sanddune_erosion_operator.py
+++ b/anuga/operators/tests/test_sanddune_erosion_operator.py
@@ -44,6 +44,33 @@ class Test_sanddune_erosion_operator(unittest.TestCase):
     def setUp(self):
         self.domain = make_domain()
 
+    def test_base_does_not_lift_a_bed_that_starts_below_it(self):
+        """#305: `base` is a limit on erosion, not a level to restore to.
+
+        Applied as a bare maximum it lifts a bed that already sits below it.
+        """
+        d = anuga.rectangular_cross_domain(20, 10, 20.0, 10.0)
+        d.set_quantity('elevation', -0.5)          # everywhere BELOW base
+        d.set_quantity('stage', 1.0)
+        d.set_quantity('friction', 0.03)
+        d.set_flow_algorithm('DE1')
+        d.set_datadir('.')
+        d.set_name('test_305_sanddune')
+        d.set_quantities_to_be_stored(None)
+        R = Reflective_boundary(d)
+        d.set_boundary({'left': R, 'right': R, 'top': R, 'bottom': R})
+        Sanddune_erosion_operator(
+            d, base=0.0,
+            polygon=[[2.0, 2.0], [18.0, 2.0], [18.0, 8.0], [2.0, 8.0]])
+
+        z0 = d.quantities['elevation'].centroid_values.copy()
+        for t in d.evolve(yieldstep=2.0, finaltime=4.0):
+            pass
+        dz = d.quantities['elevation'].centroid_values - z0
+
+        assert dz.max() <= 1.0e-10, (
+            'raised a bed already below base by %g m' % dz.max())
+
     def test_whole_domain_scalar_base_runs(self):
         """indices=None + default scalar base: previously crashed, now runs.
 

--- a/examples/operators/run_polygon_erosion.py
+++ b/examples/operators/run_polygon_erosion.py
@@ -42,69 +42,17 @@ def topography(x,y):
 
 
 #-------------------------------------------------------------------------------
-# Inherit from erosion operator
+# Erosion operator
 #-------------------------------------------------------------------------------
+# This used to subclass Polygonal_erosion_operator and re-implement
+# update_quantities(), because the library version could not run under
+# discontinuous elevation -- every DE algorithm -- and silently did nothing
+# without a polygon (anuga-community/anuga_core#301, #302). Both are fixed, and
+# the library operator now produces a bed identical to the copy that lived here,
+# so the copy is gone. It also keeps max_change up to date, which the override
+# never did: print_operator_timestepping_statistics() reported
+# "max(Delta Elev) 0" at every step regardless of what the bed was doing.
 from anuga.operators.erosion_operators import Polygonal_erosion_operator
-
-class My_polygon_erosion_operator(Polygonal_erosion_operator):
-    """
-    Local version of erosion confined to a polygon
-
-    """
-
-    def __init__(self, domain,
-                 threshold=0.0,
-                 base=0.0,
-                 polygon=None,
-                 verbose=False):
-
-
-        Polygonal_erosion_operator.__init__(self, domain, threshold, base, polygon, verbose)
-
-
-
-    def update_quantities(self):
-        """Update the vertex values of the quantities to model erosion
-        """
-        import numpy as num
-        
-        t = self.get_time()
-        dt = self.get_timestep()
-
-        updated = True
-
-        if self.indices is None:
-
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            self.elev_v[:] = self.elev_v + 0.0
-
-        else:
-            ind = self.indices
-            m = num.sqrt(self.xmom_c[ind]**2 + self.ymom_c[ind]**2)
-            
-            if self.domain.get_using_discontinuous_elevation():
-                height = self.stage_c[ind] - self.elev_c[ind]
-                
-                m = num.where(m>self.threshold, m, 0.0)
-                self.elev_c[ind] = num.maximum(self.elev_c[ind] - m*dt, self.base)
-
-                self.stage_c[ind] = self.elev_c[ind] + height
-            else:
-            #--------------------------------------
-            # Update all three vertices for each cell
-            #--------------------------------------
-            
-            
-                m = num.vstack((m,m,m)).T
-                m = num.where(m>self.threshold, m, 0.0)
-                self.elev_v[ind] = num.maximum(self.elev_v[ind] - m*dt, self.base)
-                #num.maximum(self.elev_v[ind] - momentum*dt, Z)
-
-
-        return updated
-
 
 
 #===============================================================================
@@ -154,7 +102,7 @@ domain.set_boundary({'left': Bi, 'right': Bo, 'top': Br, 'bottom': Br})
 # Setup erosion operator in the middle of dam
 #-------------------------------------------------------------------------------
 polygon1 = [ [12., 0.0], [13., 0.0], [13., 5.0], [12., 5.0] ]
-op1 = My_polygon_erosion_operator(domain, threshold=0.0, base=-0.1, polygon=polygon1)
+op1 = Polygonal_erosion_operator(domain, threshold=0.0, base=-0.1, polygon=polygon1)
 
 
 


### PR DESCRIPTION
Fixes #305.

## The bug

`Erosion_operator`’s class docstring says:

> `base`: Allow erosion down to base level

but the clamp was a bare maximum, so a bed *already below* `base` was pulled **up** to it on the first call, with no flow involved:

```python
self.elev_c[ind] = num.maximum(self.elev_c[ind] - de, self.base)
```

A flat bed at −0.5 m, `base = 0.0`, still water — nothing should move:

| Operator | max bed rise |
|---|---|
| `Polygonal_erosion_operator` | **+0.5000 m** |
| `Circular_erosion_operator` | **+0.5000 m** |
| `Bed_shear_erosion_operator` | **+0.5000 m** |
| `Sanddune_erosion_operator` | **+0.5000 m** |
| `Flat_slice_erosion_operator` | +0.0000 m (does not use `base`) |

## The fix

An outer `minimum`, at all five clamp sites — both branches of `Erosion_operator.update_quantities`, both of `Bed_shear_erosion_operator`’s, and the one in `Sanddune_erosion_operator`:

```python
self.elev_c[ind] = num.minimum(self.elev_c[ind],
                               num.maximum(self.elev_c[ind] - de, self.base))
```

A bed above `base` erodes and stops there exactly as before; a bed already below it is left alone.

## A test from #304 had encoded the old behaviour

`test_erosion_respects_the_base_level` asserted that no cell ends below `base`. That held only *because* of the lift: the test channel runs 5 m → 0 m, so its downstream end starts below `base = 1.0` and was being raised. With this fix it fails.

It now checks the real contract — cells that start above `base` stop there, cells that start below it do not move — and asserts the case actually covers both sides, so it cannot silently degenerate again.

## Example cleanup

`examples/operators/run_polygon_erosion.py` carried a hand-copied `update_quantities`, written because the library version could not run under discontinuous elevation (#302) and did nothing without a polygon (#301). With those fixed, the library operator produces a **bit-identical bed** — verified on the example’s own topography and boundaries — so the copy is gone (−72 lines).

The copy also never set `self.max_change`, so `print_operator_timestepping_statistics()` reported `max(Delta Elev) 0` at every one of 301 steps. It now reports real values:

```
before: 1 distinct value  (0, always)
after:  301 distinct values, e.g. 0.00014319997755719648
```

## Not a regression from #304

The same bare `num.maximum(..., self.base)` is in the pre-#304 code, in `Sanddune_erosion_operator`, and in that example override. Found while probing the operators after #304 merged.

## Tests

Two new regression tests, both verified to fail with the bare clamp restored:

- `test_base_does_not_lift_a_bed_that_starts_below_it` — `Polygonal`, `Circular` and `Bed_shear`
- the same for `Sanddune_erosion_operator`

## Verification

- 3000 passed, 254 skipped (fast)
- `ruff` clean
- `run_polygon_erosion.py` runs to completion and now reports real erosion depths

🤖 Generated with [Claude Code](https://claude.com/claude-code)