### PR TITLE
Energy-slope shear closure [T-7e], and a documented migration path off the erosion operators

### DIFF
--- a/anuga/operators/erosion_operators.py
+++ b/anuga/operators/erosion_operators.py
@@ -9,6 +9,8 @@ __date__ ="$09/03/2012 4:46:39 PM$"
 
 
 
+import warnings
+
 import numpy as num
 
 
@@ -16,6 +18,39 @@ from anuga import Domain
 from anuga import Quantity
 from anuga.operators.base_operator import Operator
 from anuga import Region
+
+# One notice per process, however many erosion operators a script creates.
+_MIGRATION_NOTICE_SHOWN = False
+
+
+def _erosion_migration_notice(op_name):
+    """Point first-time users at the sediment transport module.
+
+    Not a deprecation: these operators work and nothing is scheduled for
+    removal. But they are the expensive option -- Python on the host every
+    timestep, and CPU-only, so on the unified compute path they force a
+    GPU->CPU sync per RK step. Measured on 115k triangles they add 12.9x the
+    overhead of the whole sediment transport module on GPU, and 3.3x on CPU,
+    while modelling less. Most people reaching for them today want
+    domain.add_grain_size(); see anuga-community/anuga_core#310.
+    """
+    global _MIGRATION_NOTICE_SHOWN
+    if _MIGRATION_NOTICE_SHOWN:
+        return
+    _MIGRATION_NOTICE_SHOWN = True
+    warnings.warn(
+        "%s: the erosion operators are the expensive way to evolve a bed. "
+        "They run in Python on the host every timestep and are CPU-only, so "
+        "under compute mode 'unified' they force a GPU<->CPU sync every RK "
+        "step -- measured at 12.9x the overhead of the full sediment "
+        "transport module on GPU (3.3x on CPU), for less physics and no mass "
+        "conservation. Consider domain.add_grain_size(...); "
+        "Bed_shear_erosion_operator in particular maps closely onto "
+        "set_shear_closure('energy_slope') with a cohesive bed material. See "
+        "the 'Coming from the erosion operators' section of the sediment "
+        "documentation. This notice appears once per process."
+        % op_name,
+        UserWarning, stacklevel=3)
 
 
 def _mark_domain_erosion(domain):
@@ -70,6 +105,7 @@ class Erosion_operator(Operator, Region):
         # Default to dynamic storage unless the user deliberately chose static;
         # initialise_storage() warns if it ends up static regardless.
         _mark_domain_erosion(self.domain)
