### PR TITLE
install_anuga_nvc.sh: stop looking like a hang on a GPU-less login node, and stop implying gpu_aware_mpi is a detection

### DIFF
--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -247,6 +247,16 @@ if [ "$GPU_ARCH" = "auto" ]; then
         # both, the CUDA 13 default must be overridden explicitly.  So ASK the
         # compiler: try the widest list first and keep the first that builds.
         echo "# GPU_ARCH=auto -> no GPU visible here; probing what this nvc can build."
+        echo "#"
+        echo "#   NOTE: this is the SLOW path, and it is the usual one on a login"
+        echo "#   node. Probing compiles a test file once per candidate list, and"
+        echo "#   the build that follows then generates device code for EVERY"
+        echo "#   architecture in the winning list -- up to seven. Expect tens of"
+        echo "#   minutes, with long silences from nvc. It is working, not hung."
+        echo "#"
+        echo "#   If you know the compute nodes you are targeting, naming them is"
+        echo "#   much faster, e.g. GPU_ARCH=cc80 (A100) or GPU_ARCH=cc90 (H100)."
+        echo "#"
         ALL="cc75,cc80,cc86,cc89,cc90,cc120"
         GPU_ARCH=""
         for CANDIDATE in "cc70,${ALL}" \

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -171,11 +171,32 @@ arch_compiles() {
     return $rc
 }
 
+# nvidia-smi is the only way we have to see a GPU, and it is not always
+# cheap: on a node with no driver, or a driver in a bad state, it can block
+# for a long time instead of failing.  Probe ONCE, under a timeout, and reuse
+# the answer -- the script used to call it three times with no timeout, which
+# on an HPC login node looks exactly like a hang.
+nvidia_smi_query() {
+    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 10 nvidia-smi --query-gpu="$1" --format=csv,noheader 2>/dev/null
+    else
+        nvidia-smi --query-gpu="$1" --format=csv,noheader 2>/dev/null
+    fi
+}
+
+GPU_NAME_PROBE="$(nvidia_smi_query name | head -1)"
+if [ -n "$GPU_NAME_PROBE" ]; then
+    HAVE_GPU=1
+else
+    HAVE_GPU=0
+fi
+
 GPU_ARCH_EXPLICIT=1
 [ "$GPU_ARCH" = "auto" ] && GPU_ARCH_EXPLICIT=0
 
 if [ "$GPU_ARCH" = "auto" ]; then
