### PR TITLE
Docs: tell developers to check out develop, and which docs match which branch

### DIFF
--- a/docs/source/installation/install_anuga_developers.rst
+++ b/docs/source/installation/install_anuga_developers.rst
@@ -39,6 +39,33 @@ This creates a directory `anuga_core`.
 
         git clone git@github.com:anuga-community/anuga_core.git
 
+Choose a branch
+^^^^^^^^^^^^^^^
+
+The clone leaves you on ``main``, which is the released line -- currently
+ANUGA 4.0.0. Work that has not been released yet lives on ``develop``:
+
+.. code-block:: bash
+
+    cd anuga_core
+    git checkout develop
+
+Take ``develop`` if you want the passive tracer and sediment transport
+modules, :ref:`tracers` and :ref:`sediment`, which are not in 4.0.0 and are
+the parts we would most like tested before the next release. Stay on ``main``
+if you want the released code.
+
+.. note::
+
+    The documentation is published for both branches, and they describe
+    different code:
+
+    * https://anuga.readthedocs.io/en/latest/ follows ``main``
+    * https://anuga.readthedocs.io/en/develop/ follows ``develop``
+
+    Read the one that matches the branch you built, or the API you find in
+    the documentation may not be the API you have installed.
+
 Install ANUGA using Script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Small docs fix, but it currently blocks the thing we are asking users to do.

## The problem

`install_anuga_developers.rst` says:

```bash
git clone https://github.com/anuga-community/anuga_core.git
```

and goes straight on to building. The repository’s default branch is `main`, so a user who follows the page verbatim gets **4.0.0** — with no passive tracers and no sediment transport. Those are exactly the modules we would like tested before v4.1.0, and there is nothing on the page telling anyone to switch branches.

## The change

A short "Choose a branch" section after the clone:

```bash
cd anuga_core
git checkout develop
```

with a sentence on why you would (tracers and sediment, not in 4.0.0) and why you might not (stay on `main` for released code).

Plus a note that the documentation is published for **both** branches and they describe different code:

* https://anuga.readthedocs.io/en/latest/ follows `main`
* https://anuga.readthedocs.io/en/develop/ follows `develop`

That distinction matters right now rather than in the abstract: the sediment entry point differs between the two branches, so a reader on the wrong version of the docs will find an API that is not the one they installed.

## Verification

- Sphinx builds with **0 warnings**
- The `:ref:` links to *Passive Tracers* and *Sediment transport* both resolve
- Section renders as intended under "Download ANUGA from github"

🤖 Generated with [Claude Code](https://claude.com/claude-code)