+        _erosion_migration_notice(type(self).__name__)
 
         Region.__init__(self, domain,
                         indices=indices,

--- a/anuga/shallow_water/gpu/core_kernels.c
+++ b/anuga/shallow_water/gpu/core_kernels.c
@@ -700,21 +700,28 @@ static inline double core_rouse_d_star(double Z, double a_h) {
  * which the density cancels, and the dimensional stress the cohesive route
  * needs is simply rho_w times this.
  *
- * S is the bed gradient magnitude from the divergence theorem over the cell's
- * own edges, so this stays cell-local and offloads. */
+ * S is a gradient magnitude from the divergence theorem over the cell's own
+ * edges, so this stays cell-local and offloads. WHICH surface supplies it is
+ * the closure: the bed for [T-7], the free surface for [T-7e]. The two agree
+ * only in steady uniform flow, which is [T-7]'s stated assumption; where the
+ * flow is not in equilibrium the free-surface slope is the better estimate of
+ * what drives it, and it is what the older Bed_shear_erosion_operator used. */
 static inline double core_tau_b_over_rho(anuga_int closure, double f_c,
                                          double vel2, double grav, double h,
                                          const double * restrict bed_ev,
+                                         const double * restrict stage_ev,
                                          const anuga_geom_t * restrict normals,
                                          const anuga_geom_t * restrict edgelengths,
                                          double area, anuga_int k) {
-    if (closure != 1) {
+    if (closure != 1 && closure != 2) {
         return f_c * vel2;                       /* [T-1] */
     }
-    /* [T-7]: grad z = (1/A) sum_e z_e n_e L_e */
+    /* [T-7]:  grad z = (1/A) sum_e z_e n_e L_e   (bed slope)
+     * [T-7e]: grad w = (1/A) sum_e w_e n_e L_e   (free-surface slope) */
+    const double * restrict surf_ev = (closure == 2) ? stage_ev : bed_ev;
     double gx = 0.0, gy = 0.0;
     for (anuga_int i = 0; i < 3; i++) {
-        const double ze = bed_ev[3 * k + i];
+        const double ze = surf_ev[3 * k + i];
         const double L = edgelengths[3 * k + i];
         gx += ze * normals[6 * k + 2 * i] * L;
         gy += ze * normals[6 * k + 2 * i + 1] * L;
@@ -776,6 +783,7 @@ void core_apply_bedload(struct domain *D, double timestep) {
     double * restrict stage_cv = D->stage_centroid_values;
     double * restrict bed_cv = D->bed_centroid_values;
     double * restrict bed_ev = D->bed_edge_values;
+    double * restrict stage_ev = D->stage_edge_values;
     double * restrict xmom_cv = D->xmom_centroid_values;
     double * restrict ymom_cv = D->ymom_centroid_values;
     double * restrict friction_cv = D->friction_centroid_values;
@@ -832,9 +840,9 @@ void core_apply_bedload(struct domain *D, double timestep) {
             f_c = grav * nman * nman / cbrt(h);
         }
 
-        /* Same closure as the suspended source, [T-1] or [T-7]. */
+        /* Same closure as the suspended source: [T-1], [T-7] or [T-7e]. */
         const double tbr = core_tau_b_over_rho(shear_closure, f_c, vel2, grav,
-                                               h, bed_ev, normals,
+                                               h, bed_ev, stage_ev, normals,
                                                edgelengths, areas[k], k);
 
         double q_b_total = 0.0;
@@ -1272,6 +1280,7 @@ void core_apply_sediment_source(struct domain *D, double timestep) {
     double * restrict tau_c_star = D->sediment_tau_c_star;
     double * restrict a_ref = D->sediment_reference_height;
     double * restrict bed_ev_r = D->bed_edge_values;
+    double * restrict stage_ev_r = D->stage_edge_values;
     anuga_geom_t * restrict normals_r = D->normals;
     anuga_geom_t * restrict edgelengths_r = D->edgelengths;
     anuga_geom_t * restrict areas_r = D->areas;
@@ -1360,9 +1369,9 @@ void core_apply_sediment_source(struct domain *D, double timestep) {
             f_c = grav * nman * nman / cbrt(h);
         }
 
-        /* tau_b/rho under the selected closure, [T-1] or [T-7]. */
+        /* tau_b/rho under the selected closure: [T-1], [T-7] or [T-7e]. */
         const double tbr = core_tau_b_over_rho(shear_closure, f_c, vel2, grav,
-                                               h, bed_ev_r, normals_r,
+                                               h, bed_ev_r, stage_ev_r, normals_r,
                                                edgelengths_r, areas_r[k], k);
 
         for (anuga_int s = 0; s < n_classes; s++) {

--- a/anuga/shallow_water/shallow_water_domain.py
+++ b/anuga/shallow_water/shallow_water_domain.py
@@ -1659,6 +1659,16 @@ A grain size is a tracer -- so it is transported by the machinery of
         uniform (normal) flow approximation: it assumes the energy slope equals
         the **bed** slope and the flow is locally in equilibrium.
 
+        `'energy_slope'` -- `[T-7e]`, the same `tau_b = rho g h S` with `S` the
+        **free-surface** slope magnitude instead. Under the shallow-water
+        assumption the free surface is the energy grade line, so this drops
+        `[T-7]`'s equilibrium assumption and uses the slope actually driving
+        the flow. Prefer it wherever the bed slope is not a good proxy for the
+        energy slope: backwater, a pool-riffle sequence, a bed that is flat but
+        drawing down, a dam break. It is also what the older
+        `Bed_shear_erosion_operator` used (`EN_slope`), so it is the closure to
+        pick when reproducing a model built on that operator.
+
         Notes
         -----
         Spec 3.4 recommends `[T-1]` and keeps `[T-7]` only for reproducing
@@ -1675,7 +1685,7 @@ A grain size is a tracer -- so it is transported by the machinery of
         dimensionally inconsistent and the second is the undocumented clamp of
         divergence D1a. `[T-7]` here follows the manual, not the code.
         """
-        closures = {'quadratic_drag': 0, 'depth_slope': 1}
+        closures = {'quadratic_drag': 0, 'depth_slope': 1, 'energy_slope': 2}
         if closure not in closures:
             raise ValueError('unknown shear closure %r; expected one of %r'
                              % (closure, sorted(closures)))
@@ -1947,7 +1957,8 @@ A grain size is a tracer -- so it is transported by the machinery of
         dstar = {0: "constant, per grain size", 1: "Rouse profile   [S-4]"
                  }[self.sediment_d_star_mode]
         shear = {0: "quadratic drag, tau_b = rho f_c |v|^2   [T-1]",
-                 1: "depth-slope, tau_b = rho g h S (aSM16; legacy)   [T-7]"
+                 1: "depth-slope, tau_b = rho g h S (bed slope; aSM16)   [T-7]",
+                 2: "energy-slope, tau_b = rho g h S (free surface)   [T-7e]"
                  }[self.sediment_shear_closure]
         fric = {0: "constant n, from the domain friction quantity",
                 1: "larsen_lamb, n = %.5f   [T-13..15]" % self.sediment_manning_ll,

--- a/anuga/shallow_water/tests/test_sediment_shear_closure.py
+++ b/anuga/shallow_water/tests/test_sediment_shear_closure.py
@@ -1,4 +1,4 @@
-"""Bed shear closures [T-1] and [T-7] (PHYSICS_SPEC 3.1, 3.4).
+"""Bed shear closures [T-1], [T-7] and [T-7e] (PHYSICS_SPEC 3.1, 3.4).
 
     [T-1]  tau_b = rho f_c |v|^2     quadratic drag (default)
     [T-7]  tau_b = rho g h S         depth-slope
@@ -38,6 +38,52 @@ def test_depth_slope_can_be_selected():
     d = channel()
     d.set_shear_closure('depth_slope')
     assert d.sediment_shear_closure == 1
+
+
+def test_energy_slope_can_be_selected():
+    d = channel()
+    d.set_shear_closure('energy_slope')
+    assert d.sediment_shear_closure == 2
+
+
+def test_energy_slope_differs_from_depth_slope_when_the_surface_is_not_parallel():
+    """[T-7e] takes S from the free surface, [T-7] from the bed.
+
+    On a bed that is FLAT while the free surface is sloping, [T-7] sees no
+    slope at all and predicts no shear, while [T-7e] sees the surface slope
+    that is actually driving the flow. If the two ever agree here, the energy
+    closure is reading the bed.
+    """
+    import numpy as np
+    from anuga import Dirichlet_boundary
+
+    def run(closure):
+        d = rectangular_cross_domain(20, 10, 100.0, 50.0)
+        d.set_flow_algorithm('DE1')
+        d.set_quantity('elevation', 0.0)              # FLAT bed: grad z == 0
+        d.set_quantity('friction', 0.03)
+        d.set_quantity('stage', lambda x, y: 2.0 - 0.01 * x)   # sloping surface
+        d.set_boundary({'left': Dirichlet_boundary([2.0, 1.0, 0.0]),
+                        'right': Dirichlet_boundary([1.0, 0.0, 0.0]),
+                        'top': Reflective_boundary(d),
+                        'bottom': Reflective_boundary(d)})
+        d.add_grain_size('sand', diameter=2.0e-4)
+        d.set_shear_closure(closure)
+        d.set_bed_material('cohesive', tau_crit=1e-9, K_e=1.0e-5)
+        d.set_deposition(law='threshold', tau_d=0.0)
+        d.set_datadir('.')
+        d.set_name('t7e_' + closure)
+        d.set_quantities_to_be_stored(None)
+        z0 = d.quantities['elevation'].centroid_values.copy()
+        for t in d.evolve(yieldstep=5.0, finaltime=10.0):
+            pass
+        return np.abs(d.quantities['elevation'].centroid_values - z0).max()
+
+    bed = run('depth_slope')
+    energy = run('energy_slope')
+    assert energy > bed, (
+        'energy_slope (%g) did not exceed depth_slope (%g) on a flat bed with '
+        'a sloping surface -- it is reading the wrong gradient' % (energy, bed))
 
 
 def test_an_unknown_closure_is_rejected():

--- a/docs/source/appendices/sediment_physics.rst
+++ b/docs/source/appendices/sediment_physics.rst
@@ -317,6 +317,7 @@ friction factor goes into it.
 
    domain.set_shear_closure('quadratic_drag')   # default
    domain.set_shear_closure('depth_slope')
+   domain.set_shear_closure('energy_slope')
 
 .. list-table::
    :header-rows: 1
@@ -329,8 +330,11 @@ friction factor goes into it.
      - :math:`\tau_b = \rho\, f_c\, |\mathbf{v}|^2`
      - :spec:`T-1`
    * - ``'depth_slope'``
-     - :math:`\tau_b = \rho\, g\, h\, S`
+     - :math:`\tau_b = \rho\, g\, h\, S`, :math:`S` from the bed
      - :spec:`T-7`
+   * - ``'energy_slope'``
+     - :math:`\tau_b = \rho\, g\, h\, S`, :math:`S` from the free surface
+     - :spec:`T-7e`
 
 ``'quadratic_drag'`` is the default and the right choice for unsteady or
 rapidly varying flow -- dam breaks, floods, anything with significant
@@ -340,7 +344,15 @@ inertia.
 It is what anugaSed uses, so choose it when reproducing their results
 (divergence **D1** in the spec). It degrades where that balance does not hold.
 
-The two are interchangeable by construction: the kernel returns ``tau_b/rho``,
+:spec:`T-7e` is :spec:`T-7` with the equilibrium assumption dropped. Under the
+shallow-water assumption the free surface *is* the energy grade line, so where
+the bed slope is a poor proxy for it -- backwater, a pool-riffle sequence, a
+flat bed drawing down, a dam break -- the free-surface slope is what actually
+drives the flow. It is also what the older ``Bed_shear_erosion_operator`` used,
+which makes it the closure to pick when reproducing a model built on that
+operator; see :ref:`coming_from_erosion_operators`.
+
+The three are interchangeable by construction: the kernel returns ``tau_b/rho``,
 so everything downstream is unchanged by the choice.
 
 .. _72-set_sediment_friction----what:
@@ -824,7 +836,12 @@ summaries, and renumbering would only break the correspondence.
    * - .. _spec-t-7:
 
        ``[T-7]``
-     - depth-slope closure, ``tau_b = rho g h S``
+     - depth-slope closure, ``tau_b = rho g h S`` with ``S`` the BED slope
+   * - .. _spec-t-7e:
+
+       ``[T-7e]``
+     - energy-slope closure, the same ``tau_b = rho g h S`` with ``S`` the
+       FREE-SURFACE slope
    * - .. _spec-t-8:
        .. _spec-t-10:
 

--- a/docs/source/setup_anuga_script/sediment.rst
+++ b/docs/source/setup_anuga_script/sediment.rst
@@ -802,6 +802,116 @@ invalidates the device mapping, so configuring sediment after selecting
 
 --------------
 
+.. _coming_from_erosion_operators:
+
+Coming from the erosion operators
+---------------------------------
+
+ANUGA has carried a family of erosion operators for a long time --
+``Polygonal_erosion_operator``, ``Circular_erosion_operator``,
+``Bed_shear_erosion_operator``, ``Flat_slice_erosion_operator``,
+``Flat_fill_slice_erosion_operator`` and ``Sanddune_erosion_operator``. They
+still work and nothing is scheduled for removal, but they are the expensive
+way to evolve a bed: each runs in Python on the host every timestep, and none
+is GPU-safe, so under compute mode ``'unified'`` each one forces a
+GPU-to-host sync on every RK step.
+
+Measured on 115,200 triangles, the overhead an erosion operator adds above a
+plain run is **12.9x that of the entire sediment transport module on the GPU**,
+and 3.3x on the CPU -- while modelling less and conserving nothing.
+
+Structural equivalents
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - erosion operator argument
+     - sediment equivalent
+   * - ``base=``
+     - :meth:`set_erodible_base` (``elevation=``), :spec:`L-5`
+   * - ``polygon=``, ``center=``/``radius=``
+     - :meth:`set_erodible_region`
+   * - Sanddune's repose relaxation
+     - :meth:`set_angle_of_repose`
+   * - eroded material simply disappears
+     - ``set_deposition(law='threshold', tau_d=0.0)`` suppresses redeposition
+
+``Bed_shear_erosion_operator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This one maps almost exactly. It forms ``1000 * 9.81 * d * EN_slope`` -- that
+is :math:`\rho g h S` with :math:`S` the **energy** slope -- and then erodes
+``de = tau_b / shear_factor * dt``. That is the cohesive Hanson & Simon law
+:spec:`E-3`, :math:`E = K_e(\tau_b - \tau_c)`, with no threshold and
+:math:`K_e = 1/\texttt{shear\_factor}`:
+
+.. code-block:: python
+
+   domain.add_grain_size('sand', diameter=2.0e-4)
+   domain.set_shear_closure('energy_slope')            # tau_b = rho g h S   [T-7e]
+   domain.set_bed_material('cohesive', tau_crit=1e-9,
+                           K_e=0.5 / shear_factor)     # E = K_e tau_b
+   domain.set_deposition(law='threshold', tau_d=0.0)   # no redeposition
+   domain.set_erodible_base(elevation=base)
+   domain.set_erodible_region(polygon=polygon)
+
+Use ``'energy_slope'`` rather than ``'depth_slope'``: the old operator used the
+free-surface slope, and choosing the bed slope instead is what costs the
+agreement. On a sloping channel over 30 s, correlation of the bed-change field
+against the original operator:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - closure
+     - correlation with the old operator
+   * - ``'depth_slope'`` -- bed slope, :spec:`T-7`
+     - 0.815
+   * - ``'energy_slope'`` -- free surface, :spec:`T-7e`
+     - **0.964**
+   * - ``'energy_slope'`` with ``K_e`` calibrated
+     - **0.988**
+
+``K_e`` needs calibrating: the two gradient reconstructions differ, so
+``1/shear_factor`` is the right form but not the right constant. Halving it
+matched the case above. Calibrate against a run you trust.
+
+The others
+~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - operator
+     - notes
+   * - ``Polygonal``, ``Circular``
+     - Erode at ``de = |momentum| * dt``. There is no sediment law of that
+       form, and it is dimensionally inconsistent -- ``|momentum|`` is
+       m\ :sup:`2`/s, so ``de`` is not a length. Treat it as a tuning knob,
+       not a rate, and move to the Shields route :spec:`E-1` (the default)
+       rather than trying to reproduce it.
+   * - ``Flat_slice``, ``Flat_fill_slice``
+     - Not erosion: they set elevation to a target value. Use
+       ``set_quantity('elevation', ...)`` or ``Set_elevation_operator``.
+       Sediment has no equivalent because these are not scour models.
+   * - ``Sanddune``
+     - Erosion plus repose. The repose half is
+       :meth:`set_angle_of_repose`; the erosion half is another excess-shear
+       law, as for ``Bed_shear`` above.
+
+.. warning::
+
+   Nothing prevents enabling an erosion operator **and** sediment transport on
+   the same domain. Both write ``elevation`` and the bed changes simply add.
+   One conserves mass and the other does not, so the sum is unlikely to mean
+   anything -- pick one.
+
+--------------
+
 Choosing a configuration
 ------------------------
 


### PR DESCRIPTION
Follows from #310. Three related changes.

## 1. A third shear closure

`set_shear_closure('energy_slope')` forms `tau_b = rho g h S` with `S` the **free-surface** gradient. `[T-7]` uses the **bed** gradient, which assumes steady uniform flow — energy slope equals bed slope. Where that does not hold (backwater, pool-riffle, a flat bed drawing down, a dam break) the free surface is the slope actually driving the flow, and under the shallow-water assumption it *is* the energy grade line.

The kernel change is small: `core_tau_b_over_rho` selects bed or stage edge values by closure, and both callers hoist `stage_ev` at function scope per the device-pointer convention documented in that file.

## 2. A migration path off the erosion operators

`Bed_shear_erosion_operator` computes `1000*9.81*d*EN_slope` — that is `rho g h S` on the **energy** slope — then erodes `de = tau_b/shear_factor*dt`. That is the cohesive Hanson & Simon law `[E-3]`, `E = K_e(tau_b - tau_c)`, with no threshold and `K_e = 1/shear_factor`.

Measured correlation of the bed-change field against the original operator, sloping channel, 30 s:

| closure | correlation |
|---|---|
| `depth_slope` — bed slope, `[T-7]` | 0.815 |
| `energy_slope` — free surface, `[T-7e]` | **0.964** |
| `energy_slope`, `K_e` calibrated | **0.988** |

Picking the bed slope is what was costing the agreement — which is what prompted the new closure rather than the other way round.

The docs gain a **"Coming from the erosion operators"** section with the full mapping:

| old argument | sediment equivalent |
|---|---|
| `base=` | `set_erodible_base(elevation=...)` `[L-5]` |
| `polygon=` / `center=`/`radius=` | `set_erodible_region(...)` |
| Sanddune repose | `set_angle_of_repose(...)` |
| eroded material vanishes | `set_deposition(law='threshold', tau_d=0.0)` |

and an honest account of what does **not** map: `Polygonal`/`Circular` erode at `de = |momentum|*dt`, which has no sediment analogue and is dimensionally inconsistent (`|momentum|` is m²/s, so `de` is not a length); the `Flat_slice` pair are not erosion models at all.

## 3. A one-off notice

Constructing any erosion operator now warns **once per process**:

> the erosion operators are the expensive way to evolve a bed … 12.9x the overhead of the full sediment transport module on GPU (3.3x on CPU), for less physics and no mass conservation. Consider `domain.add_grain_size(...)` …

Not a deprecation — they work and nothing is scheduled for removal. Verified it fires once across three operator constructions.

## Verification

nvc GPU build:

- `pytest --run-fast`: **3003 passed**, 257 skipped
- slow suite: **242 passed**, 14 skipped
- GPU tests on device: **142 passed**, 1 skipped
- `ruff` clean, Sphinx **0 warnings**

The new closure test builds a **flat bed under a sloping free surface**, where `[T-7]` sees no slope at all — and I confirmed it fails when `energy_slope` is made to read the bed instead, so it cannot pass by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)