-    CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')
+    CAP=$(nvidia_smi_query compute_cap | head -1 | tr -d ' ')
     if [[ "$CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
         GPU_ARCH="cc${CAP//./}"
         echo "# GPU_ARCH=auto -> ${GPU_ARCH} (detected: compute capability ${CAP})"
@@ -385,7 +406,12 @@ echo "#============================================================"
 echo "# Building ANUGA with GPU offloading"
 echo "#   CC=$NVC"
 echo "#   CXX=${CXX:-<system default; no C++ sources today>}"
-echo "#   gpu_offload=true  gpu_arch=${GPU_ARCH}  gpu_aware_mpi=${GPU_AWARE_MPI:-0}"
+echo "#   gpu_offload=true  gpu_arch=${GPU_ARCH}"
+echo "#   gpu_aware_mpi=${GPU_AWARE_MPI:-0}  (halo BUFFER allocation only --"
+echo "#     ANUGA never hands device pointers to MPI, on either setting, so"
+echo "#     this says nothing about whether your MPI is CUDA-aware.  A 0 here"
+echo "#     is not a failed detection: it is the default, and it is unrelated"
+echo "#     to what 'ompi_info | grep cuda' reports.  See issue #223.)"
 echo "#============================================================"
 echo " "
 
@@ -518,29 +544,10 @@ if ! $CONDA_RUN python "${ANUGA_CORE_PATH}/tools/anuga_build_report.py" --check;
 fi
 echo " "
 
-echo "#============================================================"
-echo "# Running GPU test suite (isolated runner)"
-echo "#   One fresh process per test.  A plain 'pytest' on this file"
-echo "#   auto-skips on a GPU build: the NVHPC OpenMP-target runtime"
-echo "#   aborts once many mode-2 GPU domains are created in a single"
-echo "#   process, so the tests must each run in their own process."
-echo "#   scripts/anuga_run_isolated_tests.py defaults to test_DE_gpu_omp.py"
-echo "#   and opts in via ANUGA_GPU_TESTS_ISOLATED=1.  Run the script"
-echo "#   directly (not the installed console command, which an editable"
-echo "#   'pip install -e .' does not place on PATH)."
-echo "#============================================================"
-echo " "
-
 # Do not run the GPU tests where there is no GPU.  The usual case is an HPC
 # login node: every test would fail or skip after a long wait, and running a
 # heavy suite there is antisocial (many sites forbid it outright).  The build is
 # still complete and usable -- the tests just have to happen where the GPUs are.
-HAVE_GPU=0
-if nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1 && \
-   [ -n "$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)" ]; then
-    HAVE_GPU=1
-fi
-
 if [ "${SKIP_TESTS:-0}" = "1" ]; then
     echo "SKIP_TESTS=1 - skipping the GPU test suite."
 elif [ "$HAVE_GPU" = "0" ] && [ "${FORCE_TESTS:-0}" != "1" ]; then
@@ -562,6 +569,18 @@ elif [ "$HAVE_GPU" = "0" ] && [ "${FORCE_TESTS:-0}" != "1" ]; then
     echo "# FORCE_TESTS=1 runs them here regardless."
     echo "#=================================================================="
 else
+    echo "#============================================================"
+    echo "# Running GPU test suite (isolated runner)"
+    echo "#   One fresh process per test.  A plain 'pytest' on this file"
+    echo "#   auto-skips on a GPU build: the NVHPC OpenMP-target runtime"
+    echo "#   aborts once many mode-2 GPU domains are created in a single"
+    echo "#   process, so the tests must each run in their own process."
+    echo "#   scripts/anuga_run_isolated_tests.py defaults to test_DE_gpu_omp.py"
+    echo "#   and opts in via ANUGA_GPU_TESTS_ISOLATED=1.  Run the script"
+    echo "#   directly (not the installed console command, which an editable"
+    echo "#   'pip install -e .' does not place on PATH)."
+    echo "#============================================================"
+    echo " "
     $CONDA_RUN \
         python "${ANUGA_CORE_PATH}/scripts/anuga_run_isolated_tests.py"
 fi

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -182,7 +182,7 @@ arch_compiles() {
 # with no timeout, right after announcing the test suite, which is
 # indistinguishable from a hung test run. Probe ONCE, bounded, and reuse it.
 nvidia_smi_query() {
-    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    command -v nvidia-smi >/dev/null 2>&1 || return 1
     if command -v timeout >/dev/null 2>&1; then
         timeout 10 nvidia-smi --query-gpu="$1" --format=csv,noheader 2>/dev/null
     else
@@ -193,7 +193,19 @@ nvidia_smi_query() {
 if command -v nvidia-smi >/dev/null 2>&1; then
     echo "# Looking for a GPU (nvidia-smi)..."
 fi
+# Require BOTH a zero exit status and a plausible device name. Exit status
+# alone is not enough (some builds report success with an empty list), and a
+# non-empty line alone is not enough either: a failing nvidia-smi may still
+# print something -- "[Not Supported]", "[N/A]", or an error -- on stdout,
+# which a bare -n test reads as a GPU and sends the script on to run the GPU
+# test suite on a machine that has none.
 GPU_NAME_PROBE="$(nvidia_smi_query name | head -1)"
+GPU_PROBE_RC=$?
+case "$GPU_NAME_PROBE" in
+    ''|'['*|*'Not Supported'*|*'N/A'*|*'failed'*|*'Error'*|*'error'*)
+        GPU_NAME_PROBE="" ;;
+esac
+[ "$GPU_PROBE_RC" -ne 0 ] && GPU_NAME_PROBE=""
 if [ -n "$GPU_NAME_PROBE" ]; then
     HAVE_GPU=1
     echo "# GPU detected: ${GPU_NAME_PROBE}"

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -199,8 +199,12 @@ fi
 # print something -- "[Not Supported]", "[N/A]", or an error -- on stdout,
 # which a bare -n test reads as a GPU and sends the script on to run the GPU
 # test suite on a machine that has none.
-GPU_NAME_PROBE="$(nvidia_smi_query name | head -1)"
+# NB capture the status BEFORE piping: `$?` after a pipeline is the status of
+# the last element, so `nvidia_smi_query ... | head -1` would always report
+# head's 0 and the check below would never fire.
+GPU_PROBE_RAW="$(nvidia_smi_query name)"
 GPU_PROBE_RC=$?
+GPU_NAME_PROBE="$(printf '%s\n' "$GPU_PROBE_RAW" | head -1)"
 case "$GPU_NAME_PROBE" in
     ''|'['*|*'Not Supported'*|*'N/A'*|*'failed'*|*'Error'*|*'error'*)
         GPU_NAME_PROBE="" ;;

--- a/tools/install_anuga_nvc.sh
+++ b/tools/install_anuga_nvc.sh
@@ -171,11 +171,16 @@ arch_compiles() {
     return $rc
 }
 
-# nvidia-smi is the only way we have to see a GPU, and it is not always
-# cheap: on a node with no driver, or a driver in a bad state, it can block
-# for a long time instead of failing.  Probe ONCE, under a timeout, and reuse
-# the answer -- the script used to call it three times with no timeout, which
-# on an HPC login node looks exactly like a hang.
+# nvidia-smi is the only way we have to see a GPU, and it is not always cheap.
+# Being ON PATH says nothing: an HPC login node typically ships the binary
+# without a driver for it to talk to, where it fails with
+#
+#     NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA
+#     driver.
+#
+# but takes its time about it. The script used to call nvidia-smi three times
+# with no timeout, right after announcing the test suite, which is
+# indistinguishable from a hung test run. Probe ONCE, bounded, and reuse it.
 nvidia_smi_query() {
     command -v nvidia-smi >/dev/null 2>&1 || return 0
     if command -v timeout >/dev/null 2>&1; then
@@ -185,18 +190,36 @@ nvidia_smi_query() {
     fi
 }
 
+if command -v nvidia-smi >/dev/null 2>&1; then
+    echo "# Looking for a GPU (nvidia-smi)..."
+fi
 GPU_NAME_PROBE="$(nvidia_smi_query name | head -1)"
 if [ -n "$GPU_NAME_PROBE" ]; then
     HAVE_GPU=1
+    echo "# GPU detected: ${GPU_NAME_PROBE}"
 else
     HAVE_GPU=0
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        echo "# No usable GPU here: nvidia-smi is installed but reports no"
+        echo "# device (no driver loaded, or none allocated to this node)."
+        echo "# This is normal on an HPC login node. Building anyway."
+    else
+        echo "# No GPU here: nvidia-smi is not installed. Building anyway."
+    fi
 fi
 
 GPU_ARCH_EXPLICIT=1
 [ "$GPU_ARCH" = "auto" ] && GPU_ARCH_EXPLICIT=0
 
 if [ "$GPU_ARCH" = "auto" ]; then
-    CAP=$(nvidia_smi_query compute_cap | head -1 | tr -d ' ')
+    # Only ask again if the first probe actually saw a device; otherwise this
+    # is a second guaranteed-to-fail call, and on a driverless node a second
+    # wait for it.
+    if [ "$HAVE_GPU" = "1" ]; then
+        CAP=$(nvidia_smi_query compute_cap | head -1 | tr -d ' ')
+    else
+        CAP=""
+    fi
     if [[ "$CAP" =~ ^[0-9]+\.[0-9]+$ ]]; then
         GPU_ARCH="cc${CAP//./}"
         echo "# GPU_ARCH=auto -> ${GPU_ARCH} (detected: compute capability ${CAP})"


### PR DESCRIPTION
Both reported from a real run of `install_anuga_nvc.sh` on a **Gadi login node**.

## 1. "Running GPU test suite" then apparent hang

The no-GPU guard added in fec25192 was working. Two other things made it look otherwise.

**The banner came before the decision.** Lines 521–532 printed

```
#============================================================
# Running GPU test suite (isolated runner)
#   One fresh process per test.  A plain 'pytest' on this file
#   ... eight more lines ...
#============================================================
```

and *only then* did the guard at 538 work out whether to run anything. So on a login node you were told the suite had started, the script went quiet, and the "Skipping the GPU test suite" block appeared afterwards — contradicting what it had just said. The banner now prints inside the branch that actually runs the suite.

**`nvidia-smi` was called three times with no timeout.** Once for `GPU_ARCH=auto` detection, then twice more in the guard:

```bash
if nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1 && \
   [ -n "$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null)" ]; then
```

With no driver, or a driver in a bad state, `nvidia-smi` does not fail fast — it blocks. Three untimed blocking calls, immediately after that banner, are indistinguishable from a hung test suite.

Replaced with a single probe:

```bash
nvidia_smi_query() {
    command -v nvidia-smi >/dev/null 2>&1 || return 0
    if command -v timeout >/dev/null 2>&1; then
        timeout 10 nvidia-smi --query-gpu="$1" --format=csv,noheader 2>/dev/null
    else
        nvidia-smi --query-gpu="$1" --format=csv,noheader 2>/dev/null
    fi
}
```

`HAVE_GPU` and the `GPU_ARCH=auto` detection both reuse its answer, so `nvidia-smi` runs at most twice, each bounded.

I could not reproduce the Gadi hang directly, so this is defensive on both fronts rather than a confirmed root cause. Verified locally: the probe returns the GPU here (`NVIDIA GeForce RTX 5070 Laptop GPU`, `compute_cap 12.0`, `HAVE_GPU=1`), and returns `HAVE_GPU=0` immediately when `nvidia-smi` is absent.

## 2. `gpu_aware_mpi=0` reads as a failed detection

The same run reported `gpu_aware_mpi=0` while `ompi_info | grep -i cuda` showed a thoroughly CUDA-aware Open MPI 5.0.8 (`--with-cuda=/apps/cuda/12.9.0`, `MCA accelerator: cuda`, `btl: smcuda`). The natural reading is that ANUGA failed to detect it.

It never looked. The value is the build option, which defaults to 0, and the script does not probe MPI at all. More to the point, the flag would not use a CUDA-aware MPI even if set — `gpu_halo.c` stages every halo through host memory on **both** settings, so no device pointer is ever handed to MPI. That is #223.

The summary now says what the number means and points at the issue.

## Verification

- `bash -n` clean
- probe behaviour checked with and without `nvidia-smi` present
- no change to what gets built

Filed separately: #309, for the wider naming problem — the runtime banner and `is_gpu_aware_mpi()` carry the same implication, and that needs a decision rather than a wording tